### PR TITLE
Casper Livenet updates to match 1.5.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ examples/target
 examples/.builder_casper
 examples/wasm
 examples/.env
+examples/.env.testnet
+examples/.env.integration
 modules/target
 modules/.builder_casper
 modules/wasm

--- a/examples/bin/erc20_on_livenet.rs
+++ b/examples/bin/erc20_on_livenet.rs
@@ -13,17 +13,17 @@ fn main() {
     let recipient = "hash-2c4a6ce0da5d175e9638ec0830e01dd6cf5f4b1fbb0724f7d2d9de12b1e0f840";
     let recipient = Address::from_str(recipient).unwrap();
 
-    client_env::set_gas(150_000_000_000u64);
+    client_env::set_gas(110_000_000_000u64);
     let mut token = Erc20Deployer::init(name, symbol, decimals, &initial_supply);
 
     // Uncomment to use already deployed contract.
-    // let address = "hash-3a20a5cd38e8826346faa673576657b03bbd4d86685e404baf9f1fa406a4f7a7";
+    // let address = "hash-a12760e3ece51e0f31aa6d5af39660f5ec61185ad61c7551c796cca4592b9498";
     // let address = Address::from_str(address).unwrap();
     // let mut token = Erc20Deployer::register(address);
 
     println!("Token name: {}", token.name());
 
-    client_env::set_gas(5_000_000_000u64);
+    client_env::set_gas(3_000_000_000u64);
     token.transfer(&recipient, &U256::from(1000));
 
     println!("Owner's balance: {:?}", token.balance_of(&owner));

--- a/lang/codegen/src/generator/module_impl/deploy/deployer_casper_livenet.rs
+++ b/lang/codegen/src/generator/module_impl/deploy/deployer_casper_livenet.rs
@@ -90,7 +90,7 @@ fn build_default_constructor(
             let mut entrypoints = HashMap::<String, (Vec<String>, fn(String, &CallArgs) -> Vec<u8>)>::new();
             #entrypoint_calls
 
-            let address = odra::client_env::deploy_new_contract(&#struct_name_snake_case, odra::types::CallArgs::new(), entrypoints);
+            let address = odra::client_env::deploy_new_contract(&#struct_name_snake_case, odra::types::CallArgs::new(), entrypoints, None);
             #ref_ident::at(&address)
         }
     }
@@ -119,9 +119,10 @@ fn build_constructor(
             let mut entrypoints = HashMap::<String, (Vec<String>, fn(String, &CallArgs) -> Vec<u8>)>::new();
             #entrypoint_calls
 
-            let mut args = { #args };
-            args.insert("constructor", stringify!(#constructor_ident));
-            let address = odra::client_env::deploy_new_contract(#struct_name_snake_case, args, entrypoints);
+            let args = { #args };
+
+            let constructor = String::from(stringify!(#constructor_ident));
+            let address = odra::client_env::deploy_new_contract(#struct_name_snake_case, args, entrypoints, Some(constructor));
             #ref_ident::at(&address)
         }
     }

--- a/lang/codegen/src/generator/module_impl/deploy/deployer_casper_test.rs
+++ b/lang/codegen/src/generator/module_impl/deploy/deployer_casper_test.rs
@@ -42,7 +42,7 @@ fn build_default_constructor(struct_ident: &Ident, ref_ident: &Ident) -> TokenSt
 
     quote! {
         pub fn default() -> #ref_ident {
-            let address = odra::test_env::register_contract(&#struct_name_snake_case, &odra::types::CallArgs::new());
+            let address = odra::test_env::register_contract(&#struct_name_snake_case, &odra::types::CallArgs::new(), None);
             #ref_ident::at(&address)
         }
     }
@@ -62,9 +62,9 @@ fn build_constructor(
 
     quote! {
         pub #fn_sig {
-            let mut args = { #args };
-            args.insert("constructor", stringify!(#constructor_ident));
-            let address = odra::test_env::register_contract(#struct_name_snake_case, &args);
+            let args = { #args };
+            let constructor = String::from(stringify!(#constructor_ident));
+            let address = odra::test_env::register_contract(#struct_name_snake_case, &args, Some(constructor));
             #ref_ident::at(&address)
         }
     }

--- a/odra-casper/codegen/src/call_method.rs
+++ b/odra-casper/codegen/src/call_method.rs
@@ -81,7 +81,7 @@ impl ToTokens for CallMethod {
 
                 #entry_points
 
-                #[allow(dead_code)]
+                #[allow(unused_variables)]
                 let contract_package_hash = odra::casper::utils::install_contract(entry_points, schemas);
 
                 #constructor_call

--- a/odra-casper/codegen/src/lib.rs
+++ b/odra-casper/codegen/src/lib.rs
@@ -203,7 +203,7 @@ mod tests {
                         odra::casper::casper_types::EntryPointAccess::Public,
                         odra::casper::casper_types::EntryPointType::Contract,
                     ));
-                    #[allow(dead_code)]
+                    #[allow(unused_variables)]
                     let contract_package_hash = odra::casper::utils::install_contract(entry_points, schemas);
                     use odra::casper::casper_contract::unwrap_or_revert::UnwrapOrRevert;
                     let constructor_access = odra::casper::utils::create_constructor_group(contract_package_hash);

--- a/odra-casper/livenet/src/casper_client.rs
+++ b/odra-casper/livenet/src/casper_client.rs
@@ -284,7 +284,7 @@ impl CasperClient {
     }
 
     fn wait_for_deploy_hash(&self, deploy_hash: DeployHash) {
-        let deploy_hash_str = deploy_hash.inner().to_string();
+        let deploy_hash_str = format!("{:?}", deploy_hash.inner());
         let time_diff = Duration::from_secs(15);
         let final_result;
 

--- a/odra-casper/livenet/src/casper_node_port/account.rs
+++ b/odra-casper/livenet/src/casper_node_port/account.rs
@@ -1,0 +1,32 @@
+use casper_types::{account::AccountHash, NamedKey, URef};
+use datasize::DataSize;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Structure representing a user's account, stored in global state.
+#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize, DataSize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct Account {
+    account_hash: AccountHash,
+    #[data_size(skip)]
+    named_keys: Vec<NamedKey>,
+    #[data_size(skip)]
+    main_purse: URef,
+    associated_keys: Vec<AssociatedKey>,
+    action_thresholds: ActionThresholds
+}
+
+#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize, DataSize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct AssociatedKey {
+    account_hash: AccountHash,
+    weight: u8
+}
+
+/// Thresholds that have to be met when executing an action of a certain type.
+#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize, DataSize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct ActionThresholds {
+    deployment: u8,
+    key_management: u8
+}

--- a/odra-casper/livenet/src/casper_node_port/contract_package.rs
+++ b/odra-casper/livenet/src/casper_node_port/contract_package.rs
@@ -1,0 +1,53 @@
+use casper_types::{ContractHash, URef};
+use datasize::DataSize;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Contract definition, metadata, and security container.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, DataSize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ContractPackage {
+    #[data_size(skip)]
+    access_key: URef,
+    versions: Vec<ContractVersion>,
+    disabled_versions: Vec<DisabledVersion>,
+    groups: Vec<Groups>,
+    lock_status: ContractPackageStatus
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, DataSize, JsonSchema,
+)]
+pub struct ContractVersion {
+    protocol_version_major: u32,
+    contract_version: u32,
+    contract_hash: ContractHash
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, DataSize, JsonSchema)]
+pub struct DisabledVersion {
+    protocol_version_major: u32,
+    contract_version: u32
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, DataSize, JsonSchema)]
+pub struct Groups {
+    group: String,
+    #[data_size(skip)]
+    keys: Vec<URef>
+}
+
+/// A enum to determine the lock status of the contract package.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, DataSize, JsonSchema)]
+pub enum ContractPackageStatus {
+    /// The package is locked and cannot be versioned.
+    Locked,
+    /// The package is unlocked and can be versioned.
+    Unlocked
+}
+
+impl Default for ContractPackageStatus {
+    fn default() -> Self {
+        Self::Unlocked
+    }
+}

--- a/odra-casper/livenet/src/casper_node_port/mod.rs
+++ b/odra-casper/livenet/src/casper_node_port/mod.rs
@@ -1,7 +1,9 @@
 //! Functionalities ported from casper-node. All the code in this module is copied from casper-node.
 
+pub mod account;
 pub mod approval;
 pub mod block_hash;
+pub mod contract_package;
 pub mod deploy;
 pub mod deploy_hash;
 pub mod deploy_header;

--- a/odra-casper/livenet/src/casper_node_port/rpcs.rs
+++ b/odra-casper/livenet/src/casper_node_port/rpcs.rs
@@ -4,7 +4,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::{
+    account::Account,
     block_hash::{BlockHash, BlockHashAndHeight},
+    contract_package::ContractPackage,
     Deploy, DeployHash
 };
 
@@ -230,5 +232,11 @@ struct ValidatorWeight {
 #[serde(deny_unknown_fields)]
 pub enum StoredValue {
     /// A CasperLabs value.
-    CLValue(CLValue)
+    CLValue(CLValue),
+
+    /// An account.
+    Account(Account),
+
+    /// A contract definition, metadata, and security container.
+    ContractPackage(ContractPackage)
 }

--- a/odra-casper/shared/src/consts.rs
+++ b/odra-casper/shared/src/consts.rs
@@ -46,11 +46,11 @@ pub const ALLOW_KEY_OVERRIDE_ARG: &str = "odra_cfg_allow_key_override";
 /// The arg name for the contract upgradeability setting.
 pub const IS_UPGRADABLE_ARG: &str = "odra_cfg_is_upgradable";
 
+/// Constructor name argument.
+pub const CONSTRUCTOR_NAME_ARG: &str = "odra_cfg_constructor";
+
 /// The state key name.
 pub const STATE_KEY: &str = "state";
 
 /// Constructor group name.
 pub const CONSTRUCTOR_GROUP_NAME: &str = "constructor_group";
-
-/// Constructor name argument.
-pub const CONSTRUCTOR_NAME_ARG: &str = "constructor";

--- a/odra-casper/test-env/src/test_env.rs
+++ b/odra-casper/test-env/src/test_env.rs
@@ -18,7 +18,7 @@ pub fn backend_name() -> String {
 }
 
 /// Deploy WASM file with arguments.
-pub fn register_contract(name: &str, args: &CallArgs) -> Address {
+pub fn register_contract(name: &str, args: &CallArgs, constructor_name: Option<String>) -> Address {
     ENV.with(|env| {
         let wasm_name = format!("{}.wasm", name);
         let package_hash_key_name = format!("{}_package_hash", name);
@@ -29,6 +29,10 @@ pub fn register_contract(name: &str, args: &CallArgs) -> Address {
         );
         args.insert(consts::ALLOW_KEY_OVERRIDE_ARG, true);
         args.insert(consts::IS_UPGRADABLE_ARG, false);
+
+        if let Some(constructor_name) = constructor_name {
+            args.insert(consts::CONSTRUCTOR_NAME_ARG, constructor_name);
+        };
 
         env.borrow_mut().deploy_contract(&wasm_name, &args);
         let contract_package_hash = env


### PR DESCRIPTION
In addition I have changed the `constructor` arg to `odra_cfg_constructor` to match other constructor args.