### PR TITLE
Module members validation

### DIFF
--- a/core/src/entry_point_callback.rs
+++ b/core/src/entry_point_callback.rs
@@ -1,22 +1,22 @@
 use crate::call_def::CallDef;
-use crate::Bytes;
+use crate::{Bytes, OdraError};
 use crate::{ContractEnv, HostEnv};
 
 #[derive(Clone)]
 pub struct EntryPointsCaller {
-    pub f: fn(contract_env: ContractEnv, call_def: CallDef) -> Bytes,
+    pub f: fn(contract_env: ContractEnv, call_def: CallDef) -> Result<Bytes, OdraError>,
     host_env: HostEnv
 }
 
 impl EntryPointsCaller {
     pub fn new(
         host_env: HostEnv,
-        f: fn(contract_env: ContractEnv, call_def: CallDef) -> Bytes
+        f: fn(contract_env: ContractEnv, call_def: CallDef) -> Result<Bytes, OdraError>
     ) -> Self {
         EntryPointsCaller { f, host_env }
     }
 
-    pub fn call(&self, call_def: CallDef) -> Bytes {
+    pub fn call(&self, call_def: CallDef) -> Result<Bytes, OdraError> {
         (self.f)(self.host_env.contract_env(), call_def)
     }
 }

--- a/core/src/variable.rs
+++ b/core/src/variable.rs
@@ -2,6 +2,7 @@ use crate::prelude::*;
 use crate::{CLTyped, FromBytes, OdraError, ToBytes, UnwrapOrRevert};
 
 use crate::contract_env::ContractEnv;
+use crate::module::ModuleComponent;
 
 pub struct Variable<T> {
     env: Rc<ContractEnv>,
@@ -15,8 +16,8 @@ impl<T> Variable<T> {
     }
 }
 
-impl<T> Variable<T> {
-    pub const fn new(env: Rc<ContractEnv>, index: u8) -> Self {
+impl<T> ModuleComponent for Variable<T> {
+    fn instance(env: Rc<ContractEnv>, index: u8) -> Self {
         Self {
             env,
             phantom: core::marker::PhantomData,
@@ -77,11 +78,5 @@ impl<V: ToBytes + FromBytes + CLTyped + OverflowingSub + Default> Variable<V> {
             .overflowing_sub(value)
             .unwrap_or_revert(&self.env());
         self.set(new_value);
-    }
-}
-
-impl<T> crate::contract_def::HasEvents for Variable<T> {
-    fn events() -> Vec<crate::contract_def::Event> {
-        vec![]
     }
 }

--- a/examples2/src/erc20.rs
+++ b/examples2/src/erc20.rs
@@ -1,6 +1,8 @@
 use crate::counter::Counter;
 use casper_event_standard::Event;
-use odra::{casper_event_standard, Bytes, Module, OdraError, PublicKey};
+use odra::{
+    casper_event_standard, Bytes, ContractEnv, Module, ModuleComponent, OdraError, PublicKey
+};
 use odra::{prelude::*, CallDef, ModuleWrapper};
 use odra::{Address, Mapping, Variable, U256, U512};
 
@@ -37,9 +39,11 @@ trait TotalSupply {
     fn total_supply(&self) -> U256;
 }
 
+type VarU256 = Variable<U256>;
+
 #[odra::module(events = [OnTransfer, OnCrossTransfer, OnApprove])]
 pub struct Erc20 {
-    total_supply: Variable<U256>,
+    total_supply: VarU256,
     balances: Mapping<Address, U256>,
     counter: ModuleWrapper<Counter>
 }

--- a/examples2/src/erc20.rs
+++ b/examples2/src/erc20.rs
@@ -55,6 +55,7 @@ impl Erc20 {
             fn get_count(&self, index: u8) -> u32;
         }
     }
+
     pub fn init(&mut self, total_supply: Option<U256>) {
         if let Some(total_supply) = total_supply {
             self.total_supply.set(total_supply);

--- a/modules/src/erc1155/erc1155_base.rs
+++ b/modules/src/erc1155/erc1155_base.rs
@@ -155,11 +155,13 @@ impl Erc1155Base {
         data: &Option<Bytes>
     ) {
         if to.is_contract() {
-            let response = Erc1155ReceiverContractRef {
-                env: self.env(),
-                address: *to
-            }
-            .on_erc1155_received(*operator, *from, *id, *amount, data.clone());
+            let response = Erc1155ReceiverContractRef::new(self.env(), *to).on_erc1155_received(
+                *operator,
+                *from,
+                *id,
+                *amount,
+                data.clone()
+            );
             if !response {
                 self.env().revert(Error::TransferRejected);
             }
@@ -178,17 +180,14 @@ impl Erc1155Base {
         data: &Option<Bytes>
     ) {
         if to.is_contract() {
-            let response = Erc1155ReceiverContractRef {
-                env: self.env(),
-                address: *to
-            }
-            .on_erc1155_batch_received(
-                *operator,
-                *from,
-                ids.to_vec(),
-                amounts.to_vec(),
-                data.clone()
-            );
+            let response = Erc1155ReceiverContractRef::new(self.env(), *to)
+                .on_erc1155_batch_received(
+                    *operator,
+                    *from,
+                    ids.to_vec(),
+                    amounts.to_vec(),
+                    data.clone()
+                );
             if !response {
                 self.env().revert(Error::TransferRejected);
             }

--- a/modules/src/erc1155_receiver.rs
+++ b/modules/src/erc1155_receiver.rs
@@ -5,7 +5,7 @@ use odra::{Address, Bytes, Module, U256};
 
 /// The ERC1155 receiver implementation.
 #[odra::module(events = [SingleReceived, BatchReceived])]
-pub struct Erc1155Receiver {}
+pub struct Erc1155Receiver;
 
 #[odra::module]
 impl Erc1155Receiver {

--- a/modules/src/erc1155_token.rs
+++ b/modules/src/erc1155_token.rs
@@ -186,7 +186,7 @@ mod tests {
     use crate::erc1155_token::{Erc1155TokenDeployer, Erc1155TokenHostRef};
     use crate::wrapped_native::WrappedNativeTokenDeployer;
     use odra::prelude::*;
-    use odra::{Address, Bytes, HostEnv, U256};
+    use odra::{Address, Bytes, HostEnv, OdraError, VmError, U256};
 
     struct TokenEnv {
         env: HostEnv,
@@ -895,15 +895,19 @@ mod tests {
         // When we transfer tokens to an invalid receiver
         // Then it errors out
         env.env.set_caller(env.alice);
-        let _err = env.token.try_safe_transfer_from(
+        let err = env.token.try_safe_transfer_from(
             env.alice,
             *receiver.address(),
             U256::one(),
             100.into(),
             None
         );
-        // TODO: Reenable this assertion after https://github.com/odradev/odra/issues/298 is fixed
-        // assert_eq!(err, Err(OdraError::VmError(NoSuchMethod("on_erc1155_received".to_string()))));
+        assert_eq!(
+            err,
+            Err(OdraError::VmError(VmError::NoSuchMethod(
+                "on_erc1155_received".to_string()
+            )))
+        );
     }
 
     #[test]
@@ -998,8 +1002,6 @@ mod tests {
 
     #[test]
     fn safe_batch_transfer_to_invalid_receiver() {
-        // OdraError::VmError(NoSuchMethod("on_erc1155_batch_received".to_string())),
-        // || {
         // Given a deployed contract
         let mut env = setup();
         // And an invalid receiver
@@ -1011,7 +1013,7 @@ mod tests {
         // When we transfer tokens to an invalid receiver
         // Then it errors out
         env.env.set_caller(env.alice);
-        let _err = env
+        let err = env
             .token
             .try_safe_batch_transfer_from(
                 env.alice,
@@ -1021,7 +1023,11 @@ mod tests {
                 None
             )
             .unwrap_err();
-        // TODO: Reenable this assertion after https://github.com/odradev/odra/issues/298 is fixed
-        // assert_eq!(err, OdraError::VmError(NoSuchMethod("on_erc1155_batch_received".to_string())));
+        assert_eq!(
+            err,
+            OdraError::VmError(VmError::NoSuchMethod(
+                "on_erc1155_batch_received".to_string()
+            ))
+        );
     }
 }

--- a/modules/src/erc1155_token.rs
+++ b/modules/src/erc1155_token.rs
@@ -222,7 +222,7 @@ mod tests {
         // And the event is emitted
         let contract = env.token;
         env.env.emitted_event(
-            &contract.address,
+            contract.address(),
             &TransferSingle {
                 operator: Some(env.owner),
                 from: None,
@@ -248,7 +248,7 @@ mod tests {
 
         // Then it emits the event
         env.env.emitted_event(
-            &env.token.address,
+            env.token.address(),
             &TransferBatch {
                 operator: Some(env.owner),
                 from: None,
@@ -297,7 +297,7 @@ mod tests {
         // And the event is emitted
         let contract = env.token;
         env.env.emitted_event(
-            &contract.address,
+            contract.address(),
             &TransferSingle {
                 operator: Some(env.owner),
                 from: Some(env.alice),
@@ -359,7 +359,7 @@ mod tests {
         // And the event is emitted
         let contract = env.token;
         env.env.emitted_event(
-            &contract.address,
+            contract.address(),
             &TransferBatch {
                 operator: Some(env.owner),
                 from: Some(env.alice),
@@ -532,7 +532,7 @@ mod tests {
 
         // And the event is emitted
         env.env.emitted_event(
-            &env.token.address,
+            env.token.address(),
             &ApprovalForAll {
                 owner: env.alice,
                 operator: env.bob,
@@ -560,7 +560,7 @@ mod tests {
         // And the event is emitted
         let contract = env.token;
         env.env.emitted_event(
-            &contract.address,
+            contract.address(),
             &ApprovalForAll {
                 owner: env.alice,
                 operator: env.bob,
@@ -603,7 +603,7 @@ mod tests {
         // And the event is emitted
         let contract = env.token;
         env.env.emitted_event(
-            &contract.address,
+            contract.address(),
             &TransferSingle {
                 operator: Some(env.alice),
                 from: Some(env.alice),
@@ -638,7 +638,7 @@ mod tests {
         // And the event is emitted
         let contract = env.token;
         env.env.emitted_event(
-            &contract.address,
+            contract.address(),
             &TransferSingle {
                 operator: Some(env.bob),
                 from: Some(env.alice),
@@ -708,7 +708,7 @@ mod tests {
         // And the event is emitted
         let contract = env.token;
         env.env.emitted_event(
-            &contract.address,
+            contract.address(),
             &TransferBatch {
                 operator: Some(env.alice),
                 from: Some(env.alice),
@@ -751,7 +751,7 @@ mod tests {
         // And the event is emitted
         let contract = env.token;
         env.env.emitted_event(
-            &contract.address,
+            contract.address(),
             &TransferBatch {
                 operator: Some(env.bob),
                 from: Some(env.alice),
@@ -816,19 +816,24 @@ mod tests {
 
         // When we transfer tokens to a valid receiver
         env.env.set_caller(env.alice);
-        env.token
-            .safe_transfer_from(env.alice, receiver.address, U256::one(), 100.into(), None);
+        env.token.safe_transfer_from(
+            env.alice,
+            *receiver.address(),
+            U256::one(),
+            100.into(),
+            None
+        );
 
         // Then the tokens are transferred
         assert_eq!(env.token.balance_of(env.alice, U256::one()), 0.into());
         assert_eq!(
-            env.token.balance_of(receiver.address, U256::one()),
+            env.token.balance_of(*receiver.address(), U256::one()),
             100.into()
         );
 
         // And receiver contract is aware of received tokens
         env.env.emitted_event(
-            &receiver.address,
+            receiver.address(),
             &SingleReceived {
                 operator: Some(env.alice),
                 from: Some(env.alice),
@@ -852,7 +857,7 @@ mod tests {
         env.env.set_caller(env.alice);
         env.token.safe_transfer_from(
             env.alice,
-            receiver.address,
+            *receiver.address(),
             U256::one(),
             100.into(),
             Some(Bytes::from(b"data".to_vec()))
@@ -861,13 +866,13 @@ mod tests {
         // Then the tokens are transferred
         assert_eq!(env.token.balance_of(env.alice, U256::one()), 0.into());
         assert_eq!(
-            env.token.balance_of(receiver.address, U256::one()),
+            env.token.balance_of(*receiver.address(), U256::one()),
             100.into()
         );
 
         // And receiver contract is aware of received tokens and data
         env.env.emitted_event(
-            &receiver.address,
+            receiver.address(),
             &SingleReceived {
                 operator: Some(env.alice),
                 from: Some(env.alice),
@@ -892,7 +897,7 @@ mod tests {
         env.env.set_caller(env.alice);
         let _err = env.token.try_safe_transfer_from(
             env.alice,
-            receiver.address,
+            *receiver.address(),
             U256::one(),
             100.into(),
             None
@@ -915,7 +920,7 @@ mod tests {
         env.env.set_caller(env.alice);
         env.token.safe_batch_transfer_from(
             env.alice,
-            receiver.address,
+            *receiver.address(),
             [U256::one(), U256::from(2)].to_vec(),
             [100.into(), 100.into()].to_vec(),
             None
@@ -924,18 +929,18 @@ mod tests {
         // Then the tokens are transferred
         assert_eq!(env.token.balance_of(env.alice, U256::one()), 0.into());
         assert_eq!(
-            env.token.balance_of(receiver.address, U256::one()),
+            env.token.balance_of(*receiver.address(), U256::one()),
             100.into()
         );
         assert_eq!(env.token.balance_of(env.alice, U256::from(2)), 0.into());
         assert_eq!(
-            env.token.balance_of(receiver.address, U256::from(2)),
+            env.token.balance_of(*receiver.address(), U256::from(2)),
             100.into()
         );
 
         // And receiver contract is aware of received tokens
         env.env.emitted_event(
-            &receiver.address,
+            receiver.address(),
             &BatchReceived {
                 operator: Some(env.alice),
                 from: Some(env.alice),
@@ -960,7 +965,7 @@ mod tests {
         env.env.set_caller(env.alice);
         env.token.safe_batch_transfer_from(
             env.alice,
-            receiver.address,
+            *receiver.address(),
             [U256::one(), U256::from(2)].to_vec(),
             [100.into(), 100.into()].to_vec(),
             Some(Bytes::from(b"data".to_vec()))
@@ -969,18 +974,18 @@ mod tests {
         // Then the tokens are transferred
         assert_eq!(env.token.balance_of(env.alice, U256::one()), 0.into());
         assert_eq!(
-            env.token.balance_of(receiver.address, U256::one()),
+            env.token.balance_of(*receiver.address(), U256::one()),
             100.into()
         );
         assert_eq!(env.token.balance_of(env.alice, U256::from(2)), 0.into());
         assert_eq!(
-            env.token.balance_of(receiver.address, U256::from(2)),
+            env.token.balance_of(*receiver.address(), U256::from(2)),
             100.into()
         );
 
         // And receiver contract is aware of received tokens and data
         env.env.emitted_event(
-            &receiver.address,
+            receiver.address(),
             &BatchReceived {
                 operator: Some(env.alice),
                 from: Some(env.alice),
@@ -1010,7 +1015,7 @@ mod tests {
             .token
             .try_safe_batch_transfer_from(
                 env.alice,
-                receiver.address,
+                *receiver.address(),
                 [U256::one(), U256::from(2)].to_vec(),
                 [100.into(), 100.into()].to_vec(),
                 None

--- a/modules/src/erc20.rs
+++ b/modules/src/erc20.rs
@@ -221,7 +221,7 @@ mod tests {
 
         // Then a Transfer event was emitted.
         assert!(env.emitted_event(
-            &erc20.address,
+            erc20.address(),
             &Transfer {
                 from: None,
                 to: Some(env.get_account(0)),
@@ -252,7 +252,7 @@ mod tests {
 
         // Then Transfer event was emitted.
         assert!(env.emitted_event(
-            &erc20.address,
+            erc20.address(),
             &Transfer {
                 from: Some(sender),
                 to: Some(recipient),
@@ -291,7 +291,7 @@ mod tests {
         // Allowance was recorded.
         assert_eq!(erc20.allowance(owner, spender), approved_amount);
         assert!(env.emitted_event(
-            &erc20.address,
+            erc20.address(),
             &Approval {
                 owner,
                 spender,
@@ -310,7 +310,7 @@ mod tests {
         );
         assert_eq!(erc20.balance_of(recipient), transfer_amount);
         assert!(env.emitted_event(
-            &erc20.address,
+            erc20.address(),
             &Approval {
                 owner,
                 spender,
@@ -318,7 +318,7 @@ mod tests {
             }
         ));
         assert!(env.emitted_event(
-            &erc20.address,
+            erc20.address(),
             &Transfer {
                 from: Some(owner),
                 to: Some(recipient),

--- a/modules/src/erc721/erc721_base.rs
+++ b/modules/src/erc721/erc721_base.rs
@@ -122,11 +122,12 @@ impl Erc721Base {
     ) {
         self.transfer(from, to, token_id);
         if to.is_contract() {
-            let response = Erc721ReceiverContractRef {
-                env: self.env(),
-                address: *to
-            }
-            .on_erc721_received(self.env().caller(), *from, *token_id, data.clone());
+            let response = Erc721ReceiverContractRef::new(self.env(), *to).on_erc721_received(
+                self.env().caller(),
+                *from,
+                *token_id,
+                data.clone()
+            );
 
             if !response {
                 self.env().revert(TransferFailed)

--- a/modules/src/erc721_receiver.rs
+++ b/modules/src/erc721_receiver.rs
@@ -8,7 +8,7 @@ use odra::{Address, Bytes, Module, U256};
 /// The ERC721 receiver implementation.
 // TODO: remove {} when #295 is merged
 #[odra::module]
-pub struct Erc721Receiver {}
+pub struct Erc721Receiver;
 
 #[odra::module]
 impl Erc721ReceiverTrait for Erc721Receiver {
@@ -25,11 +25,7 @@ impl Erc721ReceiverTrait for Erc721Receiver {
             token_id: *token_id,
             data: data.clone()
         });
-        Erc721TokenContractRef {
-            env: self.env(),
-            address: self.env().caller()
-        }
-        .owner_of(*token_id)
+        Erc721TokenContractRef::new(self.env(), self.env().caller()).owner_of(*token_id)
             == self.env().self_address()
     }
 }

--- a/modules/src/erc721_receiver.rs
+++ b/modules/src/erc721_receiver.rs
@@ -6,7 +6,6 @@ use odra::prelude::*;
 use odra::{Address, Bytes, Module, U256};
 
 /// The ERC721 receiver implementation.
-// TODO: remove {} when #295 is merged
 #[odra::module]
 pub struct Erc721Receiver;
 

--- a/modules/src/erc721_token.rs
+++ b/modules/src/erc721_token.rs
@@ -465,7 +465,7 @@ mod tests {
         // When deploy a contract with the initial supply.
         let mut erc721_env = setup();
 
-        assert!(erc721_env.token.address.is_contract());
+        assert!(erc721_env.token.address().is_contract());
         assert!(!erc721_env.alice.is_contract());
 
         // And mint a token to Alice.
@@ -524,15 +524,20 @@ mod tests {
 
         // And transfer the token to the contract which does support nfts
         erc721_env.env.set_caller(erc721_env.alice);
-        erc721_env
-            .token
-            .safe_transfer_from(erc721_env.alice, receiver.address, U256::from(1));
+        erc721_env.token.safe_transfer_from(
+            erc721_env.alice,
+            receiver.address().clone(),
+            U256::from(1)
+        );
 
         // Then the owner of the token is the contract
-        assert_eq!(erc721_env.token.owner_of(U256::from(1)), receiver.address);
+        assert_eq!(
+            erc721_env.token.owner_of(U256::from(1)),
+            receiver.address().clone()
+        );
         // And the receiver contract is aware of the transfer
         erc721_env.env.emitted_event(
-            &receiver.address,
+            receiver.address(),
             &Received {
                 operator: Some(erc721_env.alice),
                 from: Some(erc721_env.alice),
@@ -556,16 +561,19 @@ mod tests {
         erc721_env.env.set_caller(erc721_env.alice);
         erc721_env.token.safe_transfer_from_with_data(
             erc721_env.alice,
-            receiver.address,
+            receiver.address().clone(),
             U256::from(1),
             b"data".to_vec().into()
         );
 
         // Then the owner of the token is the contract
-        assert_eq!(erc721_env.token.owner_of(U256::from(1)), receiver.address);
+        assert_eq!(
+            erc721_env.token.owner_of(U256::from(1)),
+            receiver.address().clone()
+        );
         // And the receiver contract is aware of the transfer
         erc721_env.env.emitted_event(
-            &receiver.address,
+            receiver.address(),
             &Received {
                 operator: Some(erc721_env.alice),
                 from: Some(erc721_env.alice),

--- a/modules/src/erc721_token.rs
+++ b/modules/src/erc721_token.rs
@@ -146,7 +146,7 @@ mod tests {
     use crate::erc721_receiver::Erc721ReceiverDeployer;
     use crate::erc721_token::errors::Error::TokenAlreadyExists;
     use odra::prelude::*;
-    use odra::{Address, HostEnv, OdraAddress, U256};
+    use odra::{Address, HostEnv, OdraAddress, OdraError, VmError, U256};
 
     const NAME: &str = "PlascoinNFT";
     const SYMBOL: &str = "PLSNFT";
@@ -487,7 +487,7 @@ mod tests {
         // When deploy a contract with the initial supply
         let mut erc721_env = setup();
         // And another contract which does not support nfts
-        let _erc20 = Erc20Deployer::init(
+        let erc20 = Erc20Deployer::init(
             &erc721_env.env,
             "PLS".to_string(),
             "PLASCOIN".to_string(),
@@ -502,14 +502,16 @@ mod tests {
         erc721_env.env.set_caller(erc721_env.alice);
 
         // TODO: Enable this after fixing mockvm
-        // assert_eq!(
-        // OdraError::VmError(NoSuchMethod("on_erc721_received".to_string())),
-        //         erc721_env.token.try_safe_transfer_from(
-        //             erc721_env.alice,
-        //             erc20.address,
-        //             U256::from(1)
-        //         ).unwrap_err()
-        // );
+        assert_eq!(
+            Err(OdraError::VmError(VmError::NoSuchMethod(
+                "on_erc721_received".to_string()
+            ))),
+            erc721_env.token.try_safe_transfer_from(
+                erc721_env.alice,
+                *erc20.address(),
+                U256::from(1)
+            )
+        );
     }
 
     #[test]

--- a/modules/src/wrapped_native.rs
+++ b/modules/src/wrapped_native.rs
@@ -164,7 +164,7 @@ mod tests {
 
         // The events were emitted.
         assert!(env.emitted_event(
-            &token.address,
+            token.address(),
             &Transfer {
                 from: None,
                 to: Some(account),
@@ -173,7 +173,7 @@ mod tests {
         ));
 
         assert!(env.emitted_event(
-            &token.address,
+            token.address(),
             &Deposit {
                 account,
                 value: deposit_amount.into()
@@ -201,7 +201,7 @@ mod tests {
             (deposit_amount + deposit_amount).to_u256().unwrap()
         );
         // Then events were emitted.
-        assert!(env.event_names(&token.address).ends_with(
+        assert!(env.event_names(token.address()).ends_with(
             vec![
                 Transfer::name(),
                 Deposit::name(),
@@ -249,7 +249,7 @@ mod tests {
 
         // Then events were emitted.
         assert!(env.emitted_event(
-            &token.address,
+            token.address(),
             &Transfer {
                 from: Some(account),
                 to: None,
@@ -257,7 +257,7 @@ mod tests {
             }
         ));
         assert!(env.emitted_event(
-            &token.address,
+            token.address(),
             &Withdrawal {
                 account,
                 value: withdrawal_amount

--- a/odra-macros/Cargo.toml
+++ b/odra-macros/Cargo.toml
@@ -19,6 +19,7 @@ convert_case = { version = "0.5.0" }
 derive-try-from ={ path = "../try-from-macro" }
 derive_more = "0.99.17"
 itertools = "0.12.0"
+static_assertions = "1.1.0"
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/odra-macros/src/ast/deployer_item.rs
+++ b/odra-macros/src/ast/deployer_item.rs
@@ -92,21 +92,23 @@ mod deployer_impl {
                         match call_def.method() {
                             "init" => {
                                 let result = execute_init(contract_env);
-                                odra::ToBytes::to_bytes(&result).map(Into::into).unwrap()
+                                odra::ToBytes::to_bytes(&result).map(Into::into).map_err(|err| odra::OdraError::ExecutionError(err.into()))
                             }
                             "total_supply" => {
                                 let result = execute_total_supply(contract_env);
-                                odra::ToBytes::to_bytes(&result).map(Into::into).unwrap()
+                                odra::ToBytes::to_bytes(&result).map(Into::into).map_err(|err| odra::OdraError::ExecutionError(err.into()))
                             }
                             "pay_to_mint" => {
                                 let result = execute_pay_to_mint(contract_env);
-                                odra::ToBytes::to_bytes(&result).map(Into::into).unwrap()
+                                odra::ToBytes::to_bytes(&result).map(Into::into).map_err(|err| odra::OdraError::ExecutionError(err.into()))
                             }
                             "approve" => {
                                 let result = execute_approve(contract_env);
-                                odra::ToBytes::to_bytes(&result).map(Into::into).unwrap()
+                                odra::ToBytes::to_bytes(&result).map(Into::into).map_err(|err| odra::OdraError::ExecutionError(err.into()))
                             }
-                            _ => panic!("Unknown method")
+                            name => Err(odra::OdraError::VmError(
+                                odra::VmError::NoSuchMethod(odra::prelude::String::from(name)),
+                            ))
                         }
                     });
 
@@ -143,13 +145,15 @@ mod deployer_impl {
                         match call_def.method() {
                             "total_supply" => {
                                 let result = execute_total_supply(contract_env);
-                                odra::ToBytes::to_bytes(&result).map(Into::into).unwrap()
+                                odra::ToBytes::to_bytes(&result).map(Into::into).map_err(|err| odra::OdraError::ExecutionError(err.into()))
                             }
                             "pay_to_mint" => {
                                 let result = execute_pay_to_mint(contract_env);
-                                odra::ToBytes::to_bytes(&result).map(Into::into).unwrap()
+                                odra::ToBytes::to_bytes(&result).map(Into::into).map_err(|err| odra::OdraError::ExecutionError(err.into()))
                             }
-                            _ => panic!("Unknown method")
+                            name => Err(odra::OdraError::VmError(
+                                odra::VmError::NoSuchMethod(odra::prelude::String::from(name)),
+                            ))
                         }
                     });
 
@@ -182,25 +186,27 @@ mod deployer_impl {
                         match call_def.method() {
                             "total_supply" => {
                                 let result = execute_total_supply(contract_env);
-                                odra::ToBytes::to_bytes(&result).map(Into::into).unwrap()
+                                odra::ToBytes::to_bytes(&result).map(Into::into).map_err(|err| odra::OdraError::ExecutionError(err.into()))
                             }
                             "get_owner" => {
                                 let result = execute_get_owner(contract_env);
-                                odra::ToBytes::to_bytes(&result).map(Into::into).unwrap()
+                                odra::ToBytes::to_bytes(&result).map(Into::into).map_err(|err| odra::OdraError::ExecutionError(err.into()))
                             }
                             "set_owner" => {
                                 let result = execute_set_owner(contract_env);
-                                odra::ToBytes::to_bytes(&result).map(Into::into).unwrap()
+                                odra::ToBytes::to_bytes(&result).map(Into::into).map_err(|err| odra::OdraError::ExecutionError(err.into()))
                             }
                             "name" => {
                                 let result = execute_name(contract_env);
-                                odra::ToBytes::to_bytes(&result).map(Into::into).unwrap()
+                                odra::ToBytes::to_bytes(&result).map(Into::into).map_err(|err| odra::OdraError::ExecutionError(err.into()))
                             }
                             "symbol" => {
                                 let result = execute_symbol(contract_env);
-                                odra::ToBytes::to_bytes(&result).map(Into::into).unwrap()
+                                odra::ToBytes::to_bytes(&result).map(Into::into).map_err(|err| odra::OdraError::ExecutionError(err.into()))
                             }
-                            _ => panic!("Unknown method")
+                            name => Err(odra::OdraError::VmError(
+                                odra::VmError::NoSuchMethod(odra::prelude::String::from(name)),
+                            ))
                         }
                     });
 

--- a/odra-macros/src/ast/deployer_utils.rs
+++ b/odra-macros/src/ast/deployer_utils.rs
@@ -71,7 +71,7 @@ impl EntrypointCallerExpr {
         let ty_caller = utils::ty::entry_points_caller();
 
         let mut branches: Vec<CallerBranch> = module
-            .functions()
+            .functions()?
             .iter()
             .map(|f| CallerBranch::Function(FunctionCallBranch::from(f)))
             .collect();

--- a/odra-macros/src/ast/deployer_utils.rs
+++ b/odra-macros/src/ast/deployer_utils.rs
@@ -195,7 +195,7 @@ impl<'a> FunctionCallBranch {
         let result_ident = utils::ident::result();
         let function_ident = func.execute_name();
         let contract_env_ident = utils::ident::contract_env();
-        parse_quote!(let #result_ident =  #function_ident(#contract_env_ident);)
+        parse_quote!(let #result_ident = #function_ident(#contract_env_ident);)
     }
 }
 
@@ -203,6 +203,8 @@ struct DefaultBranch;
 
 impl ToTokens for DefaultBranch {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        tokens.extend(quote::quote!(_ => panic!("Unknown method")))
+        tokens.extend(quote::quote!(name => Err(odra::OdraError::VmError(
+            odra::VmError::NoSuchMethod(odra::prelude::String::from(name))
+        ))))
     }
 }

--- a/odra-macros/src/ast/entrypoints_item.rs
+++ b/odra-macros/src/ast/entrypoints_item.rs
@@ -55,9 +55,9 @@ impl TryFrom<&'_ ModuleImplIR> for EntrypointsFnItem {
     }
 }
 
-fn struct_entrypoints_expr(ir: &ModuleImplIR) -> Result<syn::Expr, syn::Error> {
+fn struct_entrypoints_expr(ir: &ModuleImplIR) -> syn::Result<syn::Expr> {
     let struct_entrypoints = ir
-        .functions()
+        .functions()?
         .iter()
         .map(|f| {
             let ident = f.name_str();

--- a/odra-macros/src/ast/exec_parts.rs
+++ b/odra-macros/src/ast/exec_parts.rs
@@ -47,7 +47,7 @@ impl TryFrom<&'_ ModuleImplIR> for ExecPartsItem {
             use_prelude: UsePreludeItem,
             use_super: UseSuperItem,
             exec_functions: module
-                .functions()
+                .functions()?
                 .iter()
                 .map(|f| (module, f))
                 .map(TryInto::try_into)

--- a/odra-macros/src/ast/external_contract_item.rs
+++ b/odra-macros/src/ast/external_contract_item.rs
@@ -48,8 +48,8 @@ mod test {
             }
 
             pub struct TokenContractRef {
-                pub env: Rc<odra::ContractEnv>,
-                pub address: odra::Address,
+                env: Rc<odra::ContractEnv>,
+                address: odra::Address,
             }
 
             impl TokenContractRef {
@@ -83,18 +83,34 @@ mod test {
 
 
                 pub struct TokenHostRef {
-                    pub address: odra::Address,
-                    pub env: odra::HostEnv,
-                    pub attached_value: odra::U512
+                    address: odra::Address,
+                    env: odra::HostEnv,
+                    attached_value: odra::U512
                 }
 
                 impl TokenHostRef {
+                    pub fn new(address: odra::Address, env: odra::HostEnv) -> Self {
+                        Self {
+                            address,
+                            env,
+                            attached_value: Default::default()
+                        }
+                    }
+
                     pub fn with_tokens(&self, tokens: odra::U512) -> Self {
                         Self {
                             address: self.address,
                             env: self.env.clone(),
                             attached_value: tokens
                         }
+                    }
+
+                    pub fn address(&self) -> &odra::Address {
+                        &self.address
+                    }
+
+                    pub fn env(&self) -> &odra::HostEnv {
+                        &self.env
                     }
 
                     pub fn get_event<T>(&self, index: i32) -> Result<T, odra::event::EventError>

--- a/odra-macros/src/ast/host_ref_item.rs
+++ b/odra-macros/src/ast/host_ref_item.rs
@@ -18,8 +18,6 @@ impl TryFrom<&'_ ModuleImplIR> for HostRefStructItem {
     type Error = syn::Error;
 
     fn try_from(module: &'_ ModuleImplIR) -> Result<Self, Self::Error> {
-        let vis_pub = utils::syn::visibility_pub();
-
         let address = utils::ident::address();
         let env = utils::ident::env();
         let attached_value = utils::ident::attached_value();
@@ -29,12 +27,12 @@ impl TryFrom<&'_ ModuleImplIR> for HostRefStructItem {
         let ty_u512 = utils::ty::u512();
 
         let named_fields: syn::FieldsNamed = parse_quote!({
-            #vis_pub #address: #ty_address,
-            #vis_pub #env: #ty_host_env,
-            #vis_pub #attached_value: #ty_u512
+            #address: #ty_address,
+            #env: #ty_host_env,
+            #attached_value: #ty_u512
         });
         Ok(Self {
-            vis: vis_pub,
+            vis: utils::syn::visibility_pub(),
             struct_token: Default::default(),
             ident: module.host_ref_ident()?,
             fields: named_fields.into()
@@ -49,7 +47,13 @@ struct HostRefImplItem {
     #[syn(braced)]
     brace_token: syn::token::Brace,
     #[syn(in = brace_token)]
+    new_fn: NewFnItem,
+    #[syn(in = brace_token)]
     with_tokens_fn: WithTokensFnItem,
+    #[syn(in = brace_token)]
+    address_fn: AddressFnItem,
+    #[syn(in = brace_token)]
+    env_fn: EnvFnItem,
     #[syn(in = brace_token)]
     get_event_fn: GetEventFnItem,
     #[syn(in = brace_token)]
@@ -67,7 +71,10 @@ impl TryFrom<&'_ ModuleImplIR> for HostRefImplItem {
             impl_token: Default::default(),
             ref_ident: module.host_ref_ident()?,
             brace_token: Default::default(),
+            new_fn: NewFnItem,
             with_tokens_fn: WithTokensFnItem,
+            address_fn: AddressFnItem,
+            env_fn: EnvFnItem,
             get_event_fn: GetEventFnItem,
             last_call_fn: LastCallFnItem,
             functions: module
@@ -81,6 +88,30 @@ impl TryFrom<&'_ ModuleImplIR> for HostRefImplItem {
                 })
                 .collect()
         })
+    }
+}
+
+struct NewFnItem;
+
+impl ToTokens for NewFnItem {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let ty_address = utils::ty::address();
+        let ty_env = utils::ty::host_env();
+        let env = utils::ident::env();
+        let address = utils::ident::address();
+        let attached_value = utils::ident::attached_value();
+        let default = utils::expr::default();
+        let ty_self = utils::ty::_Self();
+
+        tokens.extend(quote!(
+            pub fn new(#address: #ty_address, #env: #ty_env) -> #ty_self {
+                #ty_self {
+                    #address,
+                    #env,
+                    #attached_value: #default
+                }
+            }
+        ));
     }
 }
 
@@ -104,6 +135,42 @@ impl ToTokens for WithTokensFnItem {
                     #env: #m_env.clone(),
                     #attached_value: tokens
                 }
+            }
+        ));
+    }
+}
+
+struct AddressFnItem;
+
+impl ToTokens for AddressFnItem {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let vis = utils::syn::visibility_pub();
+        let m_address = utils::member::address();
+        let ident = utils::ident::address();
+        let ty_address_ref = utils::ty::address_ref();
+        let ty_self_ref = utils::ty::self_ref();
+
+        tokens.extend(quote!(
+            #vis fn #ident(#ty_self_ref) -> #ty_address_ref {
+                &#m_address
+            }
+        ));
+    }
+}
+
+struct EnvFnItem;
+
+impl ToTokens for EnvFnItem {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let vis = utils::syn::visibility_pub();
+        let m_env = utils::member::env();
+        let ident = utils::ident::env();
+        let ret_ty = utils::ty::host_env();
+        let ty_self_ref = utils::ty::self_ref();
+
+        tokens.extend(quote!(
+            #vis fn #ident(#ty_self_ref) -> &#ret_ty {
+                &#m_env
             }
         ));
     }
@@ -164,18 +231,34 @@ mod ref_item_tests {
         let module = test_utils::mock::module_impl();
         let expected = quote! {
             pub struct Erc20HostRef {
-                pub address: odra::Address,
-                pub env: odra::HostEnv,
-                pub attached_value: odra::U512
+                address: odra::Address,
+                env: odra::HostEnv,
+                attached_value: odra::U512
             }
 
             impl Erc20HostRef {
+                pub fn new(address: odra::Address, env: odra::HostEnv) -> Self {
+                    Self {
+                        address,
+                        env,
+                        attached_value: Default::default()
+                    }
+                }
+
                 pub fn with_tokens(&self, tokens: odra::U512) -> Self {
                     Self {
                         address: self.address,
                         env: self.env.clone(),
                         attached_value: tokens
                     }
+                }
+
+                pub fn address(&self) -> &odra::Address {
+                    &self.address
+                }
+
+                pub fn env(&self) -> &odra::HostEnv {
+                    &self.env
                 }
 
                 pub fn get_event<T>(&self, index: i32) -> Result<T, odra::event::EventError>
@@ -269,18 +352,34 @@ mod ref_item_tests {
         let module = test_utils::mock::module_trait_impl();
         let expected = quote! {
             pub struct Erc20HostRef {
-                pub address: odra::Address,
-                pub env: odra::HostEnv,
-                pub attached_value: odra::U512
+                address: odra::Address,
+                env: odra::HostEnv,
+                attached_value: odra::U512
             }
 
             impl Erc20HostRef {
+                pub fn new(address: odra::Address, env: odra::HostEnv) -> Self {
+                    Self {
+                        address,
+                        env,
+                        attached_value: Default::default()
+                    }
+                }
+
                 pub fn with_tokens(&self, tokens: odra::U512) -> Self {
                     Self {
                         address: self.address,
                         env: self.env.clone(),
                         attached_value: tokens
                     }
+                }
+
+                pub fn address(&self) -> &odra::Address {
+                    &self.address
+                }
+
+                pub fn env(&self) -> &odra::HostEnv {
+                    &self.env
                 }
 
                 pub fn get_event<T>(&self, index: i32) -> Result<T, odra::event::EventError>
@@ -346,18 +445,34 @@ mod ref_item_tests {
         let module = test_utils::mock::module_delegation();
         let expected = quote! {
             pub struct Erc20HostRef {
-                pub address: odra::Address,
-                pub env: odra::HostEnv,
-                pub attached_value: odra::U512
+                address: odra::Address,
+                env: odra::HostEnv,
+                attached_value: odra::U512
             }
 
             impl Erc20HostRef {
+                pub fn new(address: odra::Address, env: odra::HostEnv) -> Self {
+                    Self {
+                        address,
+                        env,
+                        attached_value: Default::default()
+                    }
+                }
+
                 pub fn with_tokens(&self, tokens: odra::U512) -> Self {
                     Self {
                         address: self.address,
                         env: self.env.clone(),
                         attached_value: tokens
                     }
+                }
+
+                pub fn address(&self) -> &odra::Address {
+                    &self.address
+                }
+
+                pub fn env(&self) -> &odra::HostEnv {
+                    &self.env
                 }
 
                 pub fn get_event<T>(&self, index: i32) -> Result<T, odra::event::EventError>

--- a/odra-macros/src/ast/host_ref_item.rs
+++ b/odra-macros/src/ast/host_ref_item.rs
@@ -78,7 +78,7 @@ impl TryFrom<&'_ ModuleImplIR> for HostRefImplItem {
             get_event_fn: GetEventFnItem,
             last_call_fn: LastCallFnItem,
             functions: module
-                .host_functions()
+                .host_functions()?
                 .iter()
                 .flat_map(|f| {
                     vec![

--- a/odra-macros/src/ast/module_item.rs
+++ b/odra-macros/src/ast/module_item.rs
@@ -107,7 +107,11 @@ impl From<&'_ EnumeratedTypedField> for ModuleFieldItem {
             let_token: Default::default(),
             ident: field.ident.clone(),
             assign_token: Default::default(),
-            field_expr: utils::expr::new_type(&field.ty, &utils::ident::env(), field.idx),
+            field_expr: utils::expr::module_component_instnace(
+                &field.ty,
+                &utils::ident::env(),
+                field.idx
+            ),
             semi_token: Default::default()
         }
     }
@@ -221,11 +225,30 @@ mod test {
 
                 impl odra::Module for CounterPack {
                     fn new(env: Rc<odra::ContractEnv>) -> Self {
-                        let counter0 = ModuleWrapper::new(Rc::clone(&env), 0u8);
-                        let counter1 = ModuleWrapper::new(Rc::clone(&env), 1u8);
-                        let counter2 = ModuleWrapper::new(Rc::clone(&env), 2u8);
-                        let counters = Variable::new(Rc::clone(&env), 3u8);
-                        let counters_map = Mapping::new(Rc::clone(&env), 4u8);
+                        let counter0 =
+                            <ModuleWrapper<Counter> as odra::module::ModuleComponent>::instance(
+                                Rc::clone(&env),
+                                0u8
+                            );
+                        let counter1 =
+                            <ModuleWrapper<Counter> as odra::module::ModuleComponent>::instance(
+                                Rc::clone(&env),
+                                1u8
+                            );
+                        let counter2 =
+                            <ModuleWrapper<Counter> as odra::module::ModuleComponent>::instance(
+                                Rc::clone(&env),
+                                2u8
+                            );
+                        let counters = <Variable<u32> as odra::module::ModuleComponent>::instance(
+                            Rc::clone(&env),
+                            3u8
+                        );
+                        let counters_map =
+                            <Mapping<u8, Counter> as odra::module::ModuleComponent>::instance(
+                                Rc::clone(&env),
+                                4u8
+                            );
                         Self {
                             counter0,
                             counter1,

--- a/odra-macros/src/ast/ref_item.rs
+++ b/odra-macros/src/ast/ref_item.rs
@@ -22,8 +22,8 @@ impl TryFrom<&'_ ModuleImplIR> for ContractRefStructItem {
         let ty_address = utils::ty::address();
         let ty_contract_env = utils::ty::contract_env();
         let named_fields: syn::FieldsNamed = parse_quote!({
-            pub #env: Rc<#ty_contract_env>,
-            pub #address: #ty_address,
+            #env: Rc<#ty_contract_env>,
+            #address: #ty_address,
         });
 
         Ok(Self {
@@ -133,8 +133,8 @@ mod ref_item_tests {
         let module = test_utils::mock::module_impl();
         let expected = quote! {
             pub struct Erc20ContractRef {
-                pub env: Rc<odra::ContractEnv>,
-                pub address: odra::Address,
+                env: Rc<odra::ContractEnv>,
+                address: odra::Address,
             }
 
             impl Erc20ContractRef {
@@ -142,7 +142,6 @@ mod ref_item_tests {
                     Self { env, address }
                 }
 
-                // TODO: this means "address", can't be entrypoint name.
                 pub fn address(&self) -> &odra::Address {
                     &self.address
                 }
@@ -214,8 +213,8 @@ mod ref_item_tests {
         let module = test_utils::mock::module_trait_impl();
         let expected = quote! {
             pub struct Erc20ContractRef {
-                pub env: Rc<odra::ContractEnv>,
-                pub address: odra::Address,
+                env: Rc<odra::ContractEnv>,
+                address: odra::Address,
             }
 
             impl Erc20ContractRef {
@@ -223,7 +222,6 @@ mod ref_item_tests {
                     Self { env, address }
                 }
 
-                // TODO: this means "address", can't be entrypoint name.
                 pub fn address(&self) -> &odra::Address {
                     &self.address
                 }
@@ -265,8 +263,8 @@ mod ref_item_tests {
         let module = test_utils::mock::module_delegation();
         let expected = quote! {
             pub struct Erc20ContractRef {
-                pub env: Rc<odra::ContractEnv>,
-                pub address: odra::Address,
+                env: Rc<odra::ContractEnv>,
+                address: odra::Address,
             }
 
             impl Erc20ContractRef {
@@ -274,7 +272,6 @@ mod ref_item_tests {
                     Self { env, address }
                 }
 
-                // TODO: this means "address", can't be entrypoint name.
                 pub fn address(&self) -> &odra::Address {
                     &self.address
                 }

--- a/odra-macros/src/ast/ref_item.rs
+++ b/odra-macros/src/ast/ref_item.rs
@@ -107,7 +107,7 @@ impl TryFrom<&'_ ModuleImplIR> for ContractRefImplItem {
             new_fn: NewFnItem::new(),
             address_fn: AddressFnItem::new(),
             functions: module
-                .functions()
+                .functions()?
                 .iter()
                 .map(ref_utils::contract_function_item)
                 .collect()

--- a/odra-macros/src/ast/test_parts.rs
+++ b/odra-macros/src/ast/test_parts.rs
@@ -82,18 +82,34 @@ mod test {
                 use odra::prelude::*;
 
                 pub struct Erc20HostRef {
-                    pub address: odra::Address,
-                    pub env: odra::HostEnv,
-                    pub attached_value: odra::U512
+                    address: odra::Address,
+                    env: odra::HostEnv,
+                    attached_value: odra::U512
                 }
 
                 impl Erc20HostRef {
+                    pub fn new(address: odra::Address, env: odra::HostEnv) -> Self {
+                        Self {
+                            address,
+                            env,
+                            attached_value: Default::default()
+                        }
+                    }
+
                     pub fn with_tokens(&self, tokens: odra::U512) -> Self {
                         Self {
                             address: self.address,
                             env: self.env.clone(),
                             attached_value: tokens
                         }
+                    }
+
+                    pub fn address(&self) -> &odra::Address {
+                        &self.address
+                    }
+
+                    pub fn env(&self) -> &odra::HostEnv {
+                        &self.env
                     }
 
                     pub fn get_event<T>(&self, index: i32) -> Result<T, odra::event::EventError>
@@ -230,18 +246,34 @@ mod test {
                 use odra::prelude::*;
 
                 pub struct Erc20HostRef {
-                    pub address: odra::Address,
-                    pub env: odra::HostEnv,
-                    pub attached_value: odra::U512
+                    address: odra::Address,
+                    env: odra::HostEnv,
+                    attached_value: odra::U512
                 }
 
                 impl Erc20HostRef {
+                    pub fn new(address: odra::Address, env: odra::HostEnv) -> Self {
+                        Self {
+                            address,
+                            env,
+                            attached_value: Default::default()
+                        }
+                    }
+
                     pub fn with_tokens(&self, tokens: odra::U512) -> Self {
                         Self {
                             address: self.address,
                             env: self.env.clone(),
                             attached_value: tokens
                         }
+                    }
+
+                    pub fn address(&self) -> &odra::Address {
+                        &self.address
+                    }
+
+                    pub fn env(&self) -> &odra::HostEnv {
+                        &self.env
                     }
 
                     pub fn get_event<T>(&self, index: i32) -> Result<T, odra::event::EventError>

--- a/odra-macros/src/ast/test_parts.rs
+++ b/odra-macros/src/ast/test_parts.rs
@@ -194,21 +194,23 @@ mod test {
                             match call_def.method() {
                                 "init" => {
                                     let result = execute_init(contract_env);
-                                    odra::ToBytes::to_bytes(&result).map(Into::into).unwrap()
+                                    odra::ToBytes::to_bytes(&result).map(Into::into).map_err(|err| odra::OdraError::ExecutionError(err.into()))
                                 }
                                 "total_supply" => {
                                     let result = execute_total_supply(contract_env);
-                                    odra::ToBytes::to_bytes(&result).map(Into::into).unwrap()
+                                    odra::ToBytes::to_bytes(&result).map(Into::into).map_err(|err| odra::OdraError::ExecutionError(err.into()))
                                 }
                                 "pay_to_mint" => {
                                     let result = execute_pay_to_mint(contract_env);
-                                    odra::ToBytes::to_bytes(&result).map(Into::into).unwrap()
+                                    odra::ToBytes::to_bytes(&result).map(Into::into).map_err(|err| odra::OdraError::ExecutionError(err.into()))
                                 }
                                 "approve" => {
                                     let result = execute_approve(contract_env);
-                                    odra::ToBytes::to_bytes(&result).map(Into::into).unwrap()
+                                    odra::ToBytes::to_bytes(&result).map(Into::into).map_err(|err| odra::OdraError::ExecutionError(err.into()))
                                 }
-                                _ => panic!("Unknown method")
+                                name => Err(odra::OdraError::VmError(
+                                    odra::VmError::NoSuchMethod(odra::prelude::String::from(name))
+                                ))
                             }
                         });
 
@@ -336,13 +338,15 @@ mod test {
                             match call_def.method() {
                                 "total_supply" => {
                                     let result = execute_total_supply(contract_env);
-                                    odra::ToBytes::to_bytes(&result).map(Into::into).unwrap()
+                                    odra::ToBytes::to_bytes(&result).map(Into::into).map_err(|err| odra::OdraError::ExecutionError(err.into()))
                                 }
                                 "pay_to_mint" => {
                                     let result = execute_pay_to_mint(contract_env);
-                                    odra::ToBytes::to_bytes(&result).map(Into::into).unwrap()
+                                    odra::ToBytes::to_bytes(&result).map(Into::into).map_err(|err| odra::OdraError::ExecutionError(err.into()))
                                 }
-                                _ => panic!("Unknown method")
+                                name => Err(odra::OdraError::VmError(
+                                    odra::VmError::NoSuchMethod(odra::prelude::String::from(name)),
+                                ))
                             }
                         });
 

--- a/odra-macros/src/ast/wasm_parts.rs
+++ b/odra-macros/src/ast/wasm_parts.rs
@@ -49,7 +49,7 @@ impl TryFrom<&'_ ModuleImplIR> for WasmPartsModuleItem {
             entry_points_fn: module.try_into()?,
             call_fn: module.try_into()?,
             entry_points: module
-                .functions()
+                .functions()?
                 .iter()
                 .map(TryInto::try_into)
                 .collect::<Result<Vec<_>, _>>()?
@@ -86,7 +86,7 @@ impl TryFrom<&'_ ModuleImplIR> for EntryPointsFnItem {
             braces: Default::default(),
             var_declaration: parse_quote!(let mut #ident_entry_points = #expr_entry_points;),
             items: module
-                .functions()
+                .functions()?
                 .iter()
                 .map(TryInto::try_into)
                 .collect::<Result<Vec<_>, _>>()?,

--- a/odra-macros/src/ir/mod.rs
+++ b/odra-macros/src/ir/mod.rs
@@ -233,7 +233,7 @@ impl ModuleImplIR {
         ))
     }
 
-    pub fn exec_parts_mod_ident(&self) -> Result<syn::Ident, syn::Error> {
+    pub fn exec_parts_mod_ident(&self) -> syn::Result<syn::Ident> {
         let module_ident = self.snake_cased_module_ident()?;
         Ok(Ident::new(
             &format!("__{}_exec_parts", module_ident),
@@ -241,15 +241,17 @@ impl ModuleImplIR {
         ))
     }
 
-    pub fn host_functions(&self) -> Vec<FnIR> {
-        self.functions()
+    pub fn host_functions(&self) -> syn::Result<Vec<FnIR>> {
+        Ok(self
+            .functions()?
             .into_iter()
             .filter(|f| f.name_str() != CONSTRUCTOR_NAME)
-            .collect()
+            .collect())
     }
 
     pub fn constructor(&self) -> Option<FnIR> {
         self.functions()
+            .unwrap_or_default()
             .into_iter()
             .find(|f| f.name_str() == CONSTRUCTOR_NAME)
     }
@@ -265,7 +267,7 @@ impl ModuleImplIR {
             .unwrap_or_default()
     }
 
-    pub fn functions(&self) -> Vec<FnIR> {
+    pub fn functions(&self) -> syn::Result<Vec<FnIR>> {
         match self {
             ModuleImplIR::Impl(ir) => ir.functions(),
             ModuleImplIR::Trait(ir) => ir.functions()
@@ -297,7 +299,7 @@ impl ModuleIR {
         code
     }
 
-    fn functions(&self) -> Vec<FnIR> {
+    fn functions(&self) -> syn::Result<Vec<FnIR>> {
         self.code
             .items
             .clone()
@@ -307,9 +309,9 @@ impl ModuleIR {
                 _ => None
             })
             .chain(self.delegated_functions().unwrap_or_default())
-            .map(FnIR::from)
-            .filter(|f| self.is_trait_impl() || f.is_pub())
-            .collect::<Vec<_>>()
+            .map(FnIR::try_from)
+            .filter(|r| self.is_trait_impl() || r.as_ref().map(FnIR::is_pub).unwrap_or(true))
+            .collect::<Result<Vec<_>, _>>()
     }
 
     fn delegated_functions(&self) -> syn::Result<Vec<syn::ImplItemFn>> {
@@ -346,15 +348,15 @@ impl ModuleTraitIR {
         self.code.ident.clone()
     }
 
-    fn functions(&self) -> Vec<FnIR> {
+    fn functions(&self) -> syn::Result<Vec<FnIR>> {
         self.code
             .items
             .iter()
             .filter_map(|item| match item {
-                syn::TraitItem::Fn(func) => Some(FnIR::from(func.clone())),
+                syn::TraitItem::Fn(func) => Some(FnIR::try_from(func.clone())),
                 _ => None
             })
-            .collect::<Vec<_>>()
+            .collect()
     }
 }
 
@@ -363,15 +365,35 @@ pub enum FnIR {
     Def(FnTraitIR)
 }
 
-impl From<syn::TraitItemFn> for FnIR {
-    fn from(code: syn::TraitItemFn) -> Self {
-        Self::Def(FnTraitIR::new(code))
+const PROTECTED_FUNCTIONS: [&str; 3] = ["new", "env", "address"];
+
+fn validate_fn_name<T: ToTokens>(name: &str, ctx: T) -> Result<(), syn::Error> {
+    if PROTECTED_FUNCTIONS.contains(&name) {
+        return Err(syn::Error::new_spanned(
+            ctx,
+            format!("Entrypoint name `{}` is reserved", name)
+        ));
+    }
+    Ok(())
+}
+
+impl TryFrom<syn::TraitItemFn> for FnIR {
+    type Error = syn::Error;
+
+    fn try_from(code: syn::TraitItemFn) -> Result<Self, Self::Error> {
+        let fn_name = utils::syn::function_name(&code.sig);
+        validate_fn_name(&fn_name, &code)?;
+        Ok(Self::Def(FnTraitIR::new(code)))
     }
 }
 
-impl From<syn::ImplItemFn> for FnIR {
-    fn from(code: syn::ImplItemFn) -> Self {
-        Self::Impl(FnImplIR::new(code))
+impl TryFrom<syn::ImplItemFn> for FnIR {
+    type Error = syn::Error;
+
+    fn try_from(code: syn::ImplItemFn) -> Result<Self, Self::Error> {
+        let fn_name = utils::syn::function_name(&code.sig);
+        validate_fn_name(&fn_name, &code)?;
+        Ok(Self::Impl(FnImplIR::new(code)))
     }
 }
 

--- a/odra-macros/src/utils/expr.rs
+++ b/odra-macros/src/utils/expr.rs
@@ -15,9 +15,10 @@ pub fn parse_bytes(data_ident: &syn::Ident) -> syn::Expr {
     parse_quote!(odra::ToBytes::to_bytes(&#data_ident).map(Into::into).unwrap())
 }
 
-pub fn new_type(ty: &syn::Type, env_ident: &syn::Ident, idx: u8) -> syn::Expr {
+pub fn module_component_instnace(ty: &syn::Type, env_ident: &syn::Ident, idx: u8) -> syn::Expr {
     let rc = rc_clone(env_ident);
-    parse_quote!(#ty::new(#rc, #idx))
+    let component = super::ty::module_component();
+    parse_quote!(<#ty as #component>::instance(#rc, #idx))
 }
 
 fn rc_clone(ident: &syn::Ident) -> syn::Expr {

--- a/odra-macros/src/utils/expr.rs
+++ b/odra-macros/src/utils/expr.rs
@@ -163,6 +163,10 @@ pub fn btree_from_iter(expr: &syn::Expr) -> syn::Expr {
     parse_quote!(odra::prelude::BTreeMap::from_iter(#expr))
 }
 
+pub fn default() -> syn::Expr {
+    parse_quote!(Default::default())
+}
+
 pub trait IntoExpr {
     fn into_expr(self) -> syn::Expr;
 }

--- a/odra-macros/src/utils/expr.rs
+++ b/odra-macros/src/utils/expr.rs
@@ -12,7 +12,9 @@ pub fn u512_zero() -> syn::Expr {
 }
 
 pub fn parse_bytes(data_ident: &syn::Ident) -> syn::Expr {
-    parse_quote!(odra::ToBytes::to_bytes(&#data_ident).map(Into::into).unwrap())
+    let ty = super::ty::to_bytes();
+    let ty_err = super::ty::odra_error();
+    parse_quote!(#ty::to_bytes(&#data_ident).map(Into::into).map_err(|err| #ty_err::ExecutionError(err.into())))
 }
 
 pub fn module_component_instnace(ty: &syn::Type, env_ident: &syn::Ident, idx: u8) -> syn::Expr {

--- a/odra-macros/src/utils/string.rs
+++ b/odra-macros/src/utils/string.rs
@@ -1,13 +1,8 @@
 use convert_case::{Boundary, Case, Casing};
-use quote::ToTokens;
 
 pub fn camel_to_snake<T: ToString>(text: T) -> String {
     text.to_string()
         .from_case(Case::UpperCamel)
         .without_boundaries(&[Boundary::UpperDigit, Boundary::LowerDigit])
         .to_case(Case::Snake)
-}
-
-pub fn eq<A: ToTokens, B: ToTokens>(a: A, b: B) -> bool {
-    a.to_token_stream().to_string() == b.to_token_stream().to_string()
 }

--- a/odra-macros/src/utils/syn.rs
+++ b/odra-macros/src/utils/syn.rs
@@ -149,16 +149,6 @@ pub fn last_segment_ident(ty: &syn::Type) -> syn::Result<syn::Ident> {
     }
 }
 
-pub fn clear_generics(ty: &syn::Type) -> syn::Result<syn::Type> {
-    match ty {
-        syn::Type::Path(type_path) => clear_path(type_path).map(syn::Type::Path),
-        ty => Err(syn::Error::new(
-            ty.span(),
-            "Only support impl for type path"
-        ))
-    }
-}
-
 // A path like <Option::<U256> as odra::casper_types::CLTyped>
 pub fn as_casted_ty_stream(ty: &syn::Type, as_ty: syn::Type) -> TokenStream {
     let ty = match ty {
@@ -196,17 +186,4 @@ pub fn unreferenced_ty(ty: &syn::Type) -> syn::Type {
         syn::Type::Reference(syn::TypeReference { elem, .. }) => *elem.clone(),
         _ => ty.clone()
     }
-}
-
-fn clear_path(ty: &syn::TypePath) -> syn::Result<syn::TypePath> {
-    let mut owned_ty = ty.to_owned();
-
-    let mut segment = owned_ty
-        .path
-        .segments
-        .last_mut()
-        .ok_or(syn::Error::new(ty.span(), "Invalid type path"))?;
-    segment.arguments = syn::PathArguments::None;
-
-    Ok(owned_ty)
 }

--- a/odra-macros/src/utils/syn.rs
+++ b/odra-macros/src/utils/syn.rs
@@ -9,6 +9,10 @@ pub fn ident_from_struct(struct_code: &syn::ItemStruct) -> syn::Ident {
     struct_code.ident.clone()
 }
 
+pub fn function_name(sig: &syn::Signature) -> String {
+    sig.ident.to_string()
+}
+
 pub fn function_arg_names(sig: &syn::Signature) -> Vec<syn::Ident> {
     sig.inputs
         .iter()

--- a/odra-macros/src/utils/ty.rs
+++ b/odra-macros/src/utils/ty.rs
@@ -61,20 +61,8 @@ pub fn odra_error() -> syn::Type {
     parse_quote!(odra::OdraError)
 }
 
-pub fn module_wrapper() -> syn::Type {
-    parse_quote!(odra::ModuleWrapper)
-}
-
 pub fn module() -> syn::Type {
     parse_quote!(odra::Module)
-}
-
-pub fn variable() -> syn::Type {
-    parse_quote!(odra::Variable)
-}
-
-pub fn mapping() -> syn::Type {
-    parse_quote!(odra::Mapping)
 }
 
 pub fn entry_points() -> syn::Type {
@@ -235,4 +223,8 @@ pub fn typed_btree_map(key: &syn::Type, value: &syn::Type) -> syn::Type {
 
 pub fn btree_map() -> syn::Type {
     parse_quote!(odra::prelude::BTreeMap)
+}
+
+pub fn module_component() -> syn::Type {
+    parse_quote!(odra::module::ModuleComponent)
 }

--- a/odra-vm/src/vm/contract_container.rs
+++ b/odra-vm/src/vm/contract_container.rs
@@ -15,6 +15,7 @@ pub type EntrypointArgs = Vec<String>;
 #[derive(Clone)]
 pub struct ContractContainer {
     name: String,
+
     entry_points_caller: EntryPointsCaller
 }
 
@@ -27,36 +28,16 @@ impl ContractContainer {
     }
 
     pub fn call(&self, call_def: CallDef) -> Result<Bytes, OdraError> {
-        Ok(self.entry_points_caller.call(call_def))
-        // TODO: Restore validate_args
-        //     if self.constructors.get(&entrypoint).is_some() {
-        //         return Err(OdraError::VmError(VmError::InvalidContext));
-        //     }
-        //
-        //     match self.entrypoints.get(&entrypoint) {
-        //         Some((ep_args, call)) => {
-        //             self.validate_args(ep_args, args)?;
-        //             Ok(call(self.name.clone(), args))
-        //         }
-        //         None => Err(OdraError::VmError(VmError::NoSuchMethod(entrypoint)))
-        //     }
-        // }
-        //
-        // pub fn call_constructor(
-        //     &self,
-        //     entrypoint: String,
-        //     args: &RuntimeArgs
-        // ) -> Result<Vec<u8>, OdraError> {
-        //     match self.constructors.get(&entrypoint) {
-        //         Some((ep_args, call)) => {
-        //             self.validate_args(ep_args, args)?;
-        //             Ok(call(self.name.clone(), args))
-        //         }
-        //         None => Err(OdraError::VmError(VmError::NoSuchMethod(entrypoint)))
-        //     }
+        // TODO: Restore validate_args - to do so, we need to know names of all args.
+        // The current structure of ContractContainer doesn't allow that - we do not store the required args names.
+        // It makes impossible to mimic the behavior of the CasperVm
+
+        // let registered_args = vec![];
+        // self.validate_args(&registered_args, call_def.args())?;
+        self.entry_points_caller.call(call_def)
     }
 
-    fn _validate_args(&self, args: &[String], input_args: &RuntimeArgs) -> Result<(), OdraError> {
+    fn validate_args(&self, args: &[String], input_args: &RuntimeArgs) -> Result<(), OdraError> {
         // TODO: What's the purpose of this code? Is it needed?
         let named_args = input_args
             .named_args()

--- a/odra-vm/src/vm/contract_register.rs
+++ b/odra-vm/src/vm/contract_register.rs
@@ -16,30 +16,9 @@ impl ContractRegister {
     }
 
     pub fn call(&self, addr: &Address, call_def: CallDef) -> Result<Bytes, OdraError> {
-        // todo: make it better
-        self.contracts.get(addr).unwrap().call(call_def)
+        if let Some(contract) = self.contracts.get(addr) {
+            return contract.call(call_def);
+        }
+        Err(OdraError::VmError(VmError::InvalidContractAddress))
     }
-
-    // pub fn call_constructor(
-    //     &self,
-    //     addr: &Address,
-    //     entrypoint: String,
-    //     args: &RuntimeArgs
-    // ) -> Result<Vec<u8>, OdraError> {
-    //     self.internal_call(addr, |container| {
-    //         container.call_constructor(entrypoint, args)
-    //     })
-    // }
-    //
-    // fn internal_call<F: FnOnce(&ContractContainer) -> Result<Vec<u8>, OdraError>>(
-    //     &self,
-    //     addr: &Address,
-    //     call_fn: F
-    // ) -> Result<Vec<u8>, OdraError> {
-    //     let contract = self.contracts.get(addr);
-    //     match contract {
-    //         Some(container) => call_fn(container),
-    //         None => Err(OdraError::VmError(VmError::InvalidContractAddress))
-    //     }
-    // }
 }

--- a/odra-vm/src/vm/odra_vm.rs
+++ b/odra-vm/src/vm/odra_vm.rs
@@ -66,7 +66,6 @@ impl OdraVm {
                 self.revert(err);
             }
         }
-
         let result = self
             .contract_register
             .read()


### PR DESCRIPTION
1. Add `ModuleComponent` trait to unify module creation. It replaces the `by convention` approach with `by interface`. It helps present a more precise error message while defining a module for the user.
2. Update HostEnv/ContractEnv interfaces: fields are private, created by calling a `new` function, implement `address()` and `env()`.
3. Validate entry point names: identifiers `new, `env`, and `address`  cannot be used as an entry point name.
All the above resolve #274 . The proposed solution (using static_assertions crate) would not work (or rather wouldn't be the best) because it would require reexporting some macros and adding dependencies that are not necessary.
4. Fix error handling inside OdraVM which resolves #298 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new `ModuleComponent` trait for improved modularity.
  - Added a `Result` type for better error handling in entry point callbacks.
  - Implemented new public methods for external contract references.

- **Improvements**
  - Enhanced token transfer operations in ERC1155 and ERC721 modules.
  - Refined error propagation in macro utilities and virtual machine components.
  - Streamlined instance creation for module components.

- **Refactor**
  - Updated struct declarations to conform to new trait requirements.
  - Removed redundant `HasEvents` implementations.
  - Consolidated variable and mapping struct methods.
  - Refactored `ContractRegister` to handle invalid addresses more gracefully.

- **Bug Fixes**
  - Fixed method calls and references in ERC20 examples to align with updated codebase.
  - Corrected error handling in deployer utility macros.

- **Documentation**
  - Added comments to clarify contract container method changes.

- **Style**
  - Removed unused imports and functions from macro utilities.
  - Cleaned up visibility specifiers in macro-generated code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->