### PR TITLE
OdraType supports unit variant enums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,6 @@ members = [
 exclude = [ "contract", "contract/builder", "examples", "modules" ]
 
 [workspace.dependencies]
-casper-types = "1.6.0"
-casper-execution-engine = "3.1.0"
+casper-types = "2.0.0"
+casper-execution-engine = "4.0.0"
+casper-event-standard = "0.3.0"

--- a/examples/src/tlw.rs
+++ b/examples/src/tlw.rs
@@ -4,6 +4,12 @@ use odra::{
     Mapping, Variable
 };
 
+#[derive(odra::OdraType)]
+enum A {
+    B,
+    C
+}
+
 #[odra::module]
 pub struct TimeLockWallet {
     balances: Mapping<Address, Balance>,

--- a/examples/src/tlw.rs
+++ b/examples/src/tlw.rs
@@ -4,12 +4,6 @@ use odra::{
     Mapping, Variable
 };
 
-#[derive(odra::OdraType)]
-enum A {
-    B,
-    C
-}
-
 #[odra::module]
 pub struct TimeLockWallet {
     balances: Mapping<Address, Balance>,

--- a/lang/codegen/src/generator/odra_type_item/casper.rs
+++ b/lang/codegen/src/generator/odra_type_item/casper.rs
@@ -5,10 +5,20 @@ use crate::generator::common::casper;
 
 pub fn generate_code(item: &OdraTypeItem) -> TokenStream {
     let struct_ident = item.struct_ident();
-    let fields = item
-        .fields_iter()
-        .map(|f| f.ident.clone().unwrap())
-        .collect::<Vec<_>>();
 
-    casper::serialize_struct("", struct_ident, &fields)
+    if let Some(data) = item.data_struct() {
+        let fields = data
+            .fields
+            .iter()
+            .map(|f| f.ident.clone().unwrap())
+            .collect::<Vec<_>>();
+
+        return casper::serialize_struct("", struct_ident, &fields);
+    }
+
+    if let Some(data) = item.data_enum() {
+        // return casper::serialize_enum("", struct_ident, &fields)
+    }
+
+    TokenStream::new()
 }

--- a/lang/codegen/src/generator/odra_type_item/casper.rs
+++ b/lang/codegen/src/generator/odra_type_item/casper.rs
@@ -17,7 +17,7 @@ pub fn generate_code(item: &OdraTypeItem) -> TokenStream {
     }
 
     if let Some(data) = item.data_enum() {
-        // return casper::serialize_enum("", struct_ident, &fields)
+        return casper::serialize_enum(struct_ident, data);
     }
 
     TokenStream::new()

--- a/lang/codegen/src/generator/odra_type_item/casper.rs
+++ b/lang/codegen/src/generator/odra_type_item/casper.rs
@@ -4,21 +4,10 @@ use proc_macro2::TokenStream;
 use crate::generator::common::casper;
 
 pub fn generate_code(item: &OdraTypeItem) -> TokenStream {
-    let struct_ident = item.struct_ident();
+    let ident = item.ident();
 
-    if let Some(data) = item.data_struct() {
-        let fields = data
-            .fields
-            .iter()
-            .map(|f| f.ident.clone().unwrap())
-            .collect::<Vec<_>>();
-
-        return casper::serialize_struct("", struct_ident, &fields);
+    match item {
+        OdraTypeItem::Struct(s) => casper::serialize_struct("", ident, s.fields()),
+        OdraTypeItem::Enum(e) => casper::serialize_enum(ident, e.variants())
     }
-
-    if let Some(data) = item.data_enum() {
-        return casper::serialize_enum(struct_ident, data);
-    }
-
-    TokenStream::new()
 }

--- a/lang/codegen/src/generator/odra_type_item/clone.rs
+++ b/lang/codegen/src/generator/odra_type_item/clone.rs
@@ -1,0 +1,74 @@
+use odra_ir::OdraTypeItem;
+use proc_macro2::{Ident, TokenStream};
+use quote::{format_ident, quote};
+use syn::{punctuated::Punctuated, token::Comma};
+
+pub fn generate_code(item: &OdraTypeItem, struct_ident: &Ident) -> TokenStream {
+    let clone_struct = item.data_struct().map(|data| {
+        data.fields
+            .iter()
+            .map(|field| {
+                let field_ident = field.ident.as_ref().unwrap();
+                quote!(#field_ident: ::core::clone::Clone::clone(&self.#field_ident))
+            })
+            .collect::<Punctuated<TokenStream, Comma>>()
+    });
+
+    let clone_enum = item
+        .data_enum()
+        .map(|data|
+            data.variants
+            .iter()
+            .map(|variant| {
+                let ident = &variant.ident;
+                let cloned_fields = variant.fields.iter().enumerate().map(|(idx, f)| {
+                    let field_ident = match &f.ident {
+                        Some(ident) => ident.clone(),
+                        None => format_ident!("f{}", idx),
+                    };
+                    quote!(::core::clone::Clone::clone(#field_ident))
+                }).collect::<Vec<_>>();
+
+                let fields = variant.fields.iter().enumerate().map(|(idx, f)| {
+                    let field_ident = match &f.ident {
+                        Some(ident) => ident.clone(),
+                        None => format_ident!("f{}", idx),
+                    };
+                    quote!(#field_ident)
+                }).collect::<Vec<_>>();
+                match &variant.fields {
+                    syn::Fields::Named(_) => quote! {
+                        #struct_ident::#ident { #(#fields),* } => #struct_ident::#ident {
+                            #(#fields: #cloned_fields),*
+                        }
+                    },
+                    syn::Fields::Unnamed(_) => quote! {
+                        #struct_ident::#ident(#(#fields),*) => #struct_ident::#ident( #(#cloned_fields),*)
+                    },
+                    syn::Fields::Unit => quote!(#struct_ident::#ident => #struct_ident::#ident)
+                }
+            })
+            .collect::<Punctuated<TokenStream, Comma>>());
+
+    let mut clone = TokenStream::new();
+    if let Some(code) = clone_enum {
+        clone = quote!(match self {
+            #code
+        });
+    }
+
+    if let Some(code) = clone_struct {
+        clone = quote!(#struct_ident {
+            #code
+        });
+    }
+
+    quote! {
+        impl ::core::clone::Clone for #struct_ident {
+            #[inline]
+            fn clone(&self) -> #struct_ident {
+                #clone
+            }
+        }
+    }
+}

--- a/lang/codegen/src/generator/odra_type_item/clone.rs
+++ b/lang/codegen/src/generator/odra_type_item/clone.rs
@@ -10,7 +10,7 @@ pub fn generate_code(item: &OdraTypeItem) -> TokenStream {
             let code = s
                 .fields()
                 .iter()
-                .map(|field| quote!(#field: ::core::clone::Clone::clone(self.#field)))
+                .map(|field| quote!(#field: ::core::clone::Clone::clone(&self.#field)))
                 .collect::<Punctuated<TokenStream, Comma>>();
             quote!(#ident {
                 #code

--- a/lang/codegen/src/generator/odra_type_item/clone.rs
+++ b/lang/codegen/src/generator/odra_type_item/clone.rs
@@ -10,7 +10,7 @@ pub fn generate_code(item: &OdraTypeItem) -> TokenStream {
             let code = s
                 .fields()
                 .iter()
-                .map(|field| quote!(#field: ::core::clone::Clone::clone(#field)))
+                .map(|field| quote!(#field: ::core::clone::Clone::clone(self.#field)))
                 .collect::<Punctuated<TokenStream, Comma>>();
             quote!(#ident {
                 #code

--- a/lang/codegen/src/generator/odra_type_item/mock_vm.rs
+++ b/lang/codegen/src/generator/odra_type_item/mock_vm.rs
@@ -5,10 +5,20 @@ use crate::generator::common;
 
 pub fn generate_code(item: &OdraTypeItem) -> TokenStream {
     let struct_ident = item.struct_ident();
-    let fields = item
-        .fields_iter()
-        .map(|f| f.ident.clone().unwrap())
-        .collect::<Vec<_>>();
 
-    common::mock_vm::serialize_struct(struct_ident, &fields)
+    if let Some(data) = item.data_struct() {
+        let fields = data
+            .fields
+            .iter()
+            .map(|f| f.ident.clone().unwrap())
+            .collect::<Vec<_>>();
+
+        return common::mock_vm::serialize_struct(struct_ident, &fields);
+    }
+
+    if let Some(data) = item.data_enum() {
+        return common::mock_vm::serialize_enum(struct_ident, data);
+    }
+
+    TokenStream::new()
 }

--- a/lang/codegen/src/generator/odra_type_item/mock_vm.rs
+++ b/lang/codegen/src/generator/odra_type_item/mock_vm.rs
@@ -4,21 +4,10 @@ use proc_macro2::TokenStream;
 use crate::generator::common;
 
 pub fn generate_code(item: &OdraTypeItem) -> TokenStream {
-    let struct_ident = item.struct_ident();
+    let ident = item.ident();
 
-    if let Some(data) = item.data_struct() {
-        let fields = data
-            .fields
-            .iter()
-            .map(|f| f.ident.clone().unwrap())
-            .collect::<Vec<_>>();
-
-        return common::mock_vm::serialize_struct(struct_ident, &fields);
+    match item {
+        OdraTypeItem::Struct(s) => common::mock_vm::serialize_struct(ident, s.fields()),
+        OdraTypeItem::Enum(e) => common::mock_vm::serialize_enum(ident, e.variants())
     }
-
-    if let Some(data) = item.data_enum() {
-        return common::mock_vm::serialize_enum(struct_ident, data);
-    }
-
-    TokenStream::new()
 }

--- a/lang/codegen/src/generator/odra_type_item/mod.rs
+++ b/lang/codegen/src/generator/odra_type_item/mod.rs
@@ -16,11 +16,11 @@ pub struct OdraTypeItem<'a> {
 
 impl GenerateCode for OdraTypeItem<'_> {
     fn generate_code(&self) -> TokenStream {
-        let struct_ident = self.item.struct_ident();
+        let ident = self.item.ident();
 
         let casper_code = casper::generate_code(self.item);
         let mock_vm_code = mock_vm::generate_code(self.item);
-        let clone_code = clone::generate_code(self.item, &struct_ident);
+        let clone_code = clone::generate_code(self.item);
 
         quote! {
             #casper_code
@@ -29,7 +29,7 @@ impl GenerateCode for OdraTypeItem<'_> {
 
             #clone_code
 
-            impl odra::OdraItem for #struct_ident {
+            impl odra::OdraItem for #ident {
                 fn is_module() -> bool {
                     false
                 }

--- a/lang/codegen/src/generator/odra_type_item/mod.rs
+++ b/lang/codegen/src/generator/odra_type_item/mod.rs
@@ -2,11 +2,11 @@ use derive_more::From;
 use odra_ir::OdraTypeItem as IrOdraTypeItem;
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{punctuated::Punctuated, token::Comma};
 
 use crate::GenerateCode;
 
 mod casper;
+mod clone;
 mod mock_vm;
 
 #[derive(From)]
@@ -16,35 +16,18 @@ pub struct OdraTypeItem<'a> {
 
 impl GenerateCode for OdraTypeItem<'_> {
     fn generate_code(&self) -> TokenStream {
-        let casper_code = casper::generate_code(self.item);
-        let mock_vm_code = mock_vm::generate_code(self.item);
-
         let struct_ident = self.item.struct_ident();
 
-        let clone_fields = self
-            .item
-            .fields_iter()
-            .map(|field| {
-                let field_ident = field.ident.as_ref().unwrap();
-                quote! {
-                    #field_ident: ::core::clone::Clone::clone(&self.#field_ident)
-                }
-            })
-            .collect::<Punctuated<TokenStream, Comma>>();
+        let casper_code = casper::generate_code(self.item);
+        let mock_vm_code = mock_vm::generate_code(self.item);
+        let clone_code = clone::generate_code(self.item, &struct_ident);
 
         quote! {
             #casper_code
 
             #mock_vm_code
 
-            impl ::core::clone::Clone for #struct_ident {
-                #[inline]
-                fn clone(&self) -> #struct_ident {
-                    #struct_ident {
-                        #clone_fields
-                    }
-                }
-            }
+            #clone_code
 
             impl odra::OdraItem for #struct_ident {
                 fn is_module() -> bool {

--- a/lang/ir/src/odra_type_item.rs
+++ b/lang/ir/src/odra_type_item.rs
@@ -1,30 +1,48 @@
 use proc_macro2::Ident;
-use syn::{DeriveInput, Field, FieldsNamed};
-
-use crate::utils;
+use syn::{DataEnum, DataStruct, DeriveInput};
 
 /// Odra Type definition.
 pub struct OdraTypeItem {
     struct_ident: Ident,
-    named_fields: FieldsNamed
+    data_struct: Option<DataStruct>,
+    data_enum: Option<DataEnum>
 }
 
 impl OdraTypeItem {
     pub fn parse(input: DeriveInput) -> Result<Self, syn::Error> {
         let struct_ident = input.ident.clone();
-        let named_fields = utils::extract_fields(input)?;
+        let data_struct = match &input.data {
+            syn::Data::Struct(data_struct) => Some(data_struct.clone()),
+            _ => None
+        };
+        let data_enum = match &input.data {
+            syn::Data::Enum(data_enum) => Some(data_enum.clone()),
+            _ => None
+        };
+
+        if data_enum.is_none() && data_struct.is_none() {
+            return Err(syn::Error::new_spanned(
+                input,
+                "Expected a struct or enum with named fields."
+            ));
+        }
 
         Ok(Self {
             struct_ident,
-            named_fields
+            data_struct,
+            data_enum
         })
-    }
-
-    pub fn fields_iter(&self) -> impl Iterator<Item = &Field> {
-        self.named_fields.named.iter()
     }
 
     pub fn struct_ident(&self) -> &Ident {
         &self.struct_ident
+    }
+
+    pub fn data_struct(&self) -> Option<&DataStruct> {
+        self.data_struct.as_ref()
+    }
+
+    pub fn data_enum(&self) -> Option<&DataEnum> {
+        self.data_enum.as_ref()
     }
 }

--- a/lang/ir/src/odra_type_item.rs
+++ b/lang/ir/src/odra_type_item.rs
@@ -64,7 +64,7 @@ impl OdraTypeItem {
                 } else {
                     Err(syn::Error::new_spanned(
                         input,
-                        "Expected a struct or enum with named fields."
+                        "Expected a unit enum variant."
                     ))
                 }
             }

--- a/odra-casper/backend/Cargo.toml
+++ b/odra-casper/backend/Cargo.toml
@@ -13,9 +13,9 @@ categories = ["wasm", "smart contracts"]
 odra-casper-shared = { version = "0.2.0", path = "../shared" }
 odra-casper-types = { version = "0.2.0", path = "../types" }
 odra-types = { version = "0.2.0", path = "../../types" }
-casper-contract = { version = "1.4.4", default-features = false, features = ["std", "test-support"] }
+casper-contract = { version = "2.0.0", default-features = false, features = ["std", "test-support"] }
 casper-types = { workspace = true }
 syn = "1.0.96"
 hex = "0.4.3"
 lazy_static = "1.4.0"
-casper-event-standard = "0.2.0"
+casper-event-standard = { workspace = true }

--- a/odra-casper/codegen/Cargo.toml
+++ b/odra-casper/codegen/Cargo.toml
@@ -18,6 +18,6 @@ odra-casper-types = { version = "0.2.0", path = "../types" }
 odra-types = { version = "0.2.0", path = "../../types" }
 odra-utils = { version = "0.2.0", path = "../../utils" }
 casper-types = { workspace = true }
-casper-event-standard = "0.2.0"
+casper-event-standard = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/odra-casper/livenet/Cargo.toml
+++ b/odra-casper/livenet/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["wasm", "smart contracts"]
 
 [dependencies]
 casper-types = { workspace = true }
-casper-node = "1.4.14"
+casper-node = "=1.4.15-alt"
 casper-execution-engine = { workspace = true }
 casper-hashing = "1.4.3"
 odra-casper-shared = { version = "0.2.0", path = "../shared" }

--- a/odra-casper/shared/Cargo.toml
+++ b/odra-casper/shared/Cargo.toml
@@ -10,6 +10,6 @@ keywords = ["wasm", "webassembly", "blockchain"]
 categories = ["wasm", "smart contracts"]
 
 [dependencies]
-casper-event-standard = "0.2.0"
+casper-event-standard = { workspace = true }
 odra-casper-types = { version = "0.2.0", path = "../types" }
 hex = "0.4.3"

--- a/odra-casper/test-env/Cargo.toml
+++ b/odra-casper/test-env/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["wasm", "webassembly", "blockchain"]
 categories = ["wasm", "smart contracts"]
 
 [dependencies]
-casper-engine-test-support = { version = "3.1.0", features = ["test-support"] }
+casper-engine-test-support = { version = "4.0.0", features = ["test-support"] }
 casper-execution-engine = { workspace = true }
 casper-types = { workspace = true }
 odra-casper-shared = { version = "0.2.0", path = "../shared" }

--- a/odra-casper/test-env/getter_proxy/Cargo.toml
+++ b/odra-casper/test-env/getter_proxy/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.0.1"
 edition = "2021"
 
 [dependencies]
-casper-contract = { version = "1.4.3" }
-casper-types = "1.4.6"
+casper-contract = { version = "2.0.0" }
+casper-types = { workspace = true }
 
 [[bin]]
 name = "getter_proxy"

--- a/odra-casper/types/Cargo.toml
+++ b/odra-casper/types/Cargo.toml
@@ -12,5 +12,5 @@ categories = ["wasm", "smart contracts"]
 [dependencies]
 casper-types = { workspace = true }
 odra-types = { version = "0.2.0", path = "../../types" }
-casper-event-standard = "0.2.0"
+casper-event-standard = { workspace = true }
 num-traits = "0.2.14"


### PR DESCRIPTION
* OdraType supports unit variant enums (a variant like A(String) raises an error)
* The actual discriminant is serialized, so
```rust
enum A {
  B,
  C = 11,
  D
}
```
B is serialized as 0, C as 11, D as 12
* Update casper dependencies