### PR TITLE
Remove default constructor is any other is defined

### DIFF
--- a/examples/src/balance_checker.rs
+++ b/examples/src/balance_checker.rs
@@ -24,7 +24,7 @@ mod tests {
     #[test]
     fn balance_checker() {
         let (owner, second_account) = (test_env::get_account(0), test_env::get_account(1));
-        let balance_checker = BalanceChecker::deploy();
+        let balance_checker = BalanceCheckerDeployer::default();
         let token = erc20::tests::setup();
         let expected_owner_balance = erc20::tests::INITIAL_SUPPLY;
 

--- a/examples/src/erc20.rs
+++ b/examples/src/erc20.rs
@@ -139,7 +139,7 @@ execution_error! {
 
 #[cfg(test)]
 pub mod tests {
-    use super::{Approval, Erc20, Erc20Ref, Error, Transfer};
+    use super::{Approval, Erc20Deployer, Erc20Ref, Error, Transfer};
     use odra::{assert_events, test_env, types::U256};
 
     pub const NAME: &str = "Plascoin";
@@ -148,7 +148,7 @@ pub mod tests {
     pub const INITIAL_SUPPLY: u32 = 10_000;
 
     pub fn setup() -> Erc20Ref {
-        Erc20::deploy_init(
+        Erc20Deployer::init(
             String::from(NAME),
             String::from(SYMBOL),
             DECIMALS,

--- a/examples/src/ownable.rs
+++ b/examples/src/ownable.rs
@@ -68,7 +68,7 @@ mod tests {
 
     fn setup() -> (Address, OwnableRef) {
         let owner = test_env::get_account(0);
-        let ownable = Ownable::deploy_init(owner);
+        let ownable = OwnableDeployer::init(owner);
         (owner, ownable)
     }
 

--- a/examples/src/owned_token.rs
+++ b/examples/src/owned_token.rs
@@ -82,7 +82,7 @@ mod tests {
     const INITIAL_SUPPLY: u32 = 10_000;
 
     fn setup() -> OwnedTokenRef {
-        OwnedToken::deploy_init(
+        OwnedTokenDeployer::init(
             String::from(NAME),
             String::from(SYMBOL),
             DECIMALS,


### PR DESCRIPTION
I decided it doesn't make sense if a constructor returns `Self`, it would change the whole `instance` approach.