### PR TITLE
Fix execution_error documentation

### DIFF
--- a/examples/src/contracts/tlw.rs
+++ b/examples/src/contracts/tlw.rs
@@ -78,9 +78,13 @@ impl TimeLockWallet {
 }
 
 execution_error! {
+    /// Errors that may occur during the contract execution.
     pub enum Error {
+        /// Cannot withdraw funds, the lock period is not over.
         LockIsNotOver => 1,
+        /// A user deposit funds the second and the next time.
         CannotLockTwice => 2,
+        /// A user deposits more funds he/she owns.
         InsufficientBalance => 3
     }
 }

--- a/lang/ir/src/execution_error/variant.rs
+++ b/lang/ir/src/execution_error/variant.rs
@@ -1,9 +1,10 @@
 use proc_macro2::TokenStream;
-use quote::ToTokens;
+use quote::{ToTokens, TokenStreamExt};
 use syn::{parse::Parse, spanned::Spanned};
 
 /// Custom enum variant similar to [syn::Variant].
 pub struct Variant {
+    pub attrs: Vec<syn::Attribute>,
     pub ident: syn::Ident,
     pub fat_arrow_token: syn::Token![=>],
     pub expr: syn::Expr
@@ -11,7 +12,7 @@ pub struct Variant {
 
 impl Parse for Variant {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        let _attrs = input.call(syn::Attribute::parse_outer)?;
+        let attrs = input.call(syn::Attribute::parse_outer)?;
         let _visibility: syn::Visibility = input.parse()?;
         let ident: syn::Ident = input.parse()?;
         let fat_arrow_token: syn::Token![=>] = input.parse()?;
@@ -28,6 +29,7 @@ impl Parse for Variant {
         };
 
         Ok(Variant {
+            attrs,
             ident,
             fat_arrow_token,
             expr
@@ -37,6 +39,7 @@ impl Parse for Variant {
 
 impl ToTokens for Variant {
     fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.append_all(&self.attrs);
         self.ident.to_tokens(tokens);
     }
 }


### PR DESCRIPTION
```rust
execution_error! {
    /// Errors that may occur during the contract execution.
    pub enum Error {
        /// Cannot withdraw funds, the lock period is not over.
        LockIsNotOver => 1,
        /// A user deposit funds the second and the next time.
        CannotLockTwice => 2,
        /// A user deposits more funds he/she owns.
        InsufficientBalance => 3
    }
}
```
generates

``` rust
#[odra::odra_error]
#[derive(Debug, PartialEq, Eq, Clone, Copy)]
#[doc = " Errors that may occur during the contract execution."]
pub enum Error {
    #[doc = " Cannot withdraw funds, the lock period is not over."]
    LockIsNotOver,
    #[doc = " A user deposit funds the second and the next time."]
    CannotLockTwice,
    #[doc = " A user deposits more funds he/she owns."]
    InsufficientBalance
}
impl From<Error> for odra::types::ExecutionError {
    fn from(value: Error) -> Self {
        match value {
            Error::LockIsNotOver => odra::types::ExecutionError::new(1, "Lock Is Not Over"),
            Error::CannotLockTwice => odra::types::ExecutionError::new(2, "Cannot Lock Twice"),
            Error::InsufficientBalance => {
                odra::types::ExecutionError::new(3, "Insufficient Balance")
            }
        }
    }
}
```