### PR TITLE
Update odra-ci.yml

### DIFF
--- a/.github/workflows/odra-ci.yml
+++ b/.github/workflows/odra-ci.yml
@@ -23,9 +23,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
           components: rustfmt, clippy
-          override: true
       - run: just check-lint
       - run: just prepare-test-env
       - run: just test


### PR DESCRIPTION
According to https://rust-lang.github.io/rustup/overrides.html#overrides `rustup override set ...` has a higher priority than `rust-toolchain` file.

The previous setup
```
toolchain: nightly
components: rustfmt, clippy
override: true
```
causes downloading the most recent `nightly` version (because the version is unspecified) and overriding it in the project's root directory (it applies to all subdirectories, including `examples` and `modules`). Basically the version specified in `rust-toolchain` was ignored,