### PR TITLE
Derive Debug and other traits for Odra Errors.

### DIFF
--- a/lang/codegen/src/generator/errors.rs
+++ b/lang/codegen/src/generator/errors.rs
@@ -30,6 +30,7 @@ impl GenerateCode for ErrorEnumItem<'_> {
 
         quote::quote! {
             #[odra::odra_error]
+            #[derive(Debug, PartialEq, Eq, Clone, Copy)]
             #item_enum
 
             impl From<#enum_ident> for odra::types::ExecutionError {

--- a/mock-vm/types/src/lib.rs
+++ b/mock-vm/types/src/lib.rs
@@ -22,8 +22,13 @@ pub type BlockTime = u64;
 /// A type that can be written to the storage and read from the storage.
 pub trait OdraType: MockVMType {
     /// Serializes the value.
-    fn as_bytes(&self) -> Option<Vec<u8>> {
+    fn serialize(&self) -> Option<Vec<u8>> {
         self.ser().ok()
+    }
+
+    /// Deserializes the value.
+    fn deserialize(bytes: &[u8]) -> Option<Self> {
+        Self::deser(bytes.to_vec()).ok()
     }
 }
 
@@ -32,8 +37,26 @@ impl<T: MockVMType> OdraType for T {}
 /// Represents a serialized event.
 pub type EventData = Vec<u8>;
 
-#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Default)]
 pub struct Bytes(Vec<u8>);
+
+impl Bytes {
+    /// Constructs a new, empty vector of bytes.
+    pub fn new() -> Bytes {
+        Bytes::default()
+    }
+
+    /// Returns reference to inner container.
+    #[inline]
+    pub fn inner_bytes(&self) -> &Vec<u8> {
+        &self.0
+    }
+
+    /// Extracts a slice containing the entire vector.
+    pub fn as_slice(&self) -> &[u8] {
+        self.inner_bytes().as_slice()
+    }
+}
 
 impl From<Vec<u8>> for Bytes {
     fn from(vec: Vec<u8>) -> Self {

--- a/odra-casper/types/src/lib.rs
+++ b/odra-casper/types/src/lib.rs
@@ -20,8 +20,21 @@ use casper_types::{
 
 /// A type that can be written to the storage and read from the storage.
 pub trait OdraType: CLTyped + ToBytes + FromBytes {
-    fn as_bytes(&self) -> Option<Vec<u8>> {
+    fn serialize(&self) -> Option<Vec<u8>> {
         self.to_bytes().ok()
+    }
+
+    fn deserialize(bytes: &[u8]) -> Option<Self> {
+        match Self::from_bytes(bytes) {
+            Ok((result, leftover)) => {
+                if leftover.is_empty() {
+                    Some(result)
+                } else {
+                    None
+                }
+            }
+            Err(_) => None
+        }
     }
 }
 


### PR DESCRIPTION
Derive Debug and other traits for Odra Errors.
Unify Serialization and Deserialization for OdraType.
Unify impl of Bytes between Casper and MockVM.
Dirty fix for uint implementation - needs a rewrite.