### PR TITLE
Add events to Schema in the `call`  function

### DIFF
--- a/odra-macros/src/ast/events_item.rs
+++ b/odra-macros/src/ast/events_item.rs
@@ -1,34 +1,28 @@
 use syn::parse_quote;
 
 use crate::ast::fn_utils::FnItem;
-use crate::ast::utils::Named;
+use crate::ast::utils::ImplItem;
 use crate::ir::TypeIR;
 use crate::utils::misc::AsBlock;
 use crate::{ir::StructIR, utils};
 
 #[derive(syn_derive::ToTokens)]
 pub struct HasEventsImplItem {
-    impl_token: syn::token::Impl,
-    has_ident_ty: syn::Type,
-    for_token: syn::token::For,
-    module_ident: syn::Ident,
+    impl_item: ImplItem,
     #[syn(braced)]
     brace_token: syn::token::Brace,
     #[syn(in = brace_token)]
-    events_fn: EventsFnItem
+    events_fn: EventsFnsItem
 }
 
 impl TryFrom<&'_ StructIR> for HasEventsImplItem {
     type Error = syn::Error;
 
-    fn try_from(struct_ir: &'_ StructIR) -> Result<Self, Self::Error> {
+    fn try_from(ir: &'_ StructIR) -> Result<Self, Self::Error> {
         Ok(Self {
-            impl_token: Default::default(),
-            has_ident_ty: utils::ty::has_events(),
-            for_token: Default::default(),
-            module_ident: struct_ir.module_ident(),
+            impl_item: ImplItem::has_events(ir)?,
             brace_token: Default::default(),
-            events_fn: struct_ir.try_into()?
+            events_fn: ir.try_into()?
         })
     }
 }
@@ -38,54 +32,91 @@ impl TryFrom<&'_ TypeIR> for HasEventsImplItem {
 
     fn try_from(ir: &'_ TypeIR) -> Result<Self, Self::Error> {
         Ok(Self {
-            impl_token: Default::default(),
-            has_ident_ty: utils::ty::has_events(),
-            for_token: Default::default(),
-            module_ident: ir.name()?,
+            impl_item: ImplItem::has_events(ir)?,
             brace_token: Default::default(),
-            events_fn: EventsFnItem::empty()
+            events_fn: EventsFnsItem::empty()
         })
     }
 }
 
 #[derive(syn_derive::ToTokens)]
-pub struct EventsFnItem {
-    fn_item: FnItem
+pub struct EventsFnsItem {
+    events_fn: FnItem,
+    wasm_attr: syn::Attribute,
+    event_schemas_fn: FnItem
 }
 
-impl EventsFnItem {
+impl EventsFnsItem {
     pub fn empty() -> Self {
-        let ident_events = utils::ident::events();
-        let empty_vec = utils::expr::empty_vec();
         Self {
-            fn_item: FnItem::new(&ident_events, vec![], Self::ret_ty(), empty_vec.as_block())
+            events_fn: FnItem::new(
+                &utils::ident::events(),
+                vec![],
+                Self::events_ret_ty(),
+                utils::expr::empty_vec().as_block()
+            ),
+            wasm_attr: utils::attr::wasm32(),
+            event_schemas_fn: FnItem::new(
+                &utils::ident::event_schemas(),
+                vec![],
+                Self::schemas_ret_ty(),
+                utils::expr::empty_btree_map().as_block()
+            )
         }
     }
 
-    fn ret_ty() -> syn::ReturnType {
+    fn events_ret_ty() -> syn::ReturnType {
         let ev_ty = utils::ty::event();
         let vec = utils::ty::vec_of(&ev_ty);
         utils::misc::ret_ty(&vec)
     }
+
+    fn schemas_ret_ty() -> syn::ReturnType {
+        let string_ty = utils::ty::string();
+        let schema_ty = utils::ty::schema();
+        let btree = utils::ty::typed_btree_map(&string_ty, &schema_ty);
+        utils::misc::ret_ty(&btree)
+    }
+
+    fn events_fn(ir: &StructIR) -> Result<FnItem, syn::Error> {
+        let ident_events = utils::ident::events();
+        let struct_events_stmt = struct_events_stmt(ir);
+        let chain_events_expr = chain_events_expr(ir)?;
+        Ok(FnItem::new(
+            &ident_events,
+            vec![],
+            EventsFnsItem::events_ret_ty(),
+            parse_quote!({
+                #struct_events_stmt
+                #chain_events_expr
+            })
+        ))
+    }
+
+    fn event_schemas_fn(ir: &StructIR) -> Result<FnItem, syn::Error> {
+        let ident_events = utils::ident::event_schemas();
+        let struct_events_stmt = struct_event_schemas_stmt(ir);
+        let chain_events_expr = chain_event_schemas_expr(ir)?;
+        Ok(FnItem::new(
+            &ident_events,
+            vec![],
+            EventsFnsItem::schemas_ret_ty(),
+            parse_quote!({
+                #struct_events_stmt
+                #chain_events_expr
+            })
+        ))
+    }
 }
 
-impl TryFrom<&'_ StructIR> for EventsFnItem {
+impl TryFrom<&'_ StructIR> for EventsFnsItem {
     type Error = syn::Error;
 
-    fn try_from(struct_ir: &'_ StructIR) -> Result<Self, Self::Error> {
-        let ident_events = utils::ident::events();
-        let struct_events_stmt = struct_events_stmt(struct_ir);
-        let chain_events_expr = chain_events_expr(struct_ir)?;
+    fn try_from(ir: &'_ StructIR) -> Result<Self, Self::Error> {
         Ok(Self {
-            fn_item: FnItem::new(
-                &ident_events,
-                vec![],
-                Self::ret_ty(),
-                parse_quote!({
-                    #struct_events_stmt
-                    #chain_events_expr
-                })
-            )
+            events_fn: Self::events_fn(ir)?,
+            wasm_attr: utils::attr::wasm32(),
+            event_schemas_fn: Self::event_schemas_fn(ir)?
         })
     }
 }
@@ -121,6 +152,40 @@ fn chain_events_expr(ir: &StructIR) -> Result<syn::Expr, syn::Error> {
     ))
 }
 
+fn struct_event_schemas_stmt(ir: &StructIR) -> syn::Stmt {
+    let result_ident = utils::ident::result();
+
+    let events = ir
+        .events()
+        .iter()
+        .map(|ty| {
+            let name = utils::expr::event_instance_name(ty);
+            let schema = utils::expr::event_instance_schema(ty);
+            quote::quote!((#name, #schema))
+        })
+        .collect::<syn::punctuated::Punctuated<_, syn::token::Comma>>();
+    let iter = utils::expr::vec(events);
+    let new_btree_map = utils::expr::btree_from_iter(&iter);
+    parse_quote!(let #result_ident = #new_btree_map;)
+}
+
+fn chain_event_schemas_expr(ir: &StructIR) -> Result<syn::Expr, syn::Error> {
+    let result_ident = utils::ident::result();
+    let fields_events = ir
+        .unique_fields_ty()?
+        .iter()
+        .map(utils::expr::event_schemas)
+        .map(|expr| quote::quote!(.chain(#expr)))
+        .collect::<Vec<_>>();
+
+    Ok(parse_quote!(
+        #result_ident
+            .into_iter()
+            #(#fields_events)*
+            .collect()
+    ))
+}
+
 #[cfg(test)]
 mod test {
     use crate::test_utils;
@@ -144,6 +209,22 @@ mod test {
                         .chain(<Mapping<u8, Counter> as odra::contract_def::HasEvents>::events())
                         .chain(<ModuleWrapper<Counter> as odra::contract_def::HasEvents>::events())
                         .chain(<Variable<u32> as odra::contract_def::HasEvents>::events())
+                        .collect()
+                }
+
+                #[cfg(target_arch = "wasm32")]
+                fn event_schemas() -> odra::prelude::BTreeMap<odra::prelude::string::String, odra::casper_event_standard::Schema> {
+                    let result = odra::prelude::BTreeMap::from_iter(
+                        odra::prelude::vec![
+                            (<OnTransfer as odra::casper_event_standard::EventInstance>::name(), <OnTransfer as odra::casper_event_standard::EventInstance>::schema()),
+                            (<OnApprove as odra::casper_event_standard::EventInstance>::name(), <OnApprove as odra::casper_event_standard::EventInstance>::schema())
+                        ]
+                    );
+                    result
+                        .into_iter()
+                        .chain(<Mapping<u8, Counter> as odra::contract_def::HasEvents>::event_schemas())
+                        .chain(<ModuleWrapper<Counter> as odra::contract_def::HasEvents>::event_schemas())
+                        .chain(<Variable<u32> as odra::contract_def::HasEvents>::event_schemas())
                         .collect()
                 }
             }

--- a/odra-macros/src/ast/odra_type_item.rs
+++ b/odra-macros/src/ast/odra_type_item.rs
@@ -335,6 +335,11 @@ mod tests {
                 fn events() -> odra::prelude::vec::Vec<odra::contract_def::Event> {
                     odra::prelude::vec::Vec::new()
                 }
+
+                #[cfg(target_arch = "wasm32")]
+                fn event_schemas() -> odra::prelude::BTreeMap<odra::prelude::string::String, odra::casper_event_standard::Schema> {
+                    odra::prelude::BTreeMap::new()
+                }
             }
 
             #[automatically_derived]
@@ -387,6 +392,11 @@ mod tests {
             impl odra::contract_def::HasEvents for MyType {
                 fn events() -> odra::prelude::vec::Vec<odra::contract_def::Event> {
                     odra::prelude::vec::Vec::new()
+                }
+
+                #[cfg(target_arch = "wasm32")]
+                fn event_schemas() -> odra::prelude::BTreeMap<odra::prelude::string::String, odra::casper_event_standard::Schema> {
+                    odra::prelude::BTreeMap::new()
                 }
             }
 

--- a/odra-macros/src/ast/utils.rs
+++ b/odra-macros/src/ast/utils.rs
@@ -36,6 +36,10 @@ impl ImplItem {
         Self::new(named, utils::ty::clone())
     }
 
+    pub fn has_events<T: Named>(named: &T) -> Result<Self, syn::Error> {
+        Self::new(named, utils::ty::has_events())
+    }
+
     pub fn from<T: Named>(named: &T, for_ty: &syn::Type) -> Result<Self, syn::Error> {
         let ty_from = utils::ty::from(&named.name()?);
         Ok(Self {

--- a/odra-macros/src/utils/expr.rs
+++ b/odra-macros/src/utils/expr.rs
@@ -63,9 +63,9 @@ pub fn unit_cl_type() -> syn::Expr {
     parse_quote!(<() as #ty_cl_typed>::cl_type())
 }
 
-pub fn new_schemas() -> syn::Expr {
+pub fn schemas(events: &syn::Expr) -> syn::Expr {
     let ty = super::ty::schemas();
-    parse_quote!(#ty::new())
+    parse_quote!(#ty(#events))
 }
 
 pub fn new_wasm_contract_env() -> syn::Expr {
@@ -79,6 +79,21 @@ pub fn into_event(ty: &syn::Type) -> syn::Expr {
 pub fn events(ty: &syn::Type) -> syn::Expr {
     let has_events_ty = super::ty::has_events();
     parse_quote!(<#ty as #has_events_ty>::events())
+}
+
+pub fn event_schemas(ty: &syn::Type) -> syn::Expr {
+    let has_events_ty = super::ty::has_events();
+    parse_quote!(<#ty as #has_events_ty>::event_schemas())
+}
+
+pub fn event_instance_name(ty: &syn::Type) -> syn::Expr {
+    let event_instance_ty = super::ty::event_instance();
+    parse_quote!(<#ty as #event_instance_ty>::name())
+}
+
+pub fn event_instance_schema(ty: &syn::Type) -> syn::Expr {
+    let event_instance_ty = super::ty::event_instance();
+    parse_quote!(<#ty as #event_instance_ty>::schema())
 }
 pub fn new_blueprint(ident: &syn::Ident) -> syn::Expr {
     let ty = super::ty::contract_blueprint();
@@ -117,6 +132,11 @@ pub fn empty_vec() -> syn::Expr {
     parse_quote!(#ty::new())
 }
 
+pub fn empty_btree_map() -> syn::Expr {
+    let ty = super::ty::btree_map();
+    parse_quote!(#ty::new())
+}
+
 pub fn vec<T: ToTokens>(content: T) -> syn::Expr {
     parse_quote!(odra::prelude::vec![#content])
 }
@@ -136,6 +156,10 @@ pub fn some<T: ToTokens>(t: T) -> syn::Expr {
 
 pub fn none() -> syn::Expr {
     parse_quote!(None)
+}
+
+pub fn btree_from_iter(expr: &syn::Expr) -> syn::Expr {
+    parse_quote!(odra::prelude::BTreeMap::from_iter(#expr))
 }
 
 pub trait IntoExpr {

--- a/odra-macros/src/utils/ident.rs
+++ b/odra-macros/src/utils/ident.rs
@@ -70,6 +70,9 @@ pub fn env_rc() -> syn::Ident {
 pub fn events() -> syn::Ident {
     format_ident!("events")
 }
+pub fn event_schemas() -> syn::Ident {
+    format_ident!("event_schemas")
+}
 
 pub fn module_schema() -> syn::Ident {
     format_ident!("module_schema")

--- a/odra-macros/src/utils/ty.rs
+++ b/odra-macros/src/utils/ty.rs
@@ -100,6 +100,9 @@ pub fn group() -> syn::Type {
 pub fn schemas() -> syn::Type {
     parse_quote!(odra::casper_event_standard::Schemas)
 }
+pub fn schema() -> syn::Type {
+    parse_quote!(odra::casper_event_standard::Schema)
+}
 
 pub fn cl_typed() -> syn::Type {
     parse_quote!(odra::casper_types::CLTyped)
@@ -220,4 +223,12 @@ pub fn clone() -> syn::Type {
 
 pub fn from<T: ToTokens>(ty: &T) -> syn::Type {
     parse_quote!(::core::convert::From<#ty>)
+}
+
+pub fn typed_btree_map(key: &syn::Type, value: &syn::Type) -> syn::Type {
+    parse_quote!(odra::prelude::BTreeMap<#key, #value>)
+}
+
+pub fn btree_map() -> syn::Type {
+    parse_quote!(odra::prelude::BTreeMap)
 }


### PR DESCRIPTION
* add `event_schemas` to HasEvents trait
the function is visible only for the wasm32 target.
Using the existing function is pointless - it would be a back-and-forth conversion (EventInstance -> Event -> EventInstance). It is more appropriate to create a dedicated function for collecting EventInstances.
* update `call`  function