### PR TITLE
Fight for Prelude 

### DIFF
--- a/core/src/address.rs
+++ b/core/src/address.rs
@@ -2,12 +2,12 @@
 
 use core::str::FromStr;
 
-use crate::AddressError::ZeroAddress;
-use crate::{AddressError, OdraError, VmError};
-use alloc::{
+use crate::prelude::{
     string::{String, ToString},
     vec::Vec
 };
+use crate::AddressError::ZeroAddress;
+use crate::{AddressError, OdraError, VmError};
 use casper_types::{
     account::AccountHash,
     bytesrepr::{self, FromBytes, ToBytes},
@@ -44,7 +44,7 @@ impl Address {
 
     // TODO: move those methods to odra_vm as they shouldn't be public
     pub fn account_from_str(str: &str) -> Self {
-        use alloc::format;
+        use crate::prelude::format;
         use casper_types::account::{ACCOUNT_HASH_FORMATTED_STRING_PREFIX, ACCOUNT_HASH_LENGTH};
         let desired_length = ACCOUNT_HASH_LENGTH * 2;
         let padding_length = desired_length - str.len();
@@ -56,7 +56,7 @@ impl Address {
 
     // TODO: move those methods to odra_vm as they shouldn't be public
     pub fn contract_from_u32(i: u32) -> Self {
-        use alloc::format;
+        use crate::prelude::format;
         use casper_types::KEY_HASH_LENGTH;
         let desired_length = KEY_HASH_LENGTH * 2;
         let padding_length = desired_length - i.to_string().len();

--- a/core/src/address.rs
+++ b/core/src/address.rs
@@ -1,11 +1,5 @@
 //! Better address representation for Casper.
-
-use core::str::FromStr;
-
-use crate::prelude::{
-    string::{String, ToString},
-    vec::Vec
-};
+use crate::prelude::*;
 use crate::AddressError::ZeroAddress;
 use crate::{AddressError, OdraError, VmError};
 use casper_types::{
@@ -44,7 +38,6 @@ impl Address {
 
     // TODO: move those methods to odra_vm as they shouldn't be public
     pub fn account_from_str(str: &str) -> Self {
-        use crate::prelude::format;
         use casper_types::account::{ACCOUNT_HASH_FORMATTED_STRING_PREFIX, ACCOUNT_HASH_LENGTH};
         let desired_length = ACCOUNT_HASH_LENGTH * 2;
         let padding_length = desired_length - str.len();
@@ -56,7 +49,6 @@ impl Address {
 
     // TODO: move those methods to odra_vm as they shouldn't be public
     pub fn contract_from_u32(i: u32) -> Self {
-        use crate::prelude::format;
         use casper_types::KEY_HASH_LENGTH;
         let desired_length = KEY_HASH_LENGTH * 2;
         let padding_length = desired_length - i.to_string().len();

--- a/core/src/call_def.rs
+++ b/core/src/call_def.rs
@@ -1,4 +1,4 @@
-use crate::prelude::string::String;
+use crate::prelude::*;
 use casper_types::bytesrepr::FromBytes;
 use casper_types::{CLTyped, RuntimeArgs, U512};
 

--- a/core/src/call_def.rs
+++ b/core/src/call_def.rs
@@ -1,4 +1,4 @@
-use alloc::string::String;
+use crate::prelude::string::String;
 use casper_types::bytesrepr::FromBytes;
 use casper_types::{CLTyped, RuntimeArgs, U512};
 

--- a/core/src/call_result.rs
+++ b/core/src/call_result.rs
@@ -1,7 +1,4 @@
-use crate::prelude::collections::BTreeMap;
-use crate::prelude::string::{String, ToString};
-use crate::prelude::vec;
-use crate::prelude::vec::Vec;
+use crate::prelude::*;
 use crate::utils::extract_event_name;
 use crate::{Address, Bytes, OdraError, ToBytes};
 use casper_event_standard::EventInstance;

--- a/core/src/contract_def.rs
+++ b/core/src/contract_def.rs
@@ -1,6 +1,6 @@
 //! Encapsulates a set of structures that abstract out a smart contract layout.
 
-use crate::prelude::{string::String, vec::Vec};
+use crate::prelude::*;
 use casper_types::CLType;
 
 /// Contract's entrypoint.

--- a/core/src/contract_def.rs
+++ b/core/src/contract_def.rs
@@ -1,6 +1,6 @@
 //! Encapsulates a set of structures that abstract out a smart contract layout.
 
-use alloc::{string::String, vec::Vec};
+use crate::prelude::{string::String, vec::Vec};
 use casper_types::CLType;
 
 /// Contract's entrypoint.
@@ -99,7 +99,7 @@ pub struct ContractBlueprint2 {
 #[allow(dead_code)]
 mod test {
     use super::Node;
-    use alloc::{string::String, vec, vec::Vec};
+    use crate::prelude::{string::String, vec, vec::Vec};
     use core::marker::PhantomData;
 
     #[test]

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,6 +1,6 @@
 use core::any::Any;
 
-use alloc::{boxed::Box, string::String};
+use crate::prelude::{boxed::Box, string::String};
 
 use crate::arithmetic::ArithmeticsError;
 

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,8 +1,6 @@
-use core::any::Any;
-
-use crate::prelude::{boxed::Box, string::String};
-
 use crate::arithmetic::ArithmeticsError;
+use crate::prelude::*;
+use core::any::Any;
 
 /// General error type in Odra framework
 #[repr(u16)]

--- a/core/src/event.rs
+++ b/core/src/event.rs
@@ -1,6 +1,6 @@
 //! Events interface and errors.
 
-use crate::prelude::string::String;
+use crate::prelude::*;
 
 /// Event-related errors.
 #[derive(Debug, PartialEq, Eq, PartialOrd)]

--- a/core/src/host_env.rs
+++ b/core/src/host_env.rs
@@ -2,7 +2,6 @@ use crate::call_result::CallResult;
 use crate::entry_point_callback::EntryPointsCaller;
 use crate::event::EventError;
 use crate::host_context::HostContext;
-use crate::prelude::collections::BTreeMap;
 use crate::prelude::*;
 use crate::utils::extract_event_name;
 use crate::{Address, OdraError, VmError, U512};

--- a/core/src/item.rs
+++ b/core/src/item.rs
@@ -1,4 +1,4 @@
-use crate::prelude::{collections::BTreeMap, string::String, vec::Vec};
+use crate::prelude::*;
 use casper_types::{
     bytesrepr::{FromBytes, ToBytes},
     U128, U256, U512
@@ -11,7 +11,7 @@ pub trait OdraItem {
 
     #[cfg(not(target_arch = "wasm32"))]
     fn events() -> Vec<crate::contract_def::Event> {
-        crate::prelude::vec![]
+        vec![]
     }
 }
 

--- a/core/src/item.rs
+++ b/core/src/item.rs
@@ -1,4 +1,4 @@
-use alloc::{collections::BTreeMap, string::String, vec::Vec};
+use crate::prelude::{collections::BTreeMap, string::String, vec::Vec};
 use casper_types::{
     bytesrepr::{FromBytes, ToBytes},
     U128, U256, U512
@@ -11,7 +11,7 @@ pub trait OdraItem {
 
     #[cfg(not(target_arch = "wasm32"))]
     fn events() -> Vec<crate::contract_def::Event> {
-        alloc::vec![]
+        crate::prelude::vec![]
     }
 }
 

--- a/core/src/mapping.rs
+++ b/core/src/mapping.rs
@@ -1,6 +1,6 @@
+use crate::prelude::*;
 use crate::{
     module::{Module, ModuleWrapper},
-    prelude::*,
     variable::Variable,
     ContractEnv
 };

--- a/core/src/module.rs
+++ b/core/src/module.rs
@@ -1,10 +1,10 @@
+use crate::prelude::*;
 use core::cell::OnceCell;
-use core::ops::{Deref, DerefMut};
 
 use crate::call_def::CallDef;
 use crate::contract_env::ContractEnv;
 use crate::odra_result::OdraResult;
-use crate::prelude::*;
+use core::ops::{Deref, DerefMut};
 
 pub trait Callable {
     fn call(&self, env: ContractEnv, call_def: CallDef) -> OdraResult<Vec<u8>>;

--- a/core/src/native_token.rs
+++ b/core/src/native_token.rs
@@ -1,4 +1,4 @@
-use alloc::string::String;
+use crate::prelude::string::String;
 
 pub struct NativeTokenMetadata {
     pub name: String,

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -1,24 +1,3 @@
-#[cfg(feature = "std")]
-pub use std::{borrow, boxed, format, string, vec};
-
-#[cfg(feature = "std")]
-pub use std::string::ToString;
-
-#[cfg(feature = "std")]
-pub mod collections {
-    pub use self::{
-        binary_heap::BinaryHeap, btree_map::BTreeMap, btree_set::BTreeSet, linked_list::LinkedList,
-        vec_deque::VecDeque, Bound
-    };
-    pub use std::collections::*;
-}
-
-#[cfg(feature = "std")]
-pub use std::cell::RefCell;
-#[cfg(feature = "std")]
-pub use std::rc::Rc;
-
-#[cfg(not(feature = "std"))]
 #[allow(clippy::module_inception)]
 mod prelude {
     pub use alloc::rc::Rc;
@@ -35,5 +14,4 @@ mod prelude {
     pub use vec::Vec;
 }
 
-#[cfg(not(feature = "std"))]
 pub use prelude::*;

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -1,17 +1,15 @@
 #[allow(clippy::module_inception)]
 mod prelude {
+    pub use alloc::borrow::ToOwned;
+    pub use alloc::boxed::Box;
+    pub use alloc::collections::*;
+    pub use alloc::format;
     pub use alloc::rc::Rc;
+    pub use alloc::{string, string::*};
+    pub use alloc::{vec, vec::*};
     pub use core::cell::RefCell;
-    pub mod collections {
-        pub use self::{BTreeMap, BTreeSet, BinaryHeap, LinkedList, VecDeque};
-        pub use alloc::collections::*;
-        pub use core::ops::Bound;
-    }
-    pub use crate::module::Module;
-    pub use alloc::string::String;
-    pub use alloc::vec;
-    pub use alloc::{borrow, boxed, format, string, string::ToString};
-    pub use vec::Vec;
+    pub use core::ops::Bound;
+    pub use core::str::FromStr;
 }
 
 pub use prelude::*;

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -81,7 +81,7 @@ pub fn hex_to_slice(src: &[u8], dst: &mut [u8]) {
 /// Joins two parts of a key with the [`KEY_DELIMITER`].
 #[inline]
 pub fn create_key(left: &str, right: &str) -> String {
-    alloc::format!("{}{}{}", left, KEY_DELIMITER, right)
+    crate::prelude::format!("{}{}{}", left, KEY_DELIMITER, right)
 }
 
 #[cfg(test)]

--- a/examples2/src/counter_pack.rs
+++ b/examples2/src/counter_pack.rs
@@ -2,6 +2,7 @@ use crate::counter::Counter;
 use odra::prelude::*;
 use odra::ContractEnv;
 use odra::Mapping;
+use odra::Module;
 use odra::ModuleWrapper;
 
 pub struct CounterPack {

--- a/examples2/src/erc20.rs
+++ b/examples2/src/erc20.rs
@@ -1,4 +1,4 @@
-use odra::{casper_event_standard, OdraError};
+use odra::{casper_event_standard, Module, OdraError};
 use odra::{prelude::*, CallDef, Event, ModuleWrapper};
 use odra::{Address, ContractEnv, Mapping, Variable, U256, U512};
 
@@ -186,6 +186,7 @@ mod __erc20_wasm_parts {
     use odra::odra_casper_wasm_env::casper_contract::contract_api::runtime;
     use odra::odra_casper_wasm_env::casper_contract::unwrap_or_revert::UnwrapOrRevert;
     use odra::odra_casper_wasm_env::WasmContractEnv;
+    use odra::Module;
     use odra::{prelude::*, ContractEnv};
     use odra::{runtime_args, Address, U256};
 

--- a/justfile
+++ b/justfile
@@ -75,7 +75,7 @@ clean:
 build-erc20:
     cd examples2 && ODRA_MODULE=Erc20 cargo build --release --target wasm32-unknown-unknown --bin contract
     wasm-strip examples2/target/wasm32-unknown-unknown/release/contract.wasm
-    rm -rf examples2/wasm/erc20.wasm
+    rm -rf examples2/wasm/Erc20.wasm
     mkdir -p examples2/wasm
     mv examples2/target/wasm32-unknown-unknown/release/contract.wasm examples2/wasm/Erc20.wasm
 

--- a/odra-casper/test-vm/src/casper_host.rs
+++ b/odra-casper/test-vm/src/casper_host.rs
@@ -1,4 +1,4 @@
-use odra_core::prelude::{collections::*, *};
+use odra_core::prelude::*;
 use std::cell::RefCell;
 use std::env;
 use std::path::PathBuf;

--- a/odra-casper/test-vm/src/vm/casper_vm.rs
+++ b/odra-casper/test-vm/src/vm/casper_vm.rs
@@ -1,7 +1,5 @@
 use odra_core::consts::*;
-use odra_core::prelude::{collections::*, *};
-
-use odra_core::prelude::{collections::*, *};
+use odra_core::prelude::*;
 use std::cell::RefCell;
 use std::env;
 use std::path::PathBuf;

--- a/odra-casper/wasm-env/src/host_functions.rs
+++ b/odra-casper/wasm-env/src/host_functions.rs
@@ -17,9 +17,7 @@ use odra_core::casper_types::{
     contracts::NamedKeys,
     ApiError, CLTyped, ContractPackageHash, EntryPoints, Key, URef
 };
-use odra_core::prelude::borrow::ToOwned;
-use odra_core::prelude::boxed::Box;
-use odra_core::prelude::{format, string::String, vec, vec::Vec};
+use odra_core::prelude::*;
 use odra_core::{Address, ExecutionError};
 
 use crate::consts;
@@ -340,7 +338,7 @@ fn revoke_access_to_constructor_group(
     contract_package_hash: ContractPackageHash,
     constructor_access: URef
 ) {
-    let mut urefs = odra_core::prelude::collections::BTreeSet::new();
+    let mut urefs = BTreeSet::new();
     urefs.insert(constructor_access);
     storage::remove_contract_user_group_urefs(
         contract_package_hash,

--- a/odra-casper/wasm-env/src/wasm_contract_env.rs
+++ b/odra-casper/wasm-env/src/wasm_contract_env.rs
@@ -2,9 +2,9 @@ use crate::host_functions;
 use casper_types::bytesrepr::ToBytes;
 use casper_types::U512;
 use odra_core::casper_types;
-use odra_core::prelude::boxed::Box;
-use odra_core::{prelude::*, ContractContext, ContractEnv};
+use odra_core::prelude::*;
 use odra_core::{Address, Bytes, OdraError};
+use odra_core::{ContractContext, ContractEnv};
 
 #[derive(Clone)]
 pub struct WasmContractEnv;

--- a/odra-vm/src/odra_vm_host.rs
+++ b/odra-vm/src/odra_vm_host.rs
@@ -2,7 +2,7 @@ use crate::odra_vm_contract_env::OdraVmContractEnv;
 use crate::OdraVm;
 use odra_core::entry_point_callback::EntryPointsCaller;
 use odra_core::event::EventError;
-use odra_core::prelude::{collections::*, *};
+use odra_core::prelude::*;
 use odra_core::{Address, Bytes, OdraError, RuntimeArgs, VmError, U512};
 use odra_core::{CallDef, ContractContext, ContractEnv, HostContext, HostEnv};
 

--- a/odra-vm/src/vm/contract_container.rs
+++ b/odra-vm/src/vm/contract_container.rs
@@ -1,6 +1,6 @@
 use odra_core::call_def::CallDef;
 use odra_core::entry_point_callback::EntryPointsCaller;
-use odra_core::prelude::{collections::*, *};
+use odra_core::prelude::*;
 use odra_core::HostEnv;
 use odra_core::{
     casper_types::{NamedArg, RuntimeArgs},

--- a/odra-vm/src/vm/contract_register.rs
+++ b/odra-vm/src/vm/contract_register.rs
@@ -1,5 +1,5 @@
 use odra_core::call_def::CallDef;
-use odra_core::prelude::{collections::*, *};
+use odra_core::prelude::*;
 use odra_core::HostEnv;
 use odra_core::{casper_types::RuntimeArgs, Address, Bytes, OdraError, VmError};
 


### PR DESCRIPTION
Removed unneeded alloc:: and std:: uses, replacing them with
odra::prelude.
Removed if std from odra_core::prelude