### PR TITLE
Fix call_contract type mismatch

### DIFF
--- a/core/src/external_api/test_env.rs
+++ b/core/src/external_api/test_env.rs
@@ -4,7 +4,7 @@ macro_rules! delegate_to_wrapper {
     (
         $(
             $(#[$outer:meta])*
-            $func_name:ident($( $param_ident:ident : $param_ty:ty ),*) $( -> $ret:ty)*
+            fn $func_name:ident($( $param_ident:ident : $param_ty:ty ),*) $( -> $ret:ty)*
         )+
     ) => {
         $(
@@ -23,34 +23,30 @@ pub struct TestEnv;
 
 impl TestEnv {
     delegate_to_wrapper! {
+        /// Calls contract at `address` invoking the `entrypoint` with `args`.
+        ///
+        /// Returns optional raw bytes to further processing.
+        fn call_contract(
+            address: &Address,
+            entrypoint: &str,
+            args: &RuntimeArgs,
+            has_return: bool,
+            amount: Option<U512>
+        ) -> Option<Bytes>
         ///Registers the contract in the test environment.
-        register_contract(contract_name: &str, args: &RuntimeArgs) -> Address
+        fn register_contract(contract_name: &str, args: &RuntimeArgs) -> Address
         ///Returns the backend name.
-        backend_name() -> String
+        fn backend_name() -> String
         ///Replaces the current caller.
-        set_caller(address: &Address)
+        fn set_caller(address: &Address)
         ///Returns nth test user account.
-        get_account(n: usize) -> Address
+        fn get_account(n: usize) -> Address
         ///Gets nth event emitted by the contract at `address`.
-        get_event(address: &Address, index: i32) -> Result<EventData, EventError>
+        fn get_event(address: &Address, index: i32) -> Result<EventData, EventError>
         ///Gets the current error from the test environment.
-        get_error() -> Option<OdraError>
+        fn get_error() -> Option<OdraError>
         ///Increases the current value of block_time.
-        advance_block_time_by(seconds: u64)
-    }
-
-    /// Calls contract at `address` invoking the `entrypoint` with `args`.
-    ///
-    /// Returns optional raw bytes to further processing.
-    pub fn call_contract(
-        address: &Address,
-        entrypoint: &str,
-        args: &RuntimeArgs,
-        has_return: bool,
-    ) -> Option<Bytes> {
-        odra_test_env_wrapper::on_backend(|env| {
-            Some(env.call_contract(address, entrypoint, args, has_return))
-        })
+        fn advance_block_time_by(seconds: u64)
     }
 
     /// Expects the `block` execution will fail with the specific error.

--- a/mock_vm/src/test_env.rs
+++ b/mock_vm/src/test_env.rs
@@ -8,7 +8,7 @@ macro_rules! delegate_to_env {
     (
         $(
             $(#[$outer:meta])*
-            $func_name:ident($( $param_ident:ident : $param_ty:ty ),*) $( -> $ret:ty)*
+            fn $func_name:ident($( $param_ident:ident : $param_ty:ty ),*) $( -> $ret:ty)*
         )+
     ) => {
         $(
@@ -28,7 +28,7 @@ pub struct TestEnv;
 impl TestEnv {
     delegate_to_env! {
         /// Registers the contract in the test environment.
-        register_contract(
+        fn register_contract(
             constructor: Option<(String, RuntimeArgs, EntrypointCall)>,
             constructors: HashMap<String, (EntrypointArgs, EntrypointCall)>,
             entrypoints: HashMap<String, (EntrypointArgs, EntrypointCall)>
@@ -36,19 +36,19 @@ impl TestEnv {
         /// Calls contract at `address` invoking the `entrypoint` with `args`.
         ///
         /// Returns optional raw bytes to further processing.
-        call_contract(
+        fn call_contract(
             address: &Address,
             entrypoint: &str,
             args: &RuntimeArgs
         ) -> Option<Bytes>
         /// Increases the current value of block_time.
-        advance_block_time_by(seconds: u64)
+        fn advance_block_time_by(seconds: u64)
         /// Returns the backend name.
-        get_backend_name() -> String
+        fn get_backend_name() -> String
         /// Replaces the current caller.
-        set_caller(address: &Address)
+        fn set_caller(address: &Address)
         /// Gets nth event emitted by the contract at `address`.
-        get_event(address: &Address, index: i32) -> Result<EventData, EventError>
+        fn get_event(address: &Address, index: i32) -> Result<EventData, EventError>
     }
 
     /// Expects the `block` execution will fail with the specific error.

--- a/test_env_wrapper/src/lib.rs
+++ b/test_env_wrapper/src/lib.rs
@@ -24,7 +24,7 @@ pub struct TestBackend {
     register_contract: fn(name: &str, args: &RuntimeArgs) -> Address,
     /// Calls contract at `address` invoking the `entrypoint` with `args`.
     call_contract:
-        fn(addr: &Address, entrypoint: &str, args: &RuntimeArgs, has_return: bool) -> Bytes,
+        fn(addr: &Address, entrypoint: &str, args: &RuntimeArgs, has_return: bool) -> Option<Bytes>,
     /// Returns nth user account.
     get_account: fn(n: usize) -> Address,
     /// Replaces the current caller.


### PR DESCRIPTION
Also update delegate_to_wrapper macro to accept more verbose syntax `fn some_func()`

Resolves #49 

