### PR TITLE
Add mutability modifier support

### DIFF
--- a/core/src/list.rs
+++ b/core/src/list.rs
@@ -29,14 +29,14 @@ impl<T: OdraType> List<T> {
     }
 
     /// Pushes the `value` to the storage.
-    pub fn push(&self, value: T) {
+    pub fn push(&mut self, value: T) {
         let current_index = self.index.get_or_default();
         self.values.set(&current_index, value);
         self.index.set(current_index + 1);
     }
 
     /// Replaces the current value with the `value` and returns it.
-    pub fn replace(&self, index: u32, value: T) -> T {
+    pub fn replace(&mut self, index: u32, value: T) -> T {
         let current_index = self.index.get_or_default();
         if current_index < index {
             contract_env::revert(CollectionError::IndexOutOfBounds);
@@ -158,7 +158,7 @@ mod tests {
     #[test]
     fn test_getting_items() {
         // Given an empty list
-        let list = List::<u8>::default();
+        let mut list = List::<u8>::default();
         assert_eq!(list.len(), 0);
 
         // When push a first item
@@ -183,7 +183,7 @@ mod tests {
     #[test]
     fn test_replace() {
         // Given a list with 5 items
-        let list = List::<u8>::default();
+        let mut list = List::<u8>::default();
         for i in 0..5 {
             list.push(i);
         }
@@ -198,6 +198,7 @@ mod tests {
 
         // When replaces nonexistent value then reverts
         test_env::assert_exception(CollectionError::IndexOutOfBounds, || {
+            let mut list = List::<u8>::default();
             list.replace(100, 99);
         });
     }
@@ -205,7 +206,7 @@ mod tests {
     #[test]
     fn test_list_len() {
         // Given an empty list
-        let list = List::<u8>::default();
+        let mut list = List::<u8>::default();
 
         // When push 3 elements
         assert_eq!(list.len(), 0);
@@ -220,7 +221,7 @@ mod tests {
     #[test]
     fn test_list_is_empty() {
         // Given an empty list
-        let list = List::<u8>::default();
+        let mut list = List::<u8>::default();
         assert!(list.is_empty());
 
         // When push an element
@@ -233,7 +234,7 @@ mod tests {
     #[test]
     fn test_iter() {
         // Given a list with 5 items
-        let list = List::<u8>::default();
+        let mut list = List::<u8>::default();
         for i in 0..5 {
             list.push(i);
         }
@@ -251,7 +252,7 @@ mod tests {
     #[test]
     fn test_fuse_iter() {
         // Given a list with 3 items
-        let list = List::<u8>::default();
+        let mut list = List::<u8>::default();
         for i in 0..3 {
             list.push(i);
         }
@@ -272,7 +273,7 @@ mod tests {
     #[test]
     fn test_double_ended_iter() {
         // Given a list with 10 items
-        let list = List::<u8>::default();
+        let mut list = List::<u8>::default();
         for i in 0..10 {
             list.push(i);
         }

--- a/core/src/variable.rs
+++ b/core/src/variable.rs
@@ -25,7 +25,7 @@ impl<V: OdraType + OverflowingAdd + Default> Variable<V> {
     /// and sets the new value to the storage.
     ///
     /// If the operation fails due to overflow, the currently executing contract reverts.
-    pub fn add(&self, value: V) {
+    pub fn add(&mut self, value: V) {
         let current_value = self.get().unwrap_or_default();
         let new_value = current_value.overflowing_add(value).unwrap_or_revert();
         contract_env::set_var(&self.name, new_value);
@@ -37,7 +37,7 @@ impl<V: OdraType + OverflowingSub + Default> Variable<V> {
     /// and sets the new value to the storage.
     ///
     /// If the operation fails due to overflow, the currently executing contract reverts.
-    pub fn subtract(&self, value: V) {
+    pub fn subtract(&mut self, value: V) {
         let current_value = self.get().unwrap_or_default();
         let new_value = current_value.overflowing_sub(value).unwrap_or_revert();
         contract_env::set_var(&self.name, new_value);
@@ -59,7 +59,7 @@ impl<T: OdraType> Variable<T> {
     }
 
     /// Stores `value` to the storage.
-    pub fn set(&self, value: T) {
+    pub fn set(&mut self, value: T) {
         contract_env::set_var(&self.name, value);
     }
 
@@ -91,7 +91,7 @@ mod tests {
     fn test_get() {
         // Given uninitialized var.
         let value = 100;
-        let var = Variable::<u8>::default();
+        let mut var = Variable::<u8>::default();
 
         // When set a value.
         var.set(value);
@@ -122,7 +122,7 @@ mod tests {
     fn test_add() {
         // Given var = u8::MAX-1.
         let initial_value = u8::MAX - 1;
-        let var = Variable::<u8>::init(initial_value);
+        let mut var = Variable::<u8>::init(initial_value);
 
         // When add 1.
         var.add(1);
@@ -133,6 +133,7 @@ mod tests {
         // When add 1 to max value.
         // Then should revert.
         test_env::assert_exception(ArithmeticsError::AdditionOverflow, || {
+            let mut var = Variable::<u8>::default();
             var.add(1);
         });
     }
@@ -141,7 +142,7 @@ mod tests {
     fn test_subtract() {
         // Given var = 2.
         let initial_value = 2;
-        let var = Variable::<u8>::init(initial_value);
+        let mut var = Variable::<u8>::init(initial_value);
         // When subtract 1.
         var.subtract(1);
 
@@ -151,6 +152,7 @@ mod tests {
         // When subtraction causes overflow.
         // Then it reverts.
         test_env::assert_exception(ArithmeticsError::SubtractingOverflow, || {
+            let mut var = Variable::<u8>::default();
             var.subtract(2);
         });
     }
@@ -160,7 +162,7 @@ mod tests {
         // Given two variables with the same namespace.
         let namespace = "shared_value";
         let value = 42;
-        let x = Variable::<u8>::instance(namespace);
+        let mut x = Variable::<u8>::instance(namespace);
         let y = Variable::<u8>::instance(namespace);
 
         // When set a value for the first variable.
@@ -179,7 +181,7 @@ mod tests {
 
     impl<T: OdraType> Variable<T> {
         fn init(value: T) -> Self {
-            let var = Self::default();
+            let mut var = Self::default();
             var.set(value);
             var
         }

--- a/examples/src/owned_token.rs
+++ b/examples/src/owned_token.rs
@@ -1,6 +1,6 @@
 use odra::{
     contract_env,
-    types::{Address, U256},
+    types::{Address, U256}
 };
 
 use crate::{erc20::Erc20, ownable::Ownable};
@@ -8,13 +8,13 @@ use crate::{erc20::Erc20, ownable::Ownable};
 #[odra::module]
 pub struct OwnedToken {
     ownable: Ownable,
-    erc20: Erc20,
+    erc20: Erc20
 }
 
 #[odra::module]
 impl OwnedToken {
     #[odra(init)]
-    pub fn init(&self, name: String, symbol: String, decimals: u8, initial_supply: U256) {
+    pub fn init(&mut self, name: String, symbol: String, decimals: u8, initial_supply: U256) {
         let deployer = contract_env::caller();
         self.ownable.init(deployer);
         self.erc20.init(name, symbol, decimals, initial_supply);
@@ -44,15 +44,15 @@ impl OwnedToken {
         self.erc20.allowance(owner, spender)
     }
 
-    pub fn transfer(&self, recipient: Address, amount: U256) {
+    pub fn transfer(&mut self, recipient: Address, amount: U256) {
         self.erc20.transfer(recipient, amount);
     }
 
-    pub fn transfer_from(&self, owner: Address, recipient: Address, amount: U256) {
+    pub fn transfer_from(&mut self, owner: Address, recipient: Address, amount: U256) {
         self.erc20.transfer_from(owner, recipient, amount);
     }
 
-    pub fn approve(&self, spender: Address, amount: U256) {
+    pub fn approve(&mut self, spender: Address, amount: U256) {
         self.erc20.approve(spender, amount);
     }
 
@@ -60,11 +60,11 @@ impl OwnedToken {
         self.ownable.get_owner()
     }
 
-    pub fn change_ownership(&self, new_owner: Address) {
+    pub fn change_ownership(&mut self, new_owner: Address) {
         self.ownable.change_ownership(new_owner);
     }
 
-    pub fn mint(&self, address: Address, amount: U256) {
+    pub fn mint(&mut self, address: Address, amount: U256) {
         self.ownable.ensure_ownership(contract_env::caller());
         self.erc20.mint(address, amount);
     }
@@ -86,7 +86,7 @@ mod tests {
             String::from(NAME),
             String::from(SYMBOL),
             DECIMALS,
-            INITIAL_SUPPLY.into(),
+            INITIAL_SUPPLY.into()
         )
     }
 
@@ -114,7 +114,7 @@ mod tests {
 
     #[test]
     fn mint_works() {
-        let token = setup();
+        let mut token = setup();
         let recipient = test_env::get_account(1);
         let amount = 10.into();
         token.mint(recipient, amount);
@@ -128,12 +128,17 @@ mod tests {
         let recipient = test_env::get_account(1);
         let amount = 10.into();
         test_env::set_caller(recipient);
-        test_env::assert_exception(ownable::Error::NotOwner, || token.mint(recipient, amount));
+        test_env::assert_exception(ownable::Error::NotOwner, || {
+            // TODO: If we don't create a new ref, an error occurs:
+            // cannot borrow `token` as mutable, as it is a captured variable in a `Fn` closure cannot borrow as mutable
+            let mut token = OwnedTokenRef::at(token.address());
+            token.mint(recipient, amount);
+        });
     }
 
     #[test]
     fn change_ownership_works() {
-        let token = setup();
+        let mut token = setup();
         let new_owner = test_env::get_account(1);
         token.change_ownership(new_owner);
         assert_eq!(token.get_owner(), new_owner);
@@ -145,6 +150,9 @@ mod tests {
         let new_owner = test_env::get_account(1);
         test_env::set_caller(new_owner);
         test_env::assert_exception(ownable::Error::NotOwner, || {
+            // TODO: If we don't create a new ref, an error occurs:
+            // cannot borrow `token` as mutable, as it is a captured variable in a `Fn` closure cannot borrow as mutable
+            let mut token = OwnedTokenRef::at(token.address());
             token.change_ownership(new_owner)
         });
     }

--- a/lang/codegen/src/generator/module_impl/deploy.rs
+++ b/lang/codegen/src/generator/module_impl/deploy.rs
@@ -152,7 +152,7 @@ where
                     stringify!(#constructor_ident).to_string(),
                     args,
                     |name, args| {
-                        let instance = <#struct_ident as odra::Instance>::instance(name.as_str());
+                        let mut instance = <#struct_ident as odra::Instance>::instance(name.as_str());
                         instance.#constructor_ident( #fn_args );
                         Vec::new()
                     }
@@ -242,7 +242,7 @@ where
             quote! {
                 entrypoints.insert(#name, (#arg_names, |name, args| {
                     #attached_value_check
-                    let instance = <#struct_ident as odra::Instance>::instance(name.as_str());
+                    let mut instance = <#struct_ident as odra::Instance>::instance(name.as_str());
                     let result = instance.#ident(#args);
                     #return_value
                 }));
@@ -264,7 +264,7 @@ where
             quote! {
                 constructors.insert(stringify!(#ident).to_string(), (#arg_names,
                     |name, args| {
-                        let instance = <#struct_ident as odra::Instance>::instance(name.as_str());
+                        let mut instance = <#struct_ident as odra::Instance>::instance(name.as_str());
                         instance.#ident( #args );
                         Vec::new()
                     }

--- a/lang/ir/src/module_item.rs
+++ b/lang/ir/src/module_item.rs
@@ -9,6 +9,7 @@ pub mod impl_item;
 pub mod method;
 pub mod module_impl;
 pub mod module_struct;
+mod utils;
 
 /// Odra module item.
 ///

--- a/lang/ir/src/module_item/constructor.rs
+++ b/lang/ir/src/module_item/constructor.rs
@@ -3,6 +3,8 @@ use std::convert::TryFrom;
 use crate::attrs::{partition_attributes, OdraAttribute};
 use quote::{quote, ToTokens};
 
+use super::utils;
+
 /// Odra constructor definition.
 ///
 /// # Examples
@@ -25,6 +27,7 @@ pub struct Constructor {
 
 impl ToTokens for Constructor {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let is_mut = utils::is_mut(&self.full_sig);
         let name = &self.ident.to_string();
         let args = &self
             .args
@@ -45,6 +48,7 @@ impl ToTokens for Constructor {
             odra::types::contract_def::Entrypoint {
                 ident: String::from(#name),
                 args: vec![#args],
+                is_mut: #is_mut,
                 ret: odra::types::Type::Unit,
                 ty: odra::types::contract_def::EntrypointType::Constructor,
             },

--- a/lang/ir/src/module_item/method.rs
+++ b/lang/ir/src/module_item/method.rs
@@ -2,6 +2,8 @@ use quote::{quote, ToTokens};
 
 use crate::attrs::{partition_attributes, OdraAttribute};
 
+use super::utils;
+
 /// Odra method definition.
 ///
 /// # Examples
@@ -61,10 +63,13 @@ impl ToTokens for Method {
             false => quote!(odra::types::contract_def::EntrypointType::Public)
         };
 
+        let is_mut = utils::is_mut(&self.full_sig);
+
         let ep = quote! {
             odra::types::contract_def::Entrypoint {
                 ident: String::from(#name),
                 args: vec![#args],
+                is_mut: #is_mut,
                 ret: #ret,
                 ty: #ty,
             },

--- a/lang/ir/src/module_item/utils.rs
+++ b/lang/ir/src/module_item/utils.rs
@@ -1,0 +1,7 @@
+pub fn is_mut(sig: &syn::Signature) -> bool {
+    let receiver = sig.inputs.iter().find_map(|input| match input {
+        syn::FnArg::Receiver(receiver) => Some(receiver),
+        syn::FnArg::Typed(_) => None
+    });
+    receiver.and_then(|r| r.mutability).is_some()
+}

--- a/lang/proc-macros/src/lib.rs
+++ b/lang/proc-macros/src/lib.rs
@@ -33,11 +33,11 @@ mod odra_error;
 /// #[odra::module]
 /// impl Flipper {
 ///     #[odra(init)]
-///     pub fn initial_settings(&self, value: bool) {
+///     pub fn initial_settings(&mut self, value: bool) {
 ///         self.value.set(value);
 ///     }
 ///
-///     pub fn flip(&self) {
+///     pub fn flip(&mut self) {
 ///         self.value.set(!self.get());
 ///     }
 ///

--- a/mock-vm/backend/src/contract_env.rs
+++ b/mock-vm/backend/src/contract_env.rs
@@ -69,9 +69,9 @@ pub fn one_token() -> Balance {
 }
 
 /// Transfers native token from the contract caller to the given address.
-pub fn transfer_tokens(to: Address, amount: Balance) -> bool {
+pub fn transfer_tokens<B: Into<Balance>>(to: Address, amount: B) -> bool {
     let callee = borrow_env().callee();
-    borrow_env().transfer_tokens(callee, to, amount)
+    borrow_env().transfer_tokens(callee, to, amount.into())
 }
 
 /// Returns the balance of the account associated with the current contract.

--- a/odra-casper/backend/src/contract_env.rs
+++ b/odra-casper/backend/src/contract_env.rs
@@ -102,12 +102,12 @@ pub fn attached_value() -> Balance {
 }
 
 /// Transfers native token from the contract caller to the given address.
-pub fn transfer_tokens<B: Into<U512>>(to: Address, amount: B) {
+pub fn transfer_tokens<B: Into<Balance>>(to: Address, amount: B) {
     let main_purse = get_main_purse();
 
     match to {
         Address::Account(account) => {
-            transfer_from_purse_to_account(main_purse, account, amount.into(), None)
+            transfer_from_purse_to_account(main_purse, account, amount.into().inner(), None)
                 .unwrap_or_revert();
         }
         Address::Contract(_) => revert(ExecutionError::can_not_transfer_to_contract())

--- a/odra-casper/codegen/src/constructor.rs
+++ b/odra-casper/codegen/src/constructor.rs
@@ -97,7 +97,8 @@ mod tests {
                 ty: Type::I32
             }],
             ret: Type::Unit,
-            ty: EntrypointType::Constructor
+            ty: EntrypointType::Constructor,
+            is_mut: false
         };
         let path: Path = syn::parse2(
             quote! {

--- a/odra-casper/codegen/src/constructor.rs
+++ b/odra-casper/codegen/src/constructor.rs
@@ -32,7 +32,7 @@ impl ToTokens for WasmConstructor<'_> {
                 quote! {
                     stringify!(#entrypoint_ident) => {
                         let odra_address = odra::types::Address::from(contract_package_hash);
-                        let contract_ref = #ref_ident::at(odra_address);
+                        let mut contract_ref = #ref_ident::at(odra_address);
                         #casper_args
                         contract_ref.#entrypoint_ident( #fn_args );
                     },
@@ -121,7 +121,7 @@ mod tests {
                     match constructor_name {
                         stringify!(construct_me) => {
                             let odra_address = odra::types::Address::from(contract_package_hash);
-                            let contract_ref = my_contract::MyContract::at(odra_address);
+                            let mut contract_ref = my_contract::MyContract::at(odra_address);
                             let value = odra::casper::casper_contract::contract_api::runtime::get_named_arg (stringify!(value));
                             contract_ref.construct_me(value);
                         },

--- a/odra-casper/codegen/src/entrypoints_def.rs
+++ b/odra-casper/codegen/src/entrypoints_def.rs
@@ -90,7 +90,8 @@ mod test {
                 ty: Type::I32
             }],
             ret: Type::Bool,
-            ty: EntrypointType::Public
+            ty: EntrypointType::Public,
+            is_mut: false
         }];
         let ep = ContractEntrypoints(&a);
         assert_eq_tokens(

--- a/odra-casper/codegen/src/lib.rs
+++ b/odra-casper/codegen/src/lib.rs
@@ -115,13 +115,15 @@ mod tests {
                 ty: Type::I32
             }],
             ret: Type::Unit,
-            ty: EntrypointType::Constructor
+            ty: EntrypointType::Constructor,
+            is_mut: false
         };
         let entrypoint = Entrypoint {
             ident: String::from("call_me"),
             args: vec![],
             ret: Type::Bool,
-            ty: EntrypointType::Public
+            ty: EntrypointType::Public,
+            is_mut: false
         };
 
         let path: syn::Path = syn::parse_str("my_contract::MyContract").unwrap();

--- a/odra-casper/codegen/src/wasm_entrypoint.rs
+++ b/odra-casper/codegen/src/wasm_entrypoint.rs
@@ -56,7 +56,7 @@ impl ToTokens for WasmEntrypoint<'_> {
             #[no_mangle]
             fn #entrypoint_ident() {
                 #payable
-                let contract = #contract_path::instance("contract");
+                let mut contract = #contract_path::instance("contract");
                 #contract_call
                 #payable_cleanup
             }

--- a/odra-casper/codegen/src/wasm_entrypoint.rs
+++ b/odra-casper/codegen/src/wasm_entrypoint.rs
@@ -51,12 +51,16 @@ impl ToTokens for WasmEntrypoint<'_> {
         };
 
         let contract_path = &self.1;
+        let contract_instance = match self.0.is_mut {
+            true => quote!(let mut contract = #contract_path::instance("contract");),
+            false => quote!(let contract = #contract_path::instance("contract");)
+        };
 
         tokens.extend(quote! {
             #[no_mangle]
             fn #entrypoint_ident() {
                 #payable
-                let mut contract = #contract_path::instance("contract");
+                #contract_instance
                 #contract_call
                 #payable_cleanup
             }
@@ -80,7 +84,8 @@ mod tests {
                 ty: Type::I32
             }],
             ret: Type::Unit,
-            ty: EntrypointType::Public
+            ty: EntrypointType::Public,
+            is_mut: false
         };
         let path: Path = syn::parse2(
             quote! {
@@ -113,7 +118,8 @@ mod tests {
             ident: String::from("pay_me"),
             args: vec![],
             ret: Type::Unit,
-            ty: EntrypointType::PublicPayable
+            ty: EntrypointType::PublicPayable,
+            is_mut: false
         };
         let path: Path = syn::parse_quote!(a::b::c::Contract);
 
@@ -125,6 +131,32 @@ mod tests {
                 fn pay_me() {
                     odra::casper::utils::handle_attached_value();
                     let contract = a::b::c::Contract::instance("contract");
+                    contract.pay_me();
+                    odra::casper::utils::clear_attached_value();
+                }
+            )
+        );
+    }
+
+    #[test]
+    fn test_mutable() {
+        let entrypoint = Entrypoint {
+            ident: String::from("pay_me"),
+            args: vec![],
+            ret: Type::Unit,
+            ty: EntrypointType::PublicPayable,
+            is_mut: true
+        };
+        let path: Path = syn::parse_quote!(a::b::c::Contract);
+
+        let wasm_entrypoint = WasmEntrypoint(&entrypoint, &path);
+        assert_eq_tokens(
+            wasm_entrypoint,
+            quote!(
+                #[no_mangle]
+                fn pay_me() {
+                    odra::casper::utils::handle_attached_value();
+                    let mut contract = a::b::c::Contract::instance("contract");
                     contract.pay_me();
                     odra::casper::utils::clear_attached_value();
                 }

--- a/odra-casper/test-env/src/dummy_contract_env.rs
+++ b/odra-casper/test-env/src/dummy_contract_env.rs
@@ -51,7 +51,7 @@ pub fn one_token() -> Balance {
     unimplemented!()
 }
 
-pub fn transfer_tokens(_: Address, _: Balance) -> bool {
+pub fn transfer_tokens<B: Into<Balance>>(_: Address, _: B) -> bool {
     unimplemented!()
 }
 

--- a/types/src/contract_def.rs
+++ b/types/src/contract_def.rs
@@ -14,6 +14,7 @@ pub struct ContractDef {
 pub struct Entrypoint {
     pub ident: String,
     pub args: Vec<Argument>,
+    pub is_mut: bool,
     pub ret: Type,
     pub ty: EntrypointType
 }


### PR DESCRIPTION
Add `mut` modifier to functions of `Variable`, `Mapping`, and `List` that modify the state.

```rust
struct Counter {
    c: Variable<u32>
}

impl Counter {
   // will not compile
   fn inc(&self) {
       self.c.set(self.c.get_or_default() + 1);
   } 

   fn inc(&mut self) {
       self.c.set(self.c.get_or_default() + 1);
   } 
}
```