### PR TITLE
Use snake case when locating wasm files - makes cargo odra so much

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ casper-contract = { version = "3.0.0", default-features = false }
 casper-types = { version = "3.0.0", default-features = false }
 casper-execution-engine = "5.0.0"
 casper-event-standard = "0.4.1"
+convert_case = "0.6.0"

--- a/odra-casper/test-vm/Cargo.toml
+++ b/odra-casper/test-vm/Cargo.toml
@@ -14,6 +14,7 @@ repository = { workspace = true }
 casper-engine-test-support = { version = "5.0.0", features = ["test-support"] }
 casper-execution-engine = { workspace = true }
 odra-core = { path = "../../core" }
+convert_case = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 casper-contract = { workspace = true }

--- a/odra-casper/test-vm/src/vm/casper_vm.rs
+++ b/odra-casper/test-vm/src/vm/casper_vm.rs
@@ -1,3 +1,4 @@
+use convert_case::{Boundary, Case, Casing};
 use odra_core::consts::*;
 use odra_core::prelude::*;
 use std::cell::RefCell;
@@ -267,7 +268,11 @@ impl CasperVm {
         init_args: Option<RuntimeArgs>,
         entry_points_caller: Option<EntryPointsCaller>
     ) -> Address {
-        let wasm_path = format!("{}.wasm", name);
+        let snake_case_name = name
+            .from_case(Case::UpperCamel)
+            .without_boundaries(&[Boundary::UpperDigit, Boundary::LowerDigit])
+            .to_case(Case::Snake);
+        let wasm_path = format!("{}.wasm", snake_case_name);
         let package_hash_key_name = format!("{}_package_hash", name);
         let mut args = init_args.clone().unwrap_or(runtime_args! {});
         args.insert(PACKAGE_HASH_KEY_NAME_ARG, package_hash_key_name.clone())

--- a/odra-macros/Cargo.toml
+++ b/odra-macros/Cargo.toml
@@ -15,7 +15,7 @@ proc-macro2 = "1.0.69"
 quote = "1.0.33"
 syn = { version = "2.0.29", features = ["full", "extra-traits"] }
 syn_derive = "0.1.8"
-convert_case = { version = "0.5.0" }
+convert_case = { workspace = true }
 derive-try-from ={ path = "../try-from-macro" }
 derive_more = "0.99.17"
 itertools = "0.12.0"


### PR DESCRIPTION
easier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved naming convention consistency by automatically converting input names to snake_case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->