### PR TITLE
Detect bad argument name in external contract

### DIFF
--- a/lang/codegen/src/generator/module_impl/deploy.rs
+++ b/lang/codegen/src/generator/module_impl/deploy.rs
@@ -83,16 +83,13 @@ impl GenerateCode for Deploy<'_> {
             impl #struct_ident {
 
                 fn deploy() -> #ref_ident {
-                    type EntrypointCall = fn(String, RuntimeArgs) -> Option<Bytes>;
-                    type Constructor = (String, RuntimeArgs, EntrypointCall);
-
                     use std::collections::HashMap;
                     use odra::types::{bytesrepr::Bytes, RuntimeArgs, runtime_args};
 
-                    let mut entrypoints: HashMap<String, EntrypointCall> = HashMap::new();
+                    let mut entrypoints = HashMap::<String, (Vec<String>, fn(String, RuntimeArgs) -> Option<Bytes>)>::new();
                     #entrypoints
 
-                    let mut constructors: HashMap<String, EntrypointCall> = HashMap::new();
+                    let mut constructors = HashMap::<String, (Vec<String>, fn(String, RuntimeArgs) -> Option<Bytes>)>::new();
                     #constructors
 
                     let address = odra::TestEnv::register_contract(None, constructors, entrypoints);
@@ -139,23 +136,19 @@ where
 
         quote! {
             #deploy_fn_sig {
-                type EntrypointCall = fn(String, RuntimeArgs) -> Option<Bytes>;
-                type Constructor = (String, RuntimeArgs, EntrypointCall);
-
                 use std::collections::HashMap;
                 use odra::types::{bytesrepr::Bytes, RuntimeArgs};
 
-                let mut entrypoints: HashMap<String, EntrypointCall> = HashMap::new();
+                let mut entrypoints = HashMap::<String, (Vec<String>, fn(String, RuntimeArgs) -> Option<Bytes>)>::new();
                 #entrypoints_stream
 
-                let mut constructors: HashMap<String, EntrypointCall> = HashMap::new();
+                let mut constructors = HashMap::<String, (Vec<String>, fn(String, RuntimeArgs) -> Option<Bytes>)>::new();
                 #constructors_stream
 
                 let args = {
                     #args
                 };
-
-                let constructor: Option<Constructor> = Some((
+                let constructor: Option<(String, RuntimeArgs, fn(String, RuntimeArgs) -> Option<Bytes>)> = Some((
                     stringify!(#constructor_ident).to_string(),
                     args,
                     |name, args| {
@@ -239,13 +232,14 @@ where
                 },
             };
             let args = args_to_fn_args(&entrypoint.args);
+            let arg_names = args_to_arg_names_stream(&entrypoint.args);
 
             quote! {
-                entrypoints.insert(#name, |name, args| {
+                entrypoints.insert(#name, (#arg_names, |name, args| {
                     let instance = <#struct_ident as odra::Instance>::instance(name.as_str());
                     let result = instance.#ident(#args);
                     #return_value
-                });
+                }));
             }
         })
         .collect::<TokenStream>()
@@ -259,16 +253,16 @@ where
         .map(|constructor| {
             let ident = &constructor.ident;
             let args = args_to_fn_args(&constructor.args);
+            let arg_names = args_to_arg_names_stream(&constructor.args);
 
             quote! {
-                constructors.insert(
-                    stringify!(#ident).to_string(),
+                constructors.insert(stringify!(#ident).to_string(), (#arg_names,
                     |name, args| {
                         let instance = <#struct_ident as odra::Instance>::instance(name.as_str());
                         instance.#ident( #args );
                         None
                     }
-                );
+                ));
             }
         })
         .collect::<TokenStream>()
@@ -302,4 +296,25 @@ where
     }));
     tokens.extend(quote!(args));
     tokens
+}
+
+fn args_to_arg_names_stream<'a, T>(args: T) -> TokenStream
+where
+    T: IntoIterator<Item = &'a syn::PatType>,
+{
+    let args_stream = args
+        .into_iter()
+        .map(|arg| {
+            let pat = &*arg.pat;
+            quote! { args.push(stringify!(#pat).to_string()); }
+        })
+        .collect::<TokenStream>();
+
+    quote! {
+        {
+            let mut args: Vec<String> = vec![];
+            #args_stream
+            args
+        }
+    }
 }

--- a/mock_vm/src/contract_container.rs
+++ b/mock_vm/src/contract_container.rs
@@ -1,20 +1,21 @@
 use odra_types::{bytesrepr::Bytes, OdraError, RuntimeArgs, VmError};
 use std::collections::HashMap;
 
-use crate::EntrypointCall;
+pub type EntrypointCall = fn(String, RuntimeArgs) -> Option<Bytes>;
+pub type EntrypointArgs = Vec<String>;
 
 #[derive(Default, Clone)]
 pub struct ContractContainer {
     name: String,
-    entrypoints: HashMap<String, EntrypointCall>,
-    constructors: HashMap<String, EntrypointCall>,
+    entrypoints: HashMap<String, (EntrypointArgs, EntrypointCall)>,
+    constructors: HashMap<String, (EntrypointArgs, EntrypointCall)>,
 }
 
 impl ContractContainer {
     pub fn new(
         name: &str,
-        entrypoints: HashMap<String, EntrypointCall>,
-        constructors: HashMap<String, EntrypointCall>,
+        entrypoints: HashMap<String, (EntrypointArgs, EntrypointCall)>,
+        constructors: HashMap<String, (EntrypointArgs, EntrypointCall)>,
     ) -> Self {
         Self {
             name: String::from(name),
@@ -29,7 +30,10 @@ impl ContractContainer {
         }
 
         match self.entrypoints.get(&entrypoint) {
-            Some(f) => Ok(f(self.name.clone(), args)),
+            Some((ep_args, call)) => {
+                self.validate_args(ep_args, &args)?;
+                Ok(call(self.name.clone(), args))
+            }
             None => Err(OdraError::VmError(VmError::NoSuchMethod(entrypoint))),
         }
     }
@@ -40,8 +44,34 @@ impl ContractContainer {
         args: RuntimeArgs,
     ) -> Result<Option<Bytes>, OdraError> {
         match self.constructors.get(&entrypoint) {
-            Some(f) => Ok(f(self.name.clone(), args)),
+            Some((ep_args, call)) => {
+                self.validate_args(ep_args, &args)?;
+                Ok(call(self.name.clone(), args))
+            }
             None => Err(OdraError::VmError(VmError::NoSuchMethod(entrypoint))),
+        }
+    }
+
+    pub fn validate_args(
+        &self,
+        args: &[String],
+        input_args: &RuntimeArgs,
+    ) -> Result<(), OdraError> {
+        let named_args = input_args
+            .named_args()
+            .map(|arg| arg.name().to_owned())
+            .collect::<Vec<_>>();
+
+        let missing_args = args
+            .iter()
+            .filter(|arg| !named_args.contains(arg))
+            .map(|arg| arg.to_owned())
+            .collect::<Vec<_>>();
+
+        if missing_args.is_empty() {
+            Ok(())
+        } else {
+            Err(OdraError::VmError(VmError::MissingArgs(missing_args)))
         }
     }
 }
@@ -50,64 +80,171 @@ impl ContractContainer {
 mod tests {
     use std::collections::HashMap;
 
-    use odra_types::RuntimeArgs;
+    use odra_types::{bytesrepr::Bytes, runtime_args, OdraError, RuntimeArgs, VmError};
 
-    use crate::EntrypointCall;
+    use crate::{EntrypointArgs, EntrypointCall};
 
     use super::ContractContainer;
 
     #[test]
     fn test_call_wrong_entrypoint() {
-        let instance = ContractContainer::new("c1", HashMap::new(), HashMap::new());
+        // Given an instance with no entrypoints.
+        let instance = ContractContainer::empty();
 
-        let result = instance.call(String::from("call"), RuntimeArgs::new());
+        // When call some entrypoint.
+        let result = instance.call(String::from("ep"), RuntimeArgs::new());
+
+        // Then an error occurs.
         assert!(result.is_err());
     }
 
     #[test]
     fn test_call_valid_entrypoint() {
-        let ep_name = String::from("call");
+        // Given an instance with a single no-args entrypoint.
+        let ep_name = String::from("ep");
+        let instance = ContractContainer::setup_entrypoint(ep_name.clone(), vec![]);
 
-        let ep: EntrypointCall = |_, _| Some(vec![1, 2, 3].into());
-        let mut entrypoints = HashMap::new();
-        entrypoints.insert(ep_name.clone(), ep);
-        let instance = ContractContainer::new("c1", entrypoints, HashMap::new());
-
+        // When call the registered entrypoint.
         let result = instance.call(ep_name, RuntimeArgs::new());
+
+        // Then teh call succeeds.
         assert!(result.is_ok());
     }
 
     #[test]
+    fn test_call_valid_entrypoint_with_wrong_arg_name() {
+        // Given an instance with a single entrypoint with one arg named "first".
+        let ep_name = String::from("ep");
+        let instance = ContractContainer::setup_entrypoint(ep_name.clone(), vec!["first"]);
+
+        // When call the registered entrypoint with an arg named "second".
+        let result = instance.call(ep_name, runtime_args! { "second" => 0 });
+
+        // Then MissingArgs error is returned.
+        assert_missing_args(result, vec!["first"]);
+    }
+
+    #[test]
+    fn test_call_valid_entrypoint_with_missing_arg() {
+        // Given an instance with a single entrypoint with one arg named "first".
+        let ep_name = String::from("ep");
+        let instance = ContractContainer::setup_entrypoint(ep_name.clone(), vec!["first"]);
+
+        // When call a valid entrypoint without args.
+        let result = instance.call(ep_name, RuntimeArgs::new());
+
+        // Then MissingArgs error is returned.
+        assert_missing_args(result, vec!["first"]);
+    }
+
+    #[test]
+    fn test_all_missing_args_are_caught() {
+        // Given an instance with a single entrypoint with "first", "second" and "third" args.
+        let ep_name = String::from("ep");
+        let instance =
+            ContractContainer::setup_entrypoint(ep_name.clone(), vec!["first", "second", "third"]);
+
+        // When call a valid entrypoint with a single valid args,
+        let result = instance.call(ep_name, runtime_args! { "third" => 0 });
+
+        // Then MissingArgs error is returned with the two remaining args.
+        assert_missing_args(result, vec!["first", "second"]);
+    }
+
+    #[test]
     fn test_call_valid_constructor() {
+        // Given an instance with a single no-arg constructor.
         let name = String::from("init");
+        let instance = ContractContainer::setup_constructor(name.clone(), vec![]);
 
-        let call: EntrypointCall = |_, _| Some(vec![1, 2, 3].into());
-        let mut constructors = HashMap::new();
-        constructors.insert(name.clone(), call);
-        let instance = ContractContainer::new("c1", HashMap::new(), constructors);
-
+        // When call a valid constructor with a single valid args,
         let result = instance.call_constructor(name, RuntimeArgs::new());
+
+        // Then the call succeeds.
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_call_invalid_constructor() {
-        let instance = ContractContainer::new("c1", HashMap::new(), HashMap::new());
+        // Given an instance with no constructors.
+        let instance = ContractContainer::empty();
 
-        let result = instance.call_constructor(String::from("call"), RuntimeArgs::new());
+        // When try to call some constructor.
+        let result = instance.call_constructor(String::from("c"), RuntimeArgs::new());
+
+        // Then the call fails.
         assert!(result.is_err());
     }
 
     #[test]
-    fn test_call_constructor_in_invalid_context() {
+    fn test_call_valid_constructor_with_missing_arg() {
+        // Given an instance with a single constructor with one arg named "first".
         let name = String::from("init");
+        let instance = ContractContainer::setup_constructor(name.clone(), vec!["first"]);
 
-        let call: EntrypointCall = |_, _| Some(vec![1, 2, 3].into());
-        let mut constructors = HashMap::new();
-        constructors.insert(name.clone(), call);
-        let instance = ContractContainer::new("c1", HashMap::new(), constructors);
+        // When call a valid constructor, but with no args.
+        let result = instance.call_constructor(name, RuntimeArgs::new());
 
+        // Then MissingArgs error is returned.
+        assert_missing_args(result, vec!["first"]);
+    }
+
+    #[test]
+    fn test_call_constructor_in_invalid_context() {
+        // Given an instance with a single constructor.
+        let name = String::from("init");
+        let instance = ContractContainer::setup_constructor(name.clone(), vec![]);
+
+        // When call the constructor in the entrypoint context.
         let result = instance.call(name, RuntimeArgs::new());
+
+        // Then the call fails.
         assert!(result.is_err());
+    }
+
+    fn assert_missing_args(result: Result<Option<Bytes>, OdraError>, names: Vec<&str>) {
+        let args = names.iter().map(|arg| arg.to_string()).collect::<Vec<_>>();
+        assert_eq!(
+            result.unwrap_err(),
+            OdraError::VmError(VmError::MissingArgs(args))
+        );
+    }
+
+    impl ContractContainer {
+        fn empty() -> Self {
+            Self {
+                name: String::from("contract"),
+                entrypoints: HashMap::new(),
+                constructors: HashMap::new(),
+            }
+        }
+
+        fn setup_entrypoint(ep_name: String, args: Vec<&str>) -> Self {
+            let call: EntrypointCall = |_, _| Some(vec![1, 2, 3].into());
+            let args: EntrypointArgs = args.iter().map(|arg| arg.to_string()).collect();
+
+            let mut entrypoints = HashMap::new();
+            entrypoints.insert(ep_name.clone(), (args, call));
+
+            Self {
+                name: String::from("contract"),
+                entrypoints,
+                constructors: HashMap::new(),
+            }
+        }
+
+        fn setup_constructor(ep_name: String, args: Vec<&str>) -> Self {
+            let call: EntrypointCall = |_, _| Some(vec![1, 2, 3].into());
+            let args: EntrypointArgs = args.iter().map(|arg| arg.to_string()).collect();
+
+            let mut constructors = HashMap::new();
+            constructors.insert(ep_name.clone(), (args, call));
+
+            Self {
+                name: String::from("contract"),
+                entrypoints: HashMap::new(),
+                constructors,
+            }
+        }
     }
 }

--- a/mock_vm/src/contract_container.rs
+++ b/mock_vm/src/contract_container.rs
@@ -224,7 +224,7 @@ mod tests {
             let args: EntrypointArgs = args.iter().map(|arg| arg.to_string()).collect();
 
             let mut entrypoints = HashMap::new();
-            entrypoints.insert(ep_name.clone(), (args, call));
+            entrypoints.insert(ep_name, (args, call));
 
             Self {
                 name: String::from("contract"),
@@ -238,7 +238,7 @@ mod tests {
             let args: EntrypointArgs = args.iter().map(|arg| arg.to_string()).collect();
 
             let mut constructors = HashMap::new();
-            constructors.insert(ep_name.clone(), (args, call));
+            constructors.insert(ep_name, (args, call));
 
             Self {
                 name: String::from("contract"),

--- a/mock_vm/src/lib.rs
+++ b/mock_vm/src/lib.rs
@@ -1,4 +1,3 @@
-use odra_types::{bytesrepr::Bytes, RuntimeArgs};
 use ref_thread_local::RefThreadLocal;
 
 mod context;
@@ -9,9 +8,11 @@ mod mock_vm;
 mod storage;
 mod test_env;
 
-pub use {contract_env::ContractEnv, test_env::TestEnv};
-
-pub(crate) type EntrypointCall = fn(String, RuntimeArgs) -> Option<Bytes>;
+pub use {
+    contract_container::{EntrypointArgs, EntrypointCall},
+    contract_env::ContractEnv,
+    test_env::TestEnv,
+};
 
 ref_thread_local::ref_thread_local!(
     static managed ENV: mock_vm::MockVm = mock_vm::MockVm::default();

--- a/mock_vm/src/test_env.rs
+++ b/mock_vm/src/test_env.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use odra_types::{bytesrepr::Bytes, event::EventError, Address, EventData, OdraError, RuntimeArgs};
 
-use crate::{borrow_env, mock_vm::default_accounts, EntrypointCall};
+use crate::{borrow_env, mock_vm::default_accounts, EntrypointArgs, EntrypointCall};
 
 /// Describes test environment API. TestEnv delegates methods to the underlying env implementation.
 ///
@@ -13,8 +13,8 @@ impl TestEnv {
     /// Registers the contract in the test environment.
     pub fn register_contract(
         constructor: Option<(String, RuntimeArgs, EntrypointCall)>,
-        constructors: HashMap<String, EntrypointCall>,
-        entrypoints: HashMap<String, EntrypointCall>,
+        constructors: HashMap<String, (EntrypointArgs, EntrypointCall)>,
+        entrypoints: HashMap<String, (EntrypointArgs, EntrypointCall)>,
     ) -> Address {
         borrow_env().register_contract(constructor, constructors, entrypoints)
     }

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -124,6 +124,8 @@ pub enum VmError {
     InvalidContractAddress,
     /// Error calling a host function in a wrong context.
     InvalidContext,
+    /// Calling a contract with missing entrypoint arguments.
+    MissingArgs(Vec<String>),
     /// Non-specified error with a custom message.
     Other(String),
     /// Unspecified error.

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -125,7 +125,7 @@ pub enum VmError {
     /// Error calling a host function in a wrong context.
     InvalidContext,
     /// Calling a contract with missing entrypoint arguments.
-    MissingArgs(Vec<String>),
+    MissingArg,
     /// Non-specified error with a custom message.
     Other(String),
     /// Unspecified error.


### PR DESCRIPTION
Minimal example

```rust
#[odra::module]
pub struct Plascoin {
    value: Variable<u32>,
}

#[odra::module]
impl Plascoin {
    pub fn set_value(&self, value: u32) {
        self.value.set(value);
    }
}

#[odra::external_contract]
trait ExternalSetter {
    // correct arg name
    fn set_value(&self, value: u32);
}

#[odra::external_contract]
trait FaultySetter {
    // incorrect arg name
    fn set_value(&self, v: u32);
}

#[test]
fn test_invalid_external_setter() {
    let plascoin = Plascoin::deploy();
    let setter = FaultySetterRef::at(plascoin.address());

    TestEnv::assert_exception(
        OdraError::VmError(VmError::MissingArg),
        || {
            setter.set_value(100);
        },
    );
}
```

The initial idea was to enlist all the missing args, and it would be feasible on Mock Vm, but on Casper, I couldn't gather args names. So I reverted that change and keep it simple at the moment.