### PR TITLE
Allow running cargo test without --lib

### DIFF
--- a/examples2/Cargo.toml
+++ b/examples2/Cargo.toml
@@ -9,10 +9,12 @@ odra = { path = "../odra" }
 [[bin]]
 name = "build_contract"
 path = "bin/build_contract.rs"
+test = false
 
 [[bin]]
 name = "build_schema"
 path = "bin/build_schema.rs"
+test = false
 
 [profile.release]
 codegen-units = 1

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -17,10 +17,12 @@ hex = { version = "0.4.3", default-features = false }
 [[bin]]
 name = "build_contract"
 path = "bin/build_contract.rs"
+test = false
 
 [[bin]]
 name = "build_schema"
 path = "bin/build_schema.rs"
+test = false
 
 [profile.release]
 codegen-units = 1

--- a/templates/blank/Cargo.toml
+++ b/templates/blank/Cargo.toml
@@ -9,10 +9,12 @@ edition = "2021"
 [[bin]]
 name = "build_contract"
 path = "bin/build_contract.rs"
+test = false
 
 [[bin]]
 name = "build_schema"
 path = "bin/build_schema.rs"
+test = false
 
 [profile.release]
 codegen-units = 1

--- a/templates/full/Cargo.toml
+++ b/templates/full/Cargo.toml
@@ -9,10 +9,12 @@ edition = "2021"
 [[bin]]
 name = "build_contract"
 path = "bin/build_contract.rs"
+test = false
 
 [[bin]]
 name = "build_schema"
 path = "bin/build_schema.rs"
+test = false
 
 [profile.release]
 codegen-units = 1

--- a/templates/full/src/flipper.rs
+++ b/templates/full/src/flipper.rs
@@ -1,5 +1,5 @@
 use odra::prelude::*;
-use odra::{Module, Variable, ContractEnv};
+use odra::Variable;
 
 /// A module definition. Each module struct consists Variables and Mappings
 /// or/and another modules.


### PR DESCRIPTION
Turn off tests for odra project's bins to allow running `cargo test` without `--lib`
Remove unused imports in template's flipper.rs
Closes: 306

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified imports in the flipper module for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->