### PR TITLE
Bumped version to 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [ "examples", "examples2", "modules", "odra-casper/proxy-caller" ]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Jakub Płaskonka <kuba@odra.dev>", "Krzysztof Pobiarżyn <krzysztof@odra.dev>", "Maciej Zieliński <maciej@odra.dev>"]
 license = "MIT"
 homepage = "https://odra.dev/docs"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,21 +1,15 @@
 [package]
 name = "odra-examples"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 
 [dependencies]
-odra = { path = "../core", default-features = false }
+odra = { path = "../odra", default-features = false }
 odra-modules = { path = "../modules", default-features = false }
 sha3 = { version = "0.10.6", default-features = false }
 
 [dev-dependencies]
 hex = "0.4.3"
-
-[features]
-default = ["mock-vm"]
-mock-vm = ["odra/mock-vm", "odra-modules/mock-vm"]
-casper = ["odra/casper", "odra-modules/casper"]
-casper-livenet = ["odra/casper-livenet", "odra-modules/casper-livenet"]
 
 [[bin]]
 name = "erc20-on-livenet"

--- a/mock-vm/backend/Cargo.toml
+++ b/mock-vm/backend/Cargo.toml
@@ -11,8 +11,8 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-odra-types = { path = "../../types", version = "0.7.0", features = [ "test-support" ] }
-odra-utils = { path = "../../utils", version = "0.7.0" }
+odra-types = { path = "../../types", version = "0.8.0", features = [ "test-support" ] }
+odra-utils = { path = "../../utils", version = "0.8.0" }
 ref_thread_local = "0.1.1"
 anyhow = "1.0.65"
 hex = "0.4.3"

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odra-modules"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 authors = ["Jakub Płaskonka <kuba@odra.dev>", "Krzysztof Pobiarżyn <krzysztof@odra.dev>", "Maciej Zieliński <maciej@odra.dev>"]
 license = "MIT"
@@ -10,12 +10,5 @@ keywords = ["wasm", "webassembly", "blockchain"]
 categories = ["wasm"]
 
 [dependencies]
-odra = { path = "../core", version = "0.7.0", default-features = false }
+odra = { path = "../odra", version = "0.8.0", default-features = false }
 hex = { version = "0.4.3", default-features = false }
-
-[features]
-default = [ "mock-vm" ]
-mock-vm = [ "odra/mock-vm" ]
-casper = [ "odra/casper" ]
-casper-livenet = ["odra/casper-livenet"]
-std = []

--- a/odra-casper/backend/Cargo.toml
+++ b/odra-casper/backend/Cargo.toml
@@ -11,8 +11,8 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-odra-casper-shared = { path = "../shared", version = "0.7.0" }
-odra-types = { path = "../../types", version = "0.7.0" }
+odra-casper-shared = { path = "../shared", version = "0.8.0" }
+odra-types = { path = "../../types", version = "0.8.0" }
 lazy_static = { version = "1.4.0", features = [ "spin_no_std" ] }
 casper-event-standard = { workspace = true }
 

--- a/odra-casper/livenet/Cargo.toml
+++ b/odra-casper/livenet/Cargo.toml
@@ -13,9 +13,9 @@ repository = { workspace = true }
 [dependencies]
 casper-execution-engine = { workspace = true }
 casper-hashing = "2.0.0"
-odra-casper-shared = { path = "../shared", version = "0.7.0" }
-odra-types = { path = "../../types", version = "0.7.0" }
-odra-mock-vm = { path = "../../mock-vm/backend", version = "0.7.0" }
+odra-casper-shared = { path = "../shared", version = "0.8.0" }
+odra-types = { path = "../../types", version = "0.8.0" }
+odra-mock-vm = { path = "../../mock-vm/backend", version = "0.8.0" }
 ref_thread_local = "0.1.1"
 serde = "1.0"
 serde_json = { version = "1.0", features = ["raw_value"] }

--- a/odra-casper/shared/Cargo.toml
+++ b/odra-casper/shared/Cargo.toml
@@ -12,8 +12,8 @@ repository = { workspace = true }
 
 [dependencies]
 casper-event-standard = { workspace = true }
-odra-types = { path = "../../types", version = "0.7.0" }
-odra-utils = { path = "../../utils", version = "0.7.0" }
+odra-types = { path = "../../types", version = "0.8.0" }
+odra-utils = { path = "../../utils", version = "0.8.0" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 casper-contract = { workspace = true }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -14,7 +14,7 @@ repository = { workspace = true }
 casper-types = { workspace = true }
 
 [dev-dependencies]
-odra-utils = { path = "../utils", version = "0.7.0" }
+odra-utils = { path = "../utils", version = "0.8.0" }
 
 [features]
 default = []


### PR DESCRIPTION
Also fixed Cargo.toml of examples and modules - they don't work, but don't throw errors either