### PR TITLE
Block time modification in TestEnv 

### DIFF
--- a/core/src/external_api/contract_env.rs
+++ b/core/src/external_api/contract_env.rs
@@ -7,6 +7,7 @@ use odra_types::{
 
 #[allow(improper_ctypes)]
 extern "C" {
+    fn __get_block_time() -> u64;
     fn __self_address() -> Address;
     fn __caller() -> Address;
     fn __set_var(key: &str, value: &CLValue);
@@ -22,6 +23,10 @@ extern "C" {
 pub struct ContractEnv;
 
 impl ContractEnv {
+    pub fn get_block_time() -> u64 {
+        unsafe { __get_block_time() }
+    }
+
     pub fn self_address() -> Address {
         unsafe { __self_address() }
     }

--- a/core/src/external_api/test_env.rs
+++ b/core/src/external_api/test_env.rs
@@ -1,14 +1,42 @@
 use odra_types::{bytesrepr::Bytes, event::EventError, Address, EventData, OdraError, RuntimeArgs};
 
+macro_rules! delegate_to_wrapper {
+    (
+        $(
+            $(#[$outer:meta])*
+            $func_name:ident($( $param_ident:ident : $param_ty:ty ),*) $( -> $ret:ty)*
+        )+
+    ) => {
+        $(
+            $(#[$outer])*
+            pub fn $func_name( $($param_ident : $param_ty),* ) $(-> $ret)* {
+                odra_test_env_wrapper::on_backend(|env| env.$func_name($($param_ident),*))
+            }
+        )+
+    }
+}
+
 /// Describes test environment API. TestEnv delegates methods to the underlying dynamically loaded env.
 ///
 /// The actual test env is dynamically loaded in the runtime.
 pub struct TestEnv;
 
 impl TestEnv {
-    /// Registers the contract in the test environment.
-    pub fn register_contract(contract_name: &str, args: &RuntimeArgs) -> Address {
-        odra_test_env_wrapper::on_backend(|env| env.register_contract(contract_name, args))
+    delegate_to_wrapper! {
+        ///Registers the contract in the test environment.
+        register_contract(contract_name: &str, args: &RuntimeArgs) -> Address
+        ///Returns the backend name.
+        backend_name() -> String
+        ///Replaces the current caller.
+        set_caller(address: &Address)
+        ///Returns nth test user account.
+        get_account(n: usize) -> Address
+        ///Gets nth event emitted by the contract at `address`."
+        get_event(address: &Address, index: i32) -> Result<EventData, EventError>
+        ///Gets the current error from the test environment."
+        get_error() -> Option<OdraError>
+        ///Increases the current value of block_time.
+        advance_block_time_by(seconds: u64)
     }
 
     /// Calls contract at `address` invoking the `entrypoint` with `args`.
@@ -39,32 +67,5 @@ impl TestEnv {
         let msg = format!("Expected {:?} error.", expected);
         let error: OdraError = Self::get_error().expect(&msg);
         assert_eq!(error, expected);
-    }
-
-    /// Returns the backend name.
-    pub fn backend_name() -> String {
-        odra_test_env_wrapper::on_backend(|env| env.backend_name())
-    }
-
-    /// Replaces the current caller.
-    pub fn set_caller(address: &Address) {
-        odra_test_env_wrapper::on_backend(|env| {
-            env.set_caller(address);
-        });
-    }
-
-    /// Returns nth test user account.
-    pub fn get_account(n: usize) -> Address {
-        odra_test_env_wrapper::on_backend(|env| env.get_account(n))
-    }
-
-    /// Gets nth event emitted by the contract at `address`.
-    pub fn get_event(address: &Address, index: i32) -> Result<EventData, EventError> {
-        odra_test_env_wrapper::on_backend(|env| env.get_event(address, index))
-    }
-
-    /// Gets the current error from the test environment.
-    fn get_error() -> Option<OdraError> {
-        odra_test_env_wrapper::on_backend(|env| env.get_error())
     }
 }

--- a/core/src/external_api/test_env.rs
+++ b/core/src/external_api/test_env.rs
@@ -31,9 +31,9 @@ impl TestEnv {
         set_caller(address: &Address)
         ///Returns nth test user account.
         get_account(n: usize) -> Address
-        ///Gets nth event emitted by the contract at `address`."
+        ///Gets nth event emitted by the contract at `address`.
         get_event(address: &Address, index: i32) -> Result<EventData, EventError>
-        ///Gets the current error from the test environment."
+        ///Gets the current error from the test environment.
         get_error() -> Option<OdraError>
         ///Increases the current value of block_time.
         advance_block_time_by(seconds: u64)

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -40,7 +40,6 @@ where
 {
     cfg_if::cfg_if! {
         if #[cfg(feature = "mock-vm")] {
-            let has_return = types::CLType::Unit != T::cl_type();
             let result = TestEnv::call_contract(address, entrypoint, args);
             match result {
                 Some(bytes) => T::from_bytes(bytes.as_slice()).unwrap().0,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -41,7 +41,7 @@ where
     cfg_if::cfg_if! {
         if #[cfg(feature = "mock-vm")] {
             let has_return = types::CLType::Unit != T::cl_type();
-            let result = TestEnv::call_contract(address, entrypoint, args, has_return);
+            let result = TestEnv::call_contract(address, entrypoint, args);
             match result {
                 Some(bytes) => T::from_bytes(bytes.as_slice()).unwrap().0,
                 None => T::from_bytes(&[]).unwrap().0,

--- a/mock_vm/src/contract_env.rs
+++ b/mock_vm/src/contract_env.rs
@@ -65,4 +65,9 @@ impl ContractEnv {
         borrow_env().revert(execution_error.into());
         panic!("OdraRevert")
     }
+
+    /// Returns the current block time.
+    pub fn get_block_time() -> u64 {
+        borrow_env().get_block_time()
+    }
 }

--- a/mock_vm/src/mock_vm.rs
+++ b/mock_vm/src/mock_vm.rs
@@ -165,6 +165,14 @@ impl MockVm {
     pub fn get_event(&self, address: &Address, index: i32) -> Result<EventData, EventError> {
         self.state.read().unwrap().get_event(address, index)
     }
+
+    pub fn get_block_time(&self) -> u64 {
+        self.state.read().unwrap().block_time()
+    }
+
+    pub fn advance_block_time_by(&self, seconds: u64) {
+        self.state.write().unwrap().advance_block_time_by(seconds)
+    }
 }
 
 #[derive(Clone)]
@@ -174,6 +182,7 @@ pub struct MockVmState {
     events: HashMap<Address, Vec<EventData>>,
     contract_counter: u32,
     error: Option<OdraError>,
+    block_time: u64,
 }
 
 impl MockVmState {
@@ -286,6 +295,14 @@ impl MockVmState {
     fn restore_snapshot(&mut self) {
         self.storage.restore_snapshot();
     }
+
+    pub fn block_time(&self) -> u64 {
+        self.block_time
+    }
+
+    pub fn advance_block_time_by(&mut self, seconds: u64) {
+        self.block_time += seconds;
+    }
 }
 
 impl Default for MockVmState {
@@ -296,6 +313,7 @@ impl Default for MockVmState {
             events: Default::default(),
             contract_counter: 0,
             error: None,
+            block_time: 0,
         };
         backend.push_address(default_accounts().first().unwrap());
         backend

--- a/mock_vm/src/mock_vm.rs
+++ b/mock_vm/src/mock_vm.rs
@@ -51,7 +51,6 @@ impl MockVm {
         address: &Address,
         entrypoint: &str,
         args: &RuntimeArgs,
-        _has_return: bool,
     ) -> Option<Bytes> {
         self.prepare_call(address);
 
@@ -375,7 +374,7 @@ mod tests {
         );
 
         // when call an existing entrypoint
-        let result = instance.call_contract(&address, "abc", &RuntimeArgs::new(), false);
+        let result = instance.call_contract(&address, "abc", &RuntimeArgs::new());
 
         // then returns the expected value
         assert_eq!(result, Some(vec![1, 1, 1].into()));
@@ -389,7 +388,7 @@ mod tests {
         let address = Address::new(b"random");
 
         // when call a contract
-        instance.call_contract(&address, "abc", &RuntimeArgs::new(), false);
+        instance.call_contract(&address, "abc", &RuntimeArgs::new());
 
         // then the vm is in error state
         assert_eq!(
@@ -411,7 +410,7 @@ mod tests {
         );
 
         // when call non-existing entrypoint
-        instance.call_contract(&address, "cba", &RuntimeArgs::new(), false);
+        instance.call_contract(&address, "cba", &RuntimeArgs::new());
 
         // then the vm is in error state
         assert_eq!(

--- a/mock_vm/src/mock_vm.rs
+++ b/mock_vm/src/mock_vm.rs
@@ -51,6 +51,7 @@ impl MockVm {
         address: &Address,
         entrypoint: &str,
         args: &RuntimeArgs,
+        _has_return: bool,
     ) -> Option<Bytes> {
         self.prepare_call(address);
 
@@ -374,7 +375,7 @@ mod tests {
         );
 
         // when call an existing entrypoint
-        let result = instance.call_contract(&address, "abc", &RuntimeArgs::new());
+        let result = instance.call_contract(&address, "abc", &RuntimeArgs::new(), false);
 
         // then returns the expected value
         assert_eq!(result, Some(vec![1, 1, 1].into()));
@@ -388,7 +389,7 @@ mod tests {
         let address = Address::new(b"random");
 
         // when call a contract
-        instance.call_contract(&address, "abc", &RuntimeArgs::new());
+        instance.call_contract(&address, "abc", &RuntimeArgs::new(), false);
 
         // then the vm is in error state
         assert_eq!(
@@ -410,7 +411,7 @@ mod tests {
         );
 
         // when call non-existing entrypoint
-        instance.call_contract(&address, "cba", &RuntimeArgs::new());
+        instance.call_contract(&address, "cba", &RuntimeArgs::new(), false);
 
         // then the vm is in error state
         assert_eq!(

--- a/mock_vm/src/test_env.rs
+++ b/mock_vm/src/test_env.rs
@@ -66,4 +66,9 @@ impl TestEnv {
     pub fn get_event(address: &Address, index: i32) -> Result<EventData, EventError> {
         borrow_env().get_event(address, index)
     }
+
+    /// Increases the current value of block_time.
+    pub fn advance_block_time_by(&self, seconds: u64) {
+        borrow_env().advance_block_time_by(seconds)
+    }
 }

--- a/mock_vm/src/test_env.rs
+++ b/mock_vm/src/test_env.rs
@@ -4,7 +4,6 @@ use odra_types::{bytesrepr::Bytes, event::EventError, Address, EventData, OdraEr
 
 use crate::{mock_vm::default_accounts, EntrypointCall};
 
-
 macro_rules! delegate_to_env {
     (
         $(
@@ -27,7 +26,6 @@ macro_rules! delegate_to_env {
 pub struct TestEnv;
 
 impl TestEnv {
-
     delegate_to_env! {
         /// Registers the contract in the test environment.
         register_contract(
@@ -69,9 +67,9 @@ impl TestEnv {
             .expect("An error expected, but did not occur");
         assert_eq!(exec_err, err.into());
     }
-    
+
     /// Returns nth test user account.
     pub fn get_account(n: usize) -> Address {
         *default_accounts().get(n).unwrap()
-    }       
+    }
 }

--- a/mock_vm/src/test_env.rs
+++ b/mock_vm/src/test_env.rs
@@ -2,7 +2,24 @@ use std::collections::HashMap;
 
 use odra_types::{bytesrepr::Bytes, event::EventError, Address, EventData, OdraError, RuntimeArgs};
 
-use crate::{borrow_env, mock_vm::default_accounts, EntrypointCall};
+use crate::{mock_vm::default_accounts, EntrypointCall};
+
+
+macro_rules! delegate_to_env {
+    (
+        $(
+            $(#[$outer:meta])*
+            $func_name:ident($( $param_ident:ident : $param_ty:ty ),*) $( -> $ret:ty)*
+        )+
+    ) => {
+        $(
+            $(#[$outer])*
+            pub fn $func_name( $($param_ident : $param_ty),* ) $(-> $ret)* {
+                crate::borrow_env().$func_name($($param_ident),*)
+            }
+        )+
+    }
+}
 
 /// Describes test environment API. TestEnv delegates methods to the underlying env implementation.
 ///
@@ -10,25 +27,31 @@ use crate::{borrow_env, mock_vm::default_accounts, EntrypointCall};
 pub struct TestEnv;
 
 impl TestEnv {
-    /// Registers the contract in the test environment.
-    pub fn register_contract(
-        constructor: Option<(String, RuntimeArgs, EntrypointCall)>,
-        constructors: HashMap<String, EntrypointCall>,
-        entrypoints: HashMap<String, EntrypointCall>,
-    ) -> Address {
-        borrow_env().register_contract(constructor, constructors, entrypoints)
-    }
 
-    /// Calls contract at `address` invoking the `entrypoint` with `args`.
-    ///
-    /// Returns optional raw bytes to further processing.
-    pub fn call_contract(
-        address: &Address,
-        entrypoint: &str,
-        args: &RuntimeArgs,
-        _has_return: bool,
-    ) -> Option<Bytes> {
-        borrow_env().call_contract(address, entrypoint, args)
+    delegate_to_env! {
+        /// Registers the contract in the test environment.
+        register_contract(
+            constructor: Option<(String, RuntimeArgs, EntrypointCall)>,
+            constructors: HashMap<String, EntrypointCall>,
+            entrypoints: HashMap<String, EntrypointCall>
+        ) -> Address
+        /// Calls contract at `address` invoking the `entrypoint` with `args`.
+        ///
+        /// Returns optional raw bytes to further processing.
+        call_contract(
+            address: &Address,
+            entrypoint: &str,
+            args: &RuntimeArgs,
+            has_return: bool
+        ) -> Option<Bytes>
+        /// Increases the current value of block_time.
+        advance_block_time_by(seconds: u64)
+        /// Returns the backend name.
+        get_backend_name() -> String
+        /// Replaces the current caller.
+        set_caller(address: &Address)
+        /// Gets nth event emitted by the contract at `address`.
+        get_event(address: &Address, index: i32) -> Result<EventData, EventError>
     }
 
     /// Expects the `block` execution will fail with the specific error.
@@ -41,34 +64,14 @@ impl TestEnv {
             block();
         });
 
-        let exec_err = borrow_env()
+        let exec_err = crate::borrow_env()
             .error()
             .expect("An error expected, but did not occur");
         assert_eq!(exec_err, err.into());
     }
-
-    /// Returns the backend name.
-    pub fn backend_name() -> String {
-        borrow_env().get_backend_name()
-    }
-
-    /// Replaces the current caller.
-    pub fn set_caller(address: &Address) {
-        borrow_env().set_caller(address)
-    }
-
+    
     /// Returns nth test user account.
     pub fn get_account(n: usize) -> Address {
         *default_accounts().get(n).unwrap()
-    }
-
-    /// Gets nth event emitted by the contract at `address`.
-    pub fn get_event(address: &Address, index: i32) -> Result<EventData, EventError> {
-        borrow_env().get_event(address, index)
-    }
-
-    /// Increases the current value of block_time.
-    pub fn advance_block_time_by(&self, seconds: u64) {
-        borrow_env().advance_block_time_by(seconds)
-    }
+    }       
 }

--- a/mock_vm/src/test_env.rs
+++ b/mock_vm/src/test_env.rs
@@ -39,8 +39,7 @@ impl TestEnv {
         call_contract(
             address: &Address,
             entrypoint: &str,
-            args: &RuntimeArgs,
-            has_return: bool
+            args: &RuntimeArgs
         ) -> Option<Bytes>
         /// Increases the current value of block_time.
         advance_block_time_by(seconds: u64)

--- a/test_env_wrapper/src/lib.rs
+++ b/test_env_wrapper/src/lib.rs
@@ -33,6 +33,8 @@ pub struct TestBackend {
     get_error: fn() -> Option<OdraError>,
     /// Gets nth event emitted by contract at `address`.
     get_event: fn(address: &Address, index: i32) -> Result<EventData, EventError>,
+    /// Increases the current value of block_time.
+    advance_block_time_by: fn(seconds: u64),
 }
 
 /// An entry point for communication with dynamically loaded Test Env.


### PR DESCRIPTION
Add advancing block time feature in MockVm
Define advance_block_time_by() in test env wrapper
Add missing extern __get_block_time() definition