### PR TITLE
Add new templates

### DIFF
--- a/odra-casper/codegen/src/lib.rs
+++ b/odra-casper/codegen/src/lib.rs
@@ -292,7 +292,7 @@ mod tests {
 #[macro_export]
 macro_rules! gen_contract {
     ($contract:path, $name:literal) => {
-        fn main() {
+        pub fn main() {
             let ident = <$contract as odra::types::contract_def::HasIdent>::ident();
             let entrypoints =
                 <$contract as odra::types::contract_def::HasEntrypoints>::entrypoints();

--- a/templates/contracts_builder/gen_contract_mod.rs.template
+++ b/templates/contracts_builder/gen_contract_mod.rs.template
@@ -1,0 +1,3 @@
+mod #contract_name { 
+    odra::#backend_name::codegen::gen_contract!(#fqn, "#contract_name");
+}

--- a/templates/contracts_builder/match_contract_name.rs.template
+++ b/templates/contracts_builder/match_contract_name.rs.template
@@ -1,0 +1,1 @@
+Some("#contract_name") => #contract_name::main(), 

--- a/templates/contracts_builder/wasm_source_builder.rs.template
+++ b/templates/contracts_builder/wasm_source_builder.rs.template
@@ -1,0 +1,9 @@
+#code_gen_modules
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    match args.get(1).map(String::as_str) {
+        #contract_matcher
+        _ => println!("Please provide a valid module name!"),
+    }
+}


### PR DESCRIPTION
Add templates that allow to generate a single casper build file. Replacement for building separate *_build.rs file for each contract.