### PR TITLE
Macros improvements

### DIFF
--- a/examples2/src/erc20.rs
+++ b/examples2/src/erc20.rs
@@ -126,10 +126,7 @@ impl Erc20 {
     pub fn cross_transfer(&mut self, other: Address, to: Address, value: U256) {
         let caller = self.env().caller();
 
-        let mut other_erc20 = Erc20ContractRef {
-            address: other,
-            env: self.env()
-        };
+        let mut other_erc20 = Erc20ContractRef::new(self.env(), other);
 
         other_erc20.transfer(to, value);
         self.env().emit_event(OnCrossTransfer {

--- a/odra-macros/src/ast/external_contract_item.rs
+++ b/odra-macros/src/ast/external_contract_item.rs
@@ -53,6 +53,10 @@ mod test {
             }
 
             impl TokenContractRef {
+                pub fn new(env: Rc<odra::ContractEnv>, address: odra::Address) -> Self {
+                    Self { env, address }
+                }
+
                 pub fn address(&self) -> &odra::Address {
                     &self.address
                 }

--- a/odra-macros/src/ast/fn_utils.rs
+++ b/odra-macros/src/ast/fn_utils.rs
@@ -2,7 +2,6 @@ use crate::{
     ir::{FnArgIR, FnIR},
     utils
 };
-use quote::TokenStreamExt;
 use syn::{parse_quote, FnArg};
 
 pub fn runtime_args_block<F: FnMut(&FnArgIR) -> syn::Stmt>(
@@ -37,8 +36,7 @@ pub struct FnItem {
     #[syn(parenthesized)]
     paren_token: syn::token::Paren,
     #[syn(in = paren_token)]
-    #[to_tokens(| tokens, f | tokens.append_all(f))]
-    args: Vec<syn::FnArg>,
+    args: syn::punctuated::Punctuated<syn::FnArg, syn::Token![,]>,
     ret_ty: syn::ReturnType,
     block: syn::Block
 }
@@ -54,7 +52,7 @@ impl FnItem {
             fn_token: Default::default(),
             fn_name: name.clone(),
             paren_token: Default::default(),
-            args,
+            args: syn::punctuated::Punctuated::from_iter(args),
             ret_ty,
             block
         }

--- a/odra-macros/src/ast/module_def.rs
+++ b/odra-macros/src/ast/module_def.rs
@@ -34,7 +34,7 @@ impl TryFrom<&'_ ModuleStructIR> for ModuleDefItem {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{assert_eq, mock_module_definition};
+    use crate::test_utils::{assert_eq, mock_empty_module_definition, mock_module_definition};
 
     #[test]
     fn test_module_def_item() {
@@ -51,6 +51,18 @@ mod tests {
             }
         };
 
+        assert_eq(def, expected);
+    }
+
+    #[test]
+    fn empty_module() {
+        let ir = mock_empty_module_definition();
+        let def = ModuleDefItem::try_from(&ir).unwrap();
+        let expected = quote::quote! {
+            pub struct CounterPack {
+                __env: Rc<odra::ContractEnv>
+            }
+        };
         assert_eq(def, expected);
     }
 }

--- a/odra-macros/src/ast/module_item.rs
+++ b/odra-macros/src/ast/module_item.rs
@@ -191,6 +191,28 @@ mod test {
     use super::ModuleModItem;
 
     #[test]
+    fn empty_module() {
+        let module = test_utils::mock_empty_module_definition();
+        let expected = quote!(
+            mod __counter_pack_module {
+                use super::*;
+
+                impl odra::Module for CounterPack {
+                    fn new(env: Rc<odra::ContractEnv>) -> Self {
+                        Self { __env: env }
+                    }
+
+                    fn env(&self) -> Rc<odra::ContractEnv> {
+                        self.__env.clone()
+                    }
+                }
+            }
+        );
+        let actual = ModuleModItem::try_from(&module).unwrap();
+        test_utils::assert_eq(actual, expected);
+    }
+
+    #[test]
     fn counter_pack() {
         let module = test_utils::mock_module_definition();
         let expected = quote!(

--- a/odra-macros/src/ir/mod.rs
+++ b/odra-macros/src/ir/mod.rs
@@ -63,7 +63,7 @@ impl ModuleStructIR {
     }
 
     pub fn typed_fields(&self) -> Result<Vec<EnumeratedTypedField>, syn::Error> {
-        let fields = utils::syn::struct_fields(&self.code)?;
+        let fields = utils::syn::struct_typed_fields(&self.code)?;
         let fields = fields
             .iter()
             .filter(|(i, _)| i != &utils::ident::env())
@@ -114,7 +114,7 @@ impl ModuleStructIR {
                     .cmp(&other.0.to_token_stream().to_string())
             }
         }
-        let fields = utils::syn::struct_fields(&self.code)?;
+        let fields = utils::syn::struct_typed_fields(&self.code)?;
         let set = HashSet::<syn::Type>::from_iter(
             fields
                 .iter()

--- a/odra-macros/src/test_utils.rs
+++ b/odra-macros/src/test_utils.rs
@@ -76,6 +76,14 @@ pub fn mock_module_definition() -> ModuleStructIR {
     ModuleStructIR::try_from((&attr, &module)).unwrap()
 }
 
+pub fn mock_empty_module_definition() -> ModuleStructIR {
+    let module = quote!(
+        pub struct CounterPack;
+    );
+    let attr = quote!();
+    ModuleStructIR::try_from((&attr, &module)).unwrap()
+}
+
 pub fn mock_struct() -> TypeIR {
     let ty = quote!(
         struct MyType {

--- a/odra-macros/src/utils/ty.rs
+++ b/odra-macros/src/utils/ty.rs
@@ -5,6 +5,10 @@ pub fn address() -> syn::Type {
     parse_quote!(odra::Address)
 }
 
+pub fn address_ref() -> syn::Type {
+    parse_quote!(&odra::Address)
+}
+
 pub fn contract_env() -> syn::Type {
     parse_quote!(odra::ContractEnv)
 }


### PR DESCRIPTION
Autogenerate ContractRef constructor
support for empty modules
```rust
#[odra::module]
struct A {}

//or

#[odra::module]
struct A;
```