### PR TITLE
Enabled missing docs lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Changelog for `odra`.
 
+## [0.9.0] - 2024-XX-XX
+### Added
+- `ContractRef` trait with `new` and `address` functions. All contract references now implement it.
+
+### Changed
+- Traits implemented by modules are now also implemented by their `ContractRefs` and `HostRefs`.
+
 ## [0.8.0] - 2024-XX-XX
 
 ### Changed

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,3 +19,6 @@ serde_json = { workspace = true, default-features = false, features = ["alloc"] 
 
 [dev-dependencies]
 mockall = { version = "0.11.4" }
+
+[lints.rust]
+missing_docs = "warn"

--- a/core/src/arithmetic.rs
+++ b/core/src/arithmetic.rs
@@ -18,9 +18,9 @@ pub trait OverflowingSub: Sized {
 /// Computation result error.
 #[cfg_attr(debug_assertions, derive(Debug, PartialEq, Eq))]
 pub enum ArithmeticsError {
-    // Addition result exceeds the max value.
+    /// Addition result exceeds the max value.
     AdditionOverflow,
-    // Subtraction result is lower than the min value.
+    /// Subtraction result is lower than the min value.
     SubtractingOverflow
 }
 

--- a/core/src/contract_def.rs
+++ b/core/src/contract_def.rs
@@ -13,11 +13,17 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone)]
 #[cfg_attr(not(target_arch = "wasm32"), derive(Serialize, Deserialize))]
 pub struct Entrypoint {
+    /// The entrypoint's ident.
     pub ident: String,
+    /// The entrypoint's arguments.
     pub args: Vec<Argument>,
+    /// `true` if the entrypoint is mutable.
     pub is_mut: bool,
+    /// The entrypoint's return type.
     pub ret: CLType,
+    /// The entrypoint's type.
     pub ty: EntrypointType,
+    /// The entrypoint's attributes.
     pub attributes: Vec<EntrypointAttribute>
 }
 
@@ -25,9 +31,13 @@ pub struct Entrypoint {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(not(target_arch = "wasm32"), derive(Serialize, Deserialize))]
 pub struct Argument {
+    /// The argument's ident.
     pub ident: String,
+    /// The argument's type.
     pub ty: CLType,
+    /// `true` if the argument is a reference.
     pub is_ref: bool,
+    /// `true` if the argument is a slice.
     pub is_slice: bool
 }
 
@@ -35,7 +45,9 @@ pub struct Argument {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(not(target_arch = "wasm32"), derive(Serialize, Deserialize))]
 pub struct Event {
+    /// The event's ident.
     pub ident: String,
+    /// The event's arguments.
     pub args: Vec<Argument>
 }
 
@@ -68,18 +80,20 @@ pub enum EntrypointAttribute {
 
 /// A trait that should be implemented by each smart contract to allow the backend.
 pub trait HasIdent {
+    /// Returns the contract's ident.
     fn ident() -> String;
 }
 
 /// A trait that should be implemented by each smart contract to allow the backend
 /// to generate blockchain-specific code.
 pub trait HasEntrypoints {
-    /// Returns an abstract contract definition.
+    /// Returns the list of contract's entrypoints.
     fn entrypoints() -> Vec<Entrypoint>;
 }
 
 /// A trait that should be implemented by each smart contract to allow the backend.
 pub trait HasEvents {
+    /// Returns a list of Events used by the contract.
     fn events() -> Vec<Event>;
 
     #[cfg(target_arch = "wasm32")]

--- a/core/src/contract_def.rs
+++ b/core/src/contract_def.rs
@@ -96,6 +96,7 @@ pub trait HasEvents {
     /// Returns a list of Events used by the contract.
     fn events() -> Vec<Event>;
 
+    /// Returns a map of event schemas used by the contract.
     #[cfg(target_arch = "wasm32")]
     fn event_schemas() -> crate::prelude::BTreeMap<String, casper_event_standard::Schema> {
         crate::prelude::BTreeMap::new()

--- a/core/src/contract_env.rs
+++ b/core/src/contract_env.rs
@@ -11,6 +11,14 @@ const INDEX_SIZE: usize = 4;
 const KEY_LEN: usize = 64;
 pub(crate) type StorageKey = [u8; KEY_LEN];
 
+/// Trait that needs to be implemented by all contract refs.
+pub trait ContractRef {
+    /// Creates a new instance of the Contract Ref.
+    fn new(env: Rc<ContractEnv>, address: Address) -> Self;
+    /// Returns the address of the contract.
+    fn address(&self) -> &Address;
+}
+
 /// Represents the environment accessible in the contract context.
 ///
 /// The `ContractEnv` struct provides methods for interacting with the contract environment,

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -15,6 +15,7 @@ pub enum OdraError {
 }
 
 impl OdraError {
+    /// Returns the error code.
     pub fn code(&self) -> u16 {
         match self {
             OdraError::ExecutionError(e) => e.code(),
@@ -22,6 +23,7 @@ impl OdraError {
         }
     }
 
+    /// Creates a new user error with a given code.
     pub fn user(code: u16) -> Self {
         OdraError::ExecutionError(ExecutionError::User(code))
     }
@@ -76,36 +78,58 @@ impl From<casper_types::bytesrepr::Error> for ExecutionError {
 pub enum ExecutionError {
     /// Unwrap error
     UnwrapError = 1,
+    /// Addition overflow
     AdditionOverflow = 100,
+    /// Subtraction overflow
     SubtractionOverflow = 101,
     /// Method does not accept deposit
     NonPayable = 102,
     /// Can't transfer tokens to contract.
     TransferToContract = 103,
+    /// Reentrant call detected
     ReentrantCall = 104,
+    /// Contract already installed
     ContractAlreadyInstalled = 105,
+    /// Unknown constructor
     UnknownConstructor = 106,
+    /// Native transfer error
     NativeTransferError = 107,
+    /// Index out of bounds
     IndexOutOfBounds = 108,
+    /// Tried to construct a zero address.
     ZeroAddress = 109,
+    /// Address creation failed
     AddressCreationFailed = 110,
+    /// Early end of stream - deserialization error
     EarlyEndOfStream = 111,
+    /// Formatting error - deserialization error
     Formatting = 112,
+    /// Left over bytes - deserialization error
     LeftOverBytes = 113,
+    /// Out of memory
     OutOfMemory = 114,
+    /// Not representable
     NotRepresentable = 115,
+    /// Exceeded recursion depth
     ExceededRecursionDepth = 116,
+    /// Key not found
     KeyNotFound = 117,
+    /// Could not deserialize signature
     CouldNotDeserializeSignature = 118,
+    /// Type mismatch
     TypeMismatch = 119,
+    /// Could not sign message
     CouldNotSignMessage = 120,
+    /// Maximum code for user errors
     MaxUserError = 32767,
     /// User error too high. The code should be in range 0..32767.
     UserErrorTooHigh = 32768,
+    /// User error
     User(u16)
 }
 
 impl ExecutionError {
+    /// Returns the error code.
     pub fn code(&self) -> u16 {
         unsafe {
             match self {
@@ -155,7 +179,7 @@ pub enum VmError {
 
 /// Error that can occur while operating on a collection.
 pub enum CollectionError {
-    // The requested index is bigger than the max collection index.
+    /// The requested index is bigger than the max collection index.
     IndexOutOfBounds
 }
 

--- a/core/src/gas_report.rs
+++ b/core/src/gas_report.rs
@@ -15,11 +15,19 @@ pub type GasReport = Vec<DeployReport>;
 #[derive(Clone, Debug)]
 pub enum DeployReport {
     /// Represents a Wasm deploy.
-    WasmDeploy { gas: U512, file_name: String },
+    WasmDeploy {
+        /// The gas used for the deploy.
+        gas: U512,
+        /// The file name of the deployed WASM.
+        file_name: String
+    },
     /// Represents a contract call.
     ContractCall {
+        /// The gas used for the call.
         gas: U512,
+        /// The address of the contract called.
         contract_address: Address,
+        /// The call definition.
         call_def: CallDef
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc = "Core of the Odra Framework"]
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(test, feature(never_type))]
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -37,7 +37,7 @@ pub use call_result::ContractCallResult;
 pub use casper_event_standard;
 pub use contract_container::ContractContainer;
 pub use contract_context::ContractContext;
-pub use contract_env::{ContractEnv, ExecutionEnv};
+pub use contract_env::{ContractEnv, ContractRef, ExecutionEnv};
 pub use contract_register::ContractRegister;
 pub use error::{
     AddressError, CollectionError, EventError, ExecutionError, OdraError, OdraResult, VmError

--- a/core/src/list.rs
+++ b/core/src/list.rs
@@ -22,6 +22,7 @@ pub struct List<T> {
 }
 
 impl<T> List<T> {
+    /// Returns the ContractEnv.
     pub fn env(&self) -> ContractEnv {
         self.env.child(self.index)
     }

--- a/core/src/prelude.rs
+++ b/core/src/prelude.rs
@@ -6,6 +6,7 @@
 mod prelude {
     pub use crate::arithmetic::*;
     pub use crate::module::Module;
+    pub use crate::ContractRef;
     pub use alloc::borrow::ToOwned;
     pub use alloc::boxed::Box;
     pub use alloc::collections::*;

--- a/core/src/sequence.rs
+++ b/core/src/sequence.rs
@@ -47,6 +47,7 @@ where
 }
 
 impl<T: Num + One + Zero + Default + Copy + ToBytes + FromBytes + CLTyped> Sequence<T> {
+    /// Returns the ContractEnv.
     pub fn env(&self) -> ContractEnv {
         self.env.child(self.index)
     }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -45,3 +45,6 @@ lto = true
 
 [profile.dev.package."*"]
 opt-level = 3
+
+[lints.rust]
+missing_docs = "warn"

--- a/examples/bin/build_contract.rs
+++ b/examples/bin/build_contract.rs
@@ -1,3 +1,4 @@
+#![doc = "Binary for building wasm files from odra contracts."]
 #![no_std]
 #![no_main]
 #![allow(unused_imports, clippy::single_component_path_imports)]

--- a/examples/bin/build_schema.rs
+++ b/examples/bin/build_schema.rs
@@ -1,3 +1,4 @@
+#![doc = "Binary for building schema definitions from odra contracts."]
 #[allow(unused_imports, clippy::single_component_path_imports)]
 use odra_examples;
 

--- a/examples/build.rs
+++ b/examples/build.rs
@@ -1,5 +1,7 @@
+//! Odra's contracts build script.
 use std::env;
 
+/// Uses the ENV variable `ODRA_MODULE` to set the `odra_module` cfg flag.
 pub fn main() {
     println!("cargo:rerun-if-env-changed=ODRA_MODULE");
     let module = env::var("ODRA_MODULE").unwrap_or_else(|_| "".to_string());

--- a/examples/src/contracts/balance_checker.rs
+++ b/examples/src/contracts/balance_checker.rs
@@ -1,18 +1,23 @@
+//! Example of Balance Checker contract.
 use odra::prelude::*;
 use odra::{casper_types::U256, Address};
 
+/// BalanceChecker contract.
 #[odra::module]
 pub struct BalanceChecker;
 
 #[odra::module]
 impl BalanceChecker {
+    /// Checks the balance of the given account for the given token.
     pub fn check_balance(&self, token: &Address, account: &Address) -> U256 {
         TokenContractRef::new(self.env(), *token).balance_of(*account)
     }
 }
 
+/// Token contract interface.
 #[odra::external_contract]
 pub trait Token {
+    /// Returns the balance of the given account.
     fn balance_of(&self, owner: &Address) -> U256;
 }
 

--- a/examples/src/contracts/balance_checker.rs
+++ b/examples/src/contracts/balance_checker.rs
@@ -10,7 +10,7 @@ pub struct BalanceChecker;
 impl BalanceChecker {
     /// Checks the balance of the given account for the given token.
     pub fn check_balance(&self, token: &Address, account: &Address) -> U256 {
-        TokenContractRef::new(self.env(), *token).balance_of(*account)
+        TokenContractRef::new(self.env(), *token).balance_of(account)
     }
 }
 
@@ -37,11 +37,11 @@ mod tests {
         let expected_owner_balance = INITIAL_SUPPLY;
 
         // Owner of the token should have positive balance.
-        let balance = balance_checker.check_balance(*token.address(), owner);
+        let balance = balance_checker.check_balance(token.address(), &owner);
         assert_eq!(balance.as_u32(), expected_owner_balance);
 
         // Different account should have zero balance.
-        let balance = balance_checker.check_balance(*token.address(), second_account);
+        let balance = balance_checker.check_balance(token.address(), &second_account);
         assert!(balance.is_zero());
     }
 }

--- a/examples/src/contracts/mod.rs
+++ b/examples/src/contracts/mod.rs
@@ -1,3 +1,4 @@
+//! Module containing examples of contracts written in Odra.
 pub mod balance_checker;
 pub mod owned_token;
 pub mod tlw;

--- a/examples/src/contracts/owned_token.rs
+++ b/examples/src/contracts/owned_token.rs
@@ -11,6 +11,7 @@ pub struct OwnedToken {
 
 #[odra::module]
 impl OwnedToken {
+    /// Initializes the contract with the given parameters.
     pub fn init(&mut self, name: String, symbol: String, decimals: u8, initial_supply: U256) {
         self.ownable.init();
         self.erc20
@@ -36,6 +37,7 @@ impl OwnedToken {
         }
     }
 
+    /// Mints new tokens and assigns them to the given address.
     pub fn mint(&mut self, address: &Address, amount: &U256) {
         self.ownable.assert_owner(&self.env().caller());
         self.erc20.mint(address, amount);

--- a/examples/src/contracts/owned_token.rs
+++ b/examples/src/contracts/owned_token.rs
@@ -1,8 +1,10 @@
+//! An example of a OwnedToken contract.
 use odra::prelude::*;
 use odra::{casper_types::U256, Address, SubModule};
 use odra_modules::access::Ownable;
 use odra_modules::erc20::Erc20;
 
+/// OwnedToken contract.
 #[odra::module]
 pub struct OwnedToken {
     ownable: SubModule<Ownable>,

--- a/examples/src/contracts/owned_token.rs
+++ b/examples/src/contracts/owned_token.rs
@@ -75,7 +75,7 @@ pub mod tests {
         assert_eq!(token.symbol(), SYMBOL);
         assert_eq!(token.decimals(), DECIMALS);
         assert_eq!(token.total_supply(), INITIAL_SUPPLY.into());
-        assert_eq!(token.balance_of(owner), INITIAL_SUPPLY.into());
+        assert_eq!(token.balance_of(&owner), INITIAL_SUPPLY.into());
         test_env.emitted_event(
             token.address(),
             &odra_modules::access::events::OwnershipTransferred {
@@ -98,9 +98,9 @@ pub mod tests {
         let mut token = setup();
         let recipient = token.env().get_account(1);
         let amount = 10.into();
-        token.mint(recipient, amount);
+        token.mint(&recipient, &amount);
         assert_eq!(token.total_supply(), U256::from(INITIAL_SUPPLY) + amount);
-        assert_eq!(token.balance_of(recipient), amount);
+        assert_eq!(&token.balance_of(&recipient), &amount);
     }
 
     #[test]
@@ -111,7 +111,7 @@ pub mod tests {
         let amount = 10.into();
         test_env.set_caller(recipient);
         assert_eq!(
-            token.try_mint(recipient, amount).unwrap_err(),
+            token.try_mint(&recipient, &amount).unwrap_err(),
             CallerNotTheOwner.into()
         );
     }
@@ -120,7 +120,7 @@ pub mod tests {
     fn change_ownership_works() {
         let mut token = setup();
         let new_owner = token.env().get_account(1);
-        token.transfer_ownership(new_owner);
+        token.transfer_ownership(&new_owner);
         assert_eq!(token.get_owner(), new_owner);
     }
 
@@ -131,7 +131,7 @@ pub mod tests {
         let new_owner = test_env.get_account(1);
         test_env.set_caller(new_owner);
         assert_eq!(
-            token.try_transfer_ownership(new_owner).unwrap_err(),
+            token.try_transfer_ownership(&new_owner).unwrap_err(),
             CallerNotTheOwner.into()
         );
     }

--- a/examples/src/contracts/tlw.rs
+++ b/examples/src/contracts/tlw.rs
@@ -1,6 +1,8 @@
+//! This is an example of a TimeLockWallet.
 use odra::prelude::*;
 use odra::{casper_types::U512, Address, Event, Mapping, OdraError, Var};
 
+/// TimeLockWallet contract.
 #[odra::module]
 pub struct TimeLockWallet {
     balances: Mapping<Address, U512>,
@@ -10,10 +12,12 @@ pub struct TimeLockWallet {
 
 #[odra::module]
 impl TimeLockWallet {
+    /// Initializes the contract with the lock duration.
     pub fn init(&mut self, lock_duration: u64) {
         self.lock_duration.set(lock_duration);
     }
 
+    /// Deposits the tokens into the contract.
     #[odra(payable)]
     pub fn deposit(&mut self) {
         // Extract values
@@ -36,6 +40,7 @@ impl TimeLockWallet {
         });
     }
 
+    /// Withdraws the tokens from the contract.
     pub fn withdraw(&mut self, amount: &U512) {
         // Extract values
         let caller: Address = self.env().caller();
@@ -62,10 +67,12 @@ impl TimeLockWallet {
         });
     }
 
+    /// Returns the balance of the given account.
     pub fn get_balance(&self, address: &Address) -> U512 {
         self.balances.get_or_default(address)
     }
 
+    /// Returns the lock duration.
     pub fn lock_duration(&self) -> u64 {
         self.lock_duration.get_or_default()
     }
@@ -82,16 +89,21 @@ pub enum Error {
     InsufficientBalance = 3
 }
 
+/// Deposit event.
 #[derive(Event, PartialEq, Eq, Debug)]
-
 pub struct Deposit {
+    /// The address of the user who deposited the tokens.
     pub address: Address,
+    /// The amount of the deposited tokens.
     pub amount: U512
 }
 
+/// Withdrawal event.
 #[derive(Event, PartialEq, Eq, Debug)]
 pub struct Withdrawal {
+    /// The address of the user who withdrew the tokens.
     pub address: Address,
+    /// The amount of the withdrawn tokens.
     pub amount: U512
 }
 

--- a/examples/src/contracts/tlw.rs
+++ b/examples/src/contracts/tlw.rs
@@ -155,8 +155,8 @@ mod test {
         single_deposit(user_2, user_2_deposit);
 
         // Then the users' balance is the contract is equal to the deposited amount.
-        assert_eq!(contract.get_balance(user_1), user_1_deposit);
-        assert_eq!(contract.get_balance(user_2), user_2_deposit);
+        assert_eq!(contract.get_balance(&user_1), user_1_deposit);
+        assert_eq!(contract.get_balance(&user_2), user_2_deposit);
 
         // Then two deposit event were emitted.
         test_env.emitted_event(
@@ -204,8 +204,8 @@ mod test {
         let balance_before_withdrawals = test_env.balance_of(&user);
         let first_withdrawal_amount: U512 = 50.into();
         let second_withdrawal_amount: U512 = 40.into();
-        contract.withdraw(first_withdrawal_amount);
-        contract.withdraw(second_withdrawal_amount);
+        contract.withdraw(&first_withdrawal_amount);
+        contract.withdraw(&second_withdrawal_amount);
 
         // Then the native token balance is updated.
         assert_eq!(
@@ -215,7 +215,7 @@ mod test {
 
         // Then the user balance in the contract is deducted.
         assert_eq!(
-            contract.get_balance(user),
+            contract.get_balance(&user),
             deposit_amount - first_withdrawal_amount - second_withdrawal_amount
         );
 
@@ -244,7 +244,7 @@ mod test {
 
         // When the user withdraws tokens before the lock is released, an error occurs.
         assert_eq!(
-            contract.try_withdraw(100.into()).unwrap_err(),
+            contract.try_withdraw(&100.into()).unwrap_err(),
             Error::LockIsNotOver.into()
         );
     }
@@ -260,7 +260,7 @@ mod test {
         contract.env().advance_block_time(ONE_DAY_IN_SECONDS + 1);
         let withdrawal = deposit + 1;
         assert_eq!(
-            contract.try_withdraw(withdrawal.into()).unwrap_err(),
+            contract.try_withdraw(&withdrawal.into()).unwrap_err(),
             Error::InsufficientBalance.into()
         );
     }

--- a/examples/src/contracts/token_manager.rs
+++ b/examples/src/contracts/token_manager.rs
@@ -1,7 +1,9 @@
+//! This is an example of a TokenManager contract that manages multiple tokens.
 use crate::contracts::owned_token::OwnedToken;
 use odra::prelude::*;
 use odra::{casper_types::U256, Address, Mapping, SubModule, Var};
 
+/// Contract that manages multiple tokens.
 #[odra::module]
 pub struct TokenManager {
     tokens: Mapping<String, OwnedToken>,
@@ -10,6 +12,7 @@ pub struct TokenManager {
 
 #[odra::module]
 impl TokenManager {
+    /// Adds a new token to the contract.
     pub fn add_token(&mut self, name: String, decimals: u8, symbol: String) {
         self.tokens
             .module(&name)
@@ -19,26 +22,32 @@ impl TokenManager {
         self.count.set(new_count);
     }
 
+    /// Returns the balance of the given account for the given token.
     pub fn balance_of(&self, token_name: String, owner: &Address) -> U256 {
         self.get_token(token_name).balance_of(owner)
     }
 
+    /// Mints new tokens and assigns them to the given address.
     pub fn mint(&mut self, token_name: String, account: &Address, amount: &U256) {
         self.get_token(token_name).mint(account, amount);
     }
 
+    /// Returns the number of tokens managed by the contract.
     pub fn tokens_count(&self) -> u32 {
         self.count.get_or_default()
     }
 
+    /// Returns the owner of the given token.
     pub fn get_owner(&self, token_name: String) -> Address {
         self.get_token(token_name).get_owner()
     }
 
+    /// Transfers the ownership of the given token to the new owner.
     pub fn set_owner(&mut self, token_name: String, new_owner: &Address) {
         self.get_token(token_name).transfer_ownership(new_owner);
     }
 
+    /// Returns the token module for the given token name.
     fn get_token(&self, token_name: String) -> SubModule<OwnedToken> {
         self.tokens.module(&token_name)
     }

--- a/examples/src/contracts/token_manager.rs
+++ b/examples/src/contracts/token_manager.rs
@@ -56,11 +56,11 @@ impl TokenManager {
 #[cfg(test)]
 mod test {
     use super::TokenManagerHostRef;
+    use odra::casper_types::U256;
     use odra::{
         host::{Deployer, HostRef, NoArgs},
         prelude::*
     };
-    use odra::casper_types::U256;
 
     const PLS: &str = "PLS";
     const MCN: &str = "MCN";

--- a/examples/src/contracts/token_manager.rs
+++ b/examples/src/contracts/token_manager.rs
@@ -60,6 +60,7 @@ mod test {
         host::{Deployer, HostRef, NoArgs},
         prelude::*
     };
+    use odra::casper_types::U256;
 
     const PLS: &str = "PLS";
     const MCN: &str = "MCN";
@@ -91,20 +92,20 @@ mod test {
         let plascoin = String::from(PLASCOIN);
         let my_coin = String::from(MY_COIN);
 
-        contract.mint(plascoin.clone(), user1, pls_balance1);
-        contract.mint(plascoin.clone(), user2, pls_balance2);
-        contract.mint(plascoin.clone(), user3, pls_balance3);
+        contract.mint(plascoin.clone(), &user1, &pls_balance1);
+        contract.mint(plascoin.clone(), &user2, &pls_balance2);
+        contract.mint(plascoin.clone(), &user3, &pls_balance3);
 
-        contract.mint(my_coin.clone(), user1, mcn_balance1);
-        contract.mint(my_coin.clone(), user2, mcn_balance2);
-        contract.mint(my_coin.clone(), user3, mcn_balance3);
+        contract.mint(my_coin.clone(), &user1, &mcn_balance1);
+        contract.mint(my_coin.clone(), &user2, &mcn_balance2);
+        contract.mint(my_coin.clone(), &user3, &mcn_balance3);
 
-        assert_eq!(contract.balance_of(plascoin.clone(), user1), pls_balance1);
-        assert_eq!(contract.balance_of(plascoin.clone(), user2), pls_balance2);
-        assert_eq!(contract.balance_of(plascoin, user3), pls_balance3);
-        assert_eq!(contract.balance_of(my_coin.clone(), user1), mcn_balance1);
-        assert_eq!(contract.balance_of(my_coin.clone(), user2), mcn_balance2);
-        assert_eq!(contract.balance_of(my_coin, user3), mcn_balance3);
+        assert_eq!(contract.balance_of(plascoin.clone(), &user1), pls_balance1);
+        assert_eq!(contract.balance_of(plascoin.clone(), &user2), pls_balance2);
+        assert_eq!(contract.balance_of(plascoin, &user3), pls_balance3);
+        assert_eq!(contract.balance_of(my_coin.clone(), &user1), mcn_balance1);
+        assert_eq!(contract.balance_of(my_coin.clone(), &user2), mcn_balance2);
+        assert_eq!(contract.balance_of(my_coin, &user3), mcn_balance3);
     }
 
     #[test]
@@ -126,8 +127,8 @@ mod test {
         assert_eq!(contract.get_owner(String::from(PLASCOIN)), owner);
         assert_eq!(contract.get_owner(String::from(MY_COIN)), owner);
 
-        contract.set_owner(String::from(PLASCOIN), user2);
-        contract.set_owner(String::from(MY_COIN), user3);
+        contract.set_owner(String::from(PLASCOIN), &user2);
+        contract.set_owner(String::from(MY_COIN), &user3);
 
         assert_eq!(contract.get_owner(String::from(PLASCOIN)), user2);
         assert_eq!(contract.get_owner(String::from(MY_COIN)), user3);
@@ -137,11 +138,11 @@ mod test {
     fn many_tokens_works() {
         let test_env = odra_test::env();
         let mut contract = TokenManagerHostRef::deploy(&test_env, NoArgs);
-        let (user, balance) = (test_env.get_account(0), 111.into());
+        let (user, balance) = (test_env.get_account(0), U256::from(111));
         for i in 0..20 {
             contract.add_token(i.to_string(), DECIMALS, i.to_string());
-            contract.mint(i.to_string(), user, balance);
-            assert_eq!(contract.balance_of(i.to_string(), user), balance);
+            contract.mint(i.to_string(), &user, &balance);
+            assert_eq!(contract.balance_of(i.to_string(), &user), balance);
         }
     }
 }

--- a/examples/src/features/access_control.rs
+++ b/examples/src/features/access_control.rs
@@ -103,8 +103,8 @@ pub mod test {
         let contract = MockModeratedHostRef::deploy(&env, NoArgs);
         let admin = env.get_account(0);
 
-        assert!(contract.is_moderator(admin));
-        assert!(contract.is_admin(admin));
+        assert!(contract.is_moderator(&admin));
+        assert!(contract.is_admin(&admin));
     }
 
     #[test]
@@ -112,22 +112,22 @@ pub mod test {
         // given Admin is a moderator and an admin.
         // given User1 and User2 that are not moderators.
         let (mut contract, admin, user1, user2) = setup(false);
-        assert!(!contract.is_moderator(user1));
-        assert!(!contract.is_moderator(user2));
+        assert!(!contract.is_moderator(&user1));
+        assert!(!contract.is_moderator(&user2));
 
         // when Admin adds a moderator.
         contract.env().set_caller(admin);
-        contract.add_moderator(user1);
+        contract.add_moderator(&user1);
         // then the role is granted.
-        assert!(contract.is_moderator(user1));
+        assert!(contract.is_moderator(&user1));
 
         // when a non-admin adds a moderator.
         contract.env().set_caller(user1);
-        let err = contract.try_add_moderator(user2).unwrap_err();
+        let err = contract.try_add_moderator(&user2).unwrap_err();
         assert_eq!(err, Error::MissingRole.into());
 
         // then the User2 is not a moderator.
-        assert!(!contract.is_moderator(user2));
+        assert!(!contract.is_moderator(&user2));
 
         // then two RoleGranted events were emitted.
         contract.env().emitted_event(
@@ -151,28 +151,28 @@ pub mod test {
         // when User removes the role - it fails.
         contract.env().set_caller(user);
         assert_eq!(
-            contract.try_remove_moderator(moderator).unwrap_err(),
+            contract.try_remove_moderator(&moderator).unwrap_err(),
             Error::MissingRole.into()
         );
         // then Moderator still is a moderator.
-        assert!(contract.is_moderator(moderator));
+        assert!(contract.is_moderator(&moderator));
 
         // when Admin revokes the Moderator's role.
         contract.env().set_caller(admin);
-        contract.remove_moderator(moderator);
+        contract.remove_moderator(&moderator);
         // then Moderator no longer is a moderator.
-        assert!(!contract.is_moderator(moderator));
+        assert!(!contract.is_moderator(&moderator));
 
         // Re-grant the role.
-        contract.add_moderator(moderator);
+        contract.add_moderator(&moderator);
         // Moderator revoke his role - fails because is not an admin.
         contract.env().set_caller(moderator);
         assert_eq!(
-            contract.try_remove_moderator(moderator).unwrap_err(),
+            contract.try_remove_moderator(&moderator).unwrap_err(),
             Error::MissingRole.into()
         );
         // then Moderator still is a moderator.
-        assert!(contract.is_moderator(moderator));
+        assert!(contract.is_moderator(&moderator));
 
         contract.env().emitted_event(
             contract.address(),
@@ -207,15 +207,15 @@ pub mod test {
 
         // when Admin renounces the role on moderator's behalf - it fails.
         assert_eq!(
-            contract.try_renounce_moderator_role(moderator).unwrap_err(),
+            contract.try_renounce_moderator_role(&moderator).unwrap_err(),
             Error::RoleRenounceForAnotherAddress.into()
         );
 
         // when Moderator renounces the role.
         contract.env().set_caller(moderator);
-        contract.renounce_moderator_role(moderator);
+        contract.renounce_moderator_role(&moderator);
         // then is no longer a moderator.
-        assert!(!contract.is_moderator(moderator));
+        assert!(!contract.is_moderator(&moderator));
         // RoleRevoked event was emitted.
         contract.env().emitted_event(
             contract.address(),
@@ -237,14 +237,14 @@ pub mod test {
 
         // when Admin grants Moderator the admin role.
         contract.env().set_caller(admin);
-        contract.add_admin(moderator);
+        contract.add_admin(&moderator);
         // then Moderator is an admin.
-        assert!(contract.is_admin(moderator));
+        assert!(contract.is_admin(&moderator));
         // when Moderator grants User the moderator role.
         contract.env().set_caller(moderator);
-        contract.add_moderator(user);
+        contract.add_moderator(&user);
         // then User is a moderator.
-        assert!(contract.is_moderator(user));
+        assert!(contract.is_moderator(&user));
 
         contract.env().emitted_event(
             contract.address(),
@@ -270,8 +270,8 @@ pub mod test {
         // given admin who is a moderator and two users that are not moderators.
         let (admin, user1, user2) = (env.get_account(0), env.get_account(1), env.get_account(2));
         if add_moderator {
-            contract.add_moderator(user1);
-            assert!(contract.is_moderator(user1));
+            contract.add_moderator(&user1);
+            assert!(contract.is_moderator(&user1));
         }
         (contract, admin, user1, user2)
     }

--- a/examples/src/features/access_control.rs
+++ b/examples/src/features/access_control.rs
@@ -1,3 +1,4 @@
+//! This example is used by the Access Control tutorial.
 use odra::prelude::*;
 use odra::{Address, SubModule};
 use sha3::{Digest, Keccak256};

--- a/examples/src/features/access_control.rs
+++ b/examples/src/features/access_control.rs
@@ -4,9 +4,12 @@ use sha3::{Digest, Keccak256};
 
 use odra_modules::access::{AccessControl, Role, DEFAULT_ADMIN_ROLE};
 
+/// Name of the moderator role.
 pub const ROLE_MODERATOR: &str = "moderator";
+/// Name of the moderator admin role.
 pub const ROLE_MODERATOR_ADMIN: &str = "moderator_admin";
 
+/// Contract that uses the access control module.
 #[odra::module]
 pub struct MockModerated {
     access_control: SubModule<AccessControl>
@@ -14,6 +17,7 @@ pub struct MockModerated {
 
 #[odra::module]
 impl MockModerated {
+    /// Initializes the contract.
     pub fn init(&mut self) {
         let admin = self.env().caller();
         self.access_control
@@ -25,31 +29,37 @@ impl MockModerated {
         self.set_moderator_admin_role(&Self::role(ROLE_MODERATOR_ADMIN));
     }
 
+    /// Adds a moderator.
     pub fn add_moderator(&mut self, moderator: &Address) {
         self.access_control
             .grant_role(&Self::role(ROLE_MODERATOR), moderator);
     }
 
+    /// Adds an admin.
     pub fn add_admin(&mut self, admin: &Address) {
         self.access_control
             .grant_role(&Self::role(ROLE_MODERATOR_ADMIN), admin);
     }
 
+    /// Removes a moderator.
     pub fn remove_moderator(&mut self, moderator: &Address) {
         self.access_control
             .revoke_role(&Self::role(ROLE_MODERATOR), moderator);
     }
 
+    /// Renounces the moderator role.
     pub fn renounce_moderator_role(&mut self, address: &Address) {
         let role = Self::role(ROLE_MODERATOR);
         self.access_control.renounce_role(&role, address);
     }
 
+    /// Returns true if the given address is a moderator.
     pub fn is_moderator(&self, address: &Address) -> bool {
         self.access_control
             .has_role(&Self::role(ROLE_MODERATOR), address)
     }
 
+    /// Returns true if the given address is an admin.
     pub fn is_admin(&self, address: &Address) -> bool {
         self.access_control
             .has_role(&Self::role(ROLE_MODERATOR_ADMIN), address)
@@ -67,6 +77,7 @@ impl MockModerated {
     }
 }
 
+/// Calculates the keccak256 hash of the input string.
 pub fn keccak_256(input: &str) -> Role {
     let mut hasher = Keccak256::default();
     hasher.update(input.as_bytes());

--- a/examples/src/features/access_control.rs
+++ b/examples/src/features/access_control.rs
@@ -207,7 +207,9 @@ pub mod test {
 
         // when Admin renounces the role on moderator's behalf - it fails.
         assert_eq!(
-            contract.try_renounce_moderator_role(&moderator).unwrap_err(),
+            contract
+                .try_renounce_moderator_role(&moderator)
+                .unwrap_err(),
             Error::RoleRenounceForAnotherAddress.into()
         );
 

--- a/examples/src/features/collecting_events.rs
+++ b/examples/src/features/collecting_events.rs
@@ -1,3 +1,4 @@
+//! This example demonstrates how to collect events from a module and its submodules.
 #![allow(dead_code)]
 use odra::prelude::*;
 use odra::{Event, SubModule, Var};

--- a/examples/src/features/cross_calls.rs
+++ b/examples/src/features/cross_calls.rs
@@ -1,3 +1,4 @@
+//! This example demonstrates how to call a method from another contract.
 use odra::prelude::*;
 use odra::{Address, UnwrapOrRevert, Var};
 

--- a/examples/src/features/cross_calls.rs
+++ b/examples/src/features/cross_calls.rs
@@ -1,28 +1,34 @@
 use odra::prelude::*;
 use odra::{Address, UnwrapOrRevert, Var};
 
+/// Contract that uses another contract to perform an operation.
 #[odra::module]
 pub struct CrossContract {
+    /// Math engine contract address.
     pub math_engine: Var<Address>
 }
 
 #[odra::module]
 impl CrossContract {
+    /// Initializes the contract with the given math engine address.
     pub fn init(&mut self, math_engine_address: Address) {
         self.math_engine.set(math_engine_address);
     }
 
+    /// Adds 3 and 5 using the math engine contract.
     pub fn add_using_another(&self) -> u32 {
         let math_engine_address = self.math_engine.get().unwrap_or_revert(&self.env());
         MathEngineContractRef::new(self.env(), math_engine_address).add(3, 5)
     }
 }
 
+/// MathEngine Contract
 #[odra::module]
 pub struct MathEngine;
 
 #[odra::module]
 impl MathEngine {
+    /// Adds two numbers.
     pub fn add(&self, n1: u32, n2: u32) -> u32 {
         n1 + n2
     }

--- a/examples/src/features/events.rs
+++ b/examples/src/features/events.rs
@@ -1,17 +1,22 @@
 use odra::prelude::*;
 use odra::{Address, Event};
 
+/// Contract that emits an event when initialized.
 #[odra::module]
 pub struct PartyContract {}
 
+/// Event emitted when the contract is initialized.
 #[derive(Event, PartialEq, Eq, Debug)]
 pub struct PartyStarted {
+    /// Address of the caller.
     pub caller: Address,
+    /// Block time when the contract was initialized.
     pub block_time: u64
 }
 
 #[odra::module]
 impl PartyContract {
+    /// Initializes the contract.
     pub fn init(&self) {
         self.env().emit_event(PartyStarted {
             caller: self.env().caller(),

--- a/examples/src/features/events.rs
+++ b/examples/src/features/events.rs
@@ -1,3 +1,4 @@
+//! This examples shows how to handle events in a contract.
 use odra::prelude::*;
 use odra::{Address, Event};
 

--- a/examples/src/features/handling_errors.rs
+++ b/examples/src/features/handling_errors.rs
@@ -1,33 +1,41 @@
 use odra::prelude::*;
 use odra::{Address, OdraError, Var};
 
+/// Contract that has an owner.
 #[odra::module]
 pub struct OwnedContract {
     name: Var<String>,
     owner: Var<Address>
 }
 
+/// Errors that can occur in the `OwnedContract` module.
 #[derive(OdraError)]
 pub enum Error {
+    /// The owner is not set.
     OwnerNotSet = 1,
+    /// The caller is not the owner.
     NotAnOwner = 2
 }
 
 #[odra::module]
 impl OwnedContract {
+    /// Initializes the contract with the given name.
     pub fn init(&mut self, name: String) {
         self.name.set(name);
         self.owner.set(self.env().caller())
     }
 
+    /// Returns the contract's name.
     pub fn name(&self) -> String {
         self.name.get_or_default()
     }
 
+    /// Returns the contract's owner.
     pub fn owner(&self) -> Address {
         self.owner.get_or_revert_with(Error::OwnerNotSet)
     }
 
+    /// Changes the contract's name.
     pub fn change_name(&mut self, name: String) {
         let caller = self.env().caller();
         if caller != self.owner() {

--- a/examples/src/features/handling_errors.rs
+++ b/examples/src/features/handling_errors.rs
@@ -1,3 +1,4 @@
+//! This example demonstrates how to handle errors in a contract.
 use odra::prelude::*;
 use odra::{Address, OdraError, Var};
 

--- a/examples/src/features/host_functions.rs
+++ b/examples/src/features/host_functions.rs
@@ -1,6 +1,7 @@
 use odra::prelude::*;
 use odra::{Address, Var};
 
+/// Host contract. It shows the Odra's capabilities regarding host functions.
 #[odra::module]
 pub struct HostContract {
     name: Var<String>,
@@ -10,12 +11,14 @@ pub struct HostContract {
 
 #[odra::module]
 impl HostContract {
+    /// Initializes the contract with the given parameters.
     pub fn init(&mut self, name: String) {
         self.name.set(name);
         self.created_at.set(self.env().get_block_time());
         self.created_by.set(self.env().caller())
     }
 
+    /// Returns the contract's name.
     pub fn name(&self) -> String {
         self.name.get_or_default()
     }

--- a/examples/src/features/host_functions.rs
+++ b/examples/src/features/host_functions.rs
@@ -1,3 +1,4 @@
+//! This example demonstrates how to use host functions in a contract.
 use odra::prelude::*;
 use odra::{Address, Var};
 

--- a/examples/src/features/livenet.rs
+++ b/examples/src/features/livenet.rs
@@ -56,6 +56,6 @@ impl LivenetContract {
     /// Transfers 1 token from the ERC20 contract to the caller. This is an example of a mutable cross-contract call.
     pub fn mutable_cross_call(&mut self) {
         Erc20ContractRef::new(self.env(), self.erc20_address.get().unwrap())
-            .transfer(self.env().caller(), 1.into());
+            .transfer(&self.env().caller(), &1.into());
     }
 }

--- a/examples/src/features/livenet.rs
+++ b/examples/src/features/livenet.rs
@@ -1,3 +1,4 @@
+//! This is an example contract used to showcase and test Livenet Environment.
 use odra::casper_types::U256;
 use odra::prelude::*;
 use odra::{Address, List, SubModule, UnwrapOrRevert, Var};

--- a/examples/src/features/livenet.rs
+++ b/examples/src/features/livenet.rs
@@ -4,6 +4,7 @@ use odra::{Address, List, SubModule, UnwrapOrRevert, Var};
 use odra_modules::access::Ownable;
 use odra_modules::erc20::Erc20ContractRef;
 
+/// Contract used by the Livenet examples.
 #[odra::module]
 pub struct LivenetContract {
     creator: Var<Address>,
@@ -14,36 +15,44 @@ pub struct LivenetContract {
 
 #[odra::module]
 impl LivenetContract {
+    /// Initializes the contract.
     pub fn init(mut self, erc20_address: Address) {
         self.creator.set(self.env().caller());
         self.ownable.init();
         self.erc20_address.set(erc20_address);
     }
 
+    /// Transfers the ownership of the contract to a new owner.
     pub fn transfer_ownership(&mut self, new_owner: Address) {
         self.ownable.transfer_ownership(&new_owner);
     }
 
+    /// Returns the owner of the contract.
     pub fn owner(&self) -> Address {
         self.ownable.get_owner()
     }
 
+    /// Pushes a value on the stack.
     pub fn push_on_stack(&mut self, value: u64) {
         self.stack.push(value);
     }
 
+    /// Pops a value from the stack.
     pub fn pop_from_stack(&mut self) -> u64 {
         self.stack.pop().unwrap_or_revert(&self.env())
     }
 
+    /// Returns the length of the stack.
     pub fn get_stack_len(&self) -> u32 {
         self.stack.len()
     }
 
+    /// Returns the total supply of the ERC20 contract. This is an example of an immutable cross-contract call.
     pub fn immutable_cross_call(&self) -> U256 {
         Erc20ContractRef::new(self.env(), self.erc20_address.get().unwrap()).total_supply()
     }
 
+    /// Transfers 1 token from the ERC20 contract to the caller. This is an example of a mutable cross-contract call.
     pub fn mutable_cross_call(&mut self) {
         Erc20ContractRef::new(self.env(), self.erc20_address.get().unwrap())
             .transfer(self.env().caller(), 1.into());

--- a/examples/src/features/mod.rs
+++ b/examples/src/features/mod.rs
@@ -1,3 +1,4 @@
+//! Module containing examples of various Odra features.
 pub mod access_control;
 pub mod collecting_events;
 pub mod cross_calls;

--- a/examples/src/features/module_nesting.rs
+++ b/examples/src/features/module_nesting.rs
@@ -3,12 +3,14 @@ use odra::casper_event_standard;
 use odra::prelude::*;
 use odra::{Mapping, OdraType, SubModule, UnwrapOrRevert, Var};
 
+/// Module containing the results storage.
 #[odra::module]
 pub struct ResultsStorage {
     results: Mapping<u32, OperationResult>,
     results_count: Var<u32>
 }
 
+/// Contract that uses a module with nested Odra types.
 #[odra::module]
 pub struct NestedOdraTypesContract {
     latest_result: Var<OperationResult>,
@@ -17,6 +19,7 @@ pub struct NestedOdraTypesContract {
 
 #[odra::module]
 impl NestedOdraTypesContract {
+    /// Saves the operation result in the storage.
     pub fn save_operation_result(&mut self, operation_result: OperationResult) {
         // save it in simple storage
         self.latest_result.set(operation_result.clone());
@@ -41,10 +44,12 @@ impl NestedOdraTypesContract {
         });
     }
 
+    /// Returns the latest operation result.
     pub fn latest_result(&self) -> Option<OperationResult> {
         self.latest_result.get()
     }
 
+    /// Returns the current generation of operation results.
     pub fn current_generation(&self) -> Vec<OperationResult> {
         let keys = self
             .current_generation_storage
@@ -62,19 +67,27 @@ impl NestedOdraTypesContract {
     }
 }
 
+/// Status of the operation.
 #[derive(OdraType, PartialEq, Debug)]
 pub enum Status {
+    /// Operation failed.
     Failure,
+    /// Operation succeeded.
     Success
 }
 
 #[derive(OdraType, PartialEq, Debug)]
+/// Result of the operation.
 pub struct OperationResult {
+    /// Id of the operation.
     pub id: u32,
+    /// Status of the operation.
     pub status: Status,
+    /// Description of the operation.
     pub description: String
 }
 
+/// Event emitted when the operation ends.
 #[derive(Event, PartialEq, Debug)]
 pub struct OperationEnded {
     id: u32,

--- a/examples/src/features/module_nesting.rs
+++ b/examples/src/features/module_nesting.rs
@@ -1,9 +1,10 @@
+//! This example demonstrates how to use nested Odra types in a contract.
 use casper_event_standard::Event;
 use odra::casper_event_standard;
 use odra::prelude::*;
 use odra::{Mapping, OdraType, SubModule, UnwrapOrRevert, Var};
 
-/// Module containing the results storage.
+/// Module containing the results' storage.
 #[odra::module]
 pub struct ResultsStorage {
     results: Mapping<u32, OperationResult>,

--- a/examples/src/features/modules.rs
+++ b/examples/src/features/modules.rs
@@ -2,13 +2,16 @@ use crate::features::cross_calls::MathEngine;
 use odra::prelude::*;
 use odra::SubModule;
 
+/// Contract that uses a module.
 #[odra::module]
 pub struct ModulesContract {
+    /// Math engine module.
     pub math_engine: SubModule<MathEngine>
 }
 
 #[odra::module]
 impl ModulesContract {
+    /// Adds 3 and 5 using the math engine module.
     pub fn add_using_module(&self) -> u32 {
         self.math_engine.add(3, 5)
     }

--- a/examples/src/features/modules.rs
+++ b/examples/src/features/modules.rs
@@ -1,3 +1,4 @@
+//! This example demonstrates how to use modules in a contract.
 use crate::features::cross_calls::MathEngine;
 use odra::prelude::*;
 use odra::SubModule;

--- a/examples/src/features/native_token.rs
+++ b/examples/src/features/native_token.rs
@@ -41,7 +41,7 @@ mod tests {
         my_contract.with_tokens(U512::from(100)).deposit();
         assert_eq!(test_env.balance_of(my_contract.address()), U512::from(100));
 
-        my_contract.withdraw(U512::from(25));
+        my_contract.withdraw(&U512::from(25));
         assert_eq!(test_env.balance_of(my_contract.address()), U512::from(75));
 
         let contract_balance = my_contract.balance();

--- a/examples/src/features/native_token.rs
+++ b/examples/src/features/native_token.rs
@@ -1,3 +1,4 @@
+//! This example demonstrates how to handle native CSPR transfers in a contract.
 use odra::casper_types::U512;
 use odra::prelude::*;
 

--- a/examples/src/features/native_token.rs
+++ b/examples/src/features/native_token.rs
@@ -1,18 +1,22 @@
 use odra::casper_types::U512;
 use odra::prelude::*;
 
+/// Public wallet contract - used to show how Odra handles native CSPR transfers.
 #[odra::module]
 pub struct PublicWallet;
 
 #[odra::module]
 impl PublicWallet {
+    /// Deposits the tokens into the contract.
     #[odra(payable)]
     pub fn deposit(&mut self) {}
 
+    /// Withdraws the tokens from the contract.
     pub fn withdraw(&mut self, amount: &U512) {
         self.env().transfer_tokens(&self.env().caller(), amount);
     }
 
+    /// Returns the balance of the contract.
     pub fn balance(&self) -> U512 {
         self.env().self_balance()
     }

--- a/examples/src/features/pauseable.rs
+++ b/examples/src/features/pauseable.rs
@@ -2,6 +2,7 @@ use odra::prelude::*;
 use odra::{SubModule, Var};
 use odra_modules::security::Pauseable;
 
+/// Contract showing the capabilities of the pauseable module.
 #[odra::module]
 pub struct PauseableCounter {
     value: Var<u32>,
@@ -10,23 +11,28 @@ pub struct PauseableCounter {
 
 #[odra::module]
 impl PauseableCounter {
+    /// Increments a value.
     pub fn increment(&mut self) {
         self.pauseable.require_not_paused();
         self.raw_increment();
     }
 
+    /// Pauses the contract.
     pub fn pause(&mut self) {
         self.pauseable.pause();
     }
 
+    /// Unpauses the contract.
     pub fn unpause(&mut self) {
         self.pauseable.unpause();
     }
 
+    /// Returns true if the contract is paused, and false otherwise.
     pub fn is_paused(&self) -> bool {
         self.pauseable.is_paused()
     }
 
+    /// Returns the value of the counter.
     pub fn get_value(&self) -> u32 {
         self.value.get_or_default()
     }

--- a/examples/src/features/pauseable.rs
+++ b/examples/src/features/pauseable.rs
@@ -1,3 +1,4 @@
+//! This example demonstrates how to use the pauseable module in a contract.
 use odra::prelude::*;
 use odra::{SubModule, Var};
 use odra_modules::security::Pauseable;

--- a/examples/src/features/reentrancy_guard.rs
+++ b/examples/src/features/reentrancy_guard.rs
@@ -1,6 +1,7 @@
 use odra::prelude::*;
 use odra::Var;
 
+/// Contract used to test reentrancy guard.
 #[odra::module]
 pub struct ReentrancyMock {
     counter: Var<u32>
@@ -8,6 +9,7 @@ pub struct ReentrancyMock {
 
 #[odra::module]
 impl ReentrancyMock {
+    /// Simple recursive function that counts to `n`.
     #[odra(non_reentrant)]
     pub fn count_local_recursive(&mut self, n: u32) {
         if n > 0 {
@@ -16,6 +18,7 @@ impl ReentrancyMock {
         }
     }
 
+    /// Recursive function that counts to `n` using a reference to the contract.
     #[odra(non_reentrant)]
     pub fn count_ref_recursive(&mut self, n: u32) {
         if n > 0 {
@@ -25,11 +28,13 @@ impl ReentrancyMock {
         }
     }
 
+    /// Recursive function that counts to `n` and is protected.
     #[odra(non_reentrant)]
     pub fn non_reentrant_count(&mut self) {
         self.count();
     }
 
+    /// Returns the value of the counter.
     pub fn get_value(&self) -> u32 {
         self.counter.get_or_default()
     }

--- a/examples/src/features/reentrancy_guard.rs
+++ b/examples/src/features/reentrancy_guard.rs
@@ -1,3 +1,4 @@
+//! This example demonstrates how to use the reentrancy guard in a contract.
 use odra::prelude::*;
 use odra::Var;
 

--- a/examples/src/features/signature_verifier.rs
+++ b/examples/src/features/signature_verifier.rs
@@ -42,7 +42,7 @@ mod test {
         let public_key = test_env.public_key(&account);
 
         let signature_verifier = SignatureVerifierHostRef::deploy(&test_env, NoArgs);
-        assert!(signature_verifier.verify_signature(message_bytes, signature, public_key));
+        assert!(signature_verifier.verify_signature(&message_bytes, &signature, &public_key));
     }
 
     // The following test checks that the signature verification works with the signature produced
@@ -69,6 +69,6 @@ mod test {
         let (public_key, _) = PublicKey::from_bytes(public_key_decoded.as_slice()).unwrap();
 
         let signature_verifier = SignatureVerifierHostRef::deploy(&odra_test::env(), NoArgs);
-        assert!(signature_verifier.verify_signature(message_bytes, signature_bytes, public_key));
+        assert!(signature_verifier.verify_signature(&message_bytes, &signature_bytes, &public_key));
     }
 }

--- a/examples/src/features/signature_verifier.rs
+++ b/examples/src/features/signature_verifier.rs
@@ -1,11 +1,13 @@
 use odra::casper_types::{bytesrepr::Bytes, PublicKey};
 use odra::prelude::*;
 
+/// A Contract that verifies signatures.
 #[odra::module]
 pub struct SignatureVerifier;
 
 #[odra::module]
 impl SignatureVerifier {
+    /// Verifies if the message was signed by the owner of the public key.
     pub fn verify_signature(
         &self,
         message: &Bytes,

--- a/examples/src/features/signature_verifier.rs
+++ b/examples/src/features/signature_verifier.rs
@@ -1,3 +1,4 @@
+//! This example shows how to handle signature verification in a contract.
 use odra::casper_types::{bytesrepr::Bytes, PublicKey};
 use odra::prelude::*;
 

--- a/examples/src/features/storage/list.rs
+++ b/examples/src/features/storage/list.rs
@@ -1,5 +1,7 @@
+//! Module containing DogContract. It is used in docs to explain how to interact with the storage.
 use odra::{prelude::*, List, Var};
 
+/// A simple contract that represents a third dog.
 #[odra::module]
 pub struct DogContract3 {
     name: Var<String>,
@@ -8,22 +10,27 @@ pub struct DogContract3 {
 
 #[odra::module]
 impl DogContract3 {
+    /// Initializes the contract with the given parameters.
     pub fn init(&mut self, name: String) {
         self.name.set(name);
     }
 
+    /// Returns the dog's name.
     pub fn name(&self) -> String {
         self.name.get_or_default()
     }
 
+    /// Returns the amount of walks the dog has taken. 
     pub fn walks_amount(&self) -> u32 {
         self.walks.len()
     }
 
+    /// Returns the total length of the dog's walks.
     pub fn walks_total_length(&self) -> u32 {
         self.walks.iter().sum()
     }
 
+    /// Adds a walk to the dog's walks.
     pub fn walk_the_dog(&mut self, length: u32) {
         self.walks.push(length);
     }

--- a/examples/src/features/storage/list.rs
+++ b/examples/src/features/storage/list.rs
@@ -20,7 +20,7 @@ impl DogContract3 {
         self.name.get_or_default()
     }
 
-    /// Returns the amount of walks the dog has taken. 
+    /// Returns the amount of walks the dog has taken.
     pub fn walks_amount(&self) -> u32 {
         self.walks.len()
     }

--- a/examples/src/features/storage/mapping.rs
+++ b/examples/src/features/storage/mapping.rs
@@ -25,14 +25,14 @@ impl DogContract2 {
     }
 
     /// Adds a visit to the friend's visits.
-    pub fn visit(&mut self, friend_name: FriendName) {
-        let visits = self.visits(friend_name.clone());
+    pub fn visit(&mut self, friend_name: &FriendName) {
+        let visits = self.visits(friend_name);
         self.friends.set(&friend_name, visits + 1);
     }
 
     /// Returns the total visits of the friend.
-    pub fn visits(&self, friend_name: FriendName) -> u32 {
-        self.friends.get_or_default(&friend_name)
+    pub fn visits(&self, friend_name: &FriendName) -> u32 {
+        self.friends.get_or_default(friend_name)
     }
 }
 

--- a/examples/src/features/storage/mapping.rs
+++ b/examples/src/features/storage/mapping.rs
@@ -1,9 +1,11 @@
+//! Module containing DogContract. It is used in docs to explain how to interact with the storage.
 use odra::prelude::*;
 use odra::{Mapping, Var};
 
 type FriendName = String;
 type Visits = u32;
 
+/// A simple contract that represents a second dog.
 #[odra::module]
 pub struct DogContract2 {
     name: Var<String>,
@@ -12,19 +14,23 @@ pub struct DogContract2 {
 
 #[odra::module]
 impl DogContract2 {
+    /// Initializes the contract with the given parameters.
     pub fn init(&mut self, name: String) {
         self.name.set(name);
     }
 
+    /// Returns the dog's name.
     pub fn name(&self) -> String {
         self.name.get_or_default()
     }
 
+    /// Adds a visit to the friend's visits.
     pub fn visit(&mut self, friend_name: FriendName) {
         let visits = self.visits(friend_name.clone());
         self.friends.set(&friend_name, visits + 1);
     }
 
+    /// Returns the total visits of the friend.
     pub fn visits(&self, friend_name: FriendName) -> u32 {
         self.friends.get_or_default(&friend_name)
     }

--- a/examples/src/features/storage/mapping.rs
+++ b/examples/src/features/storage/mapping.rs
@@ -27,7 +27,7 @@ impl DogContract2 {
     /// Adds a visit to the friend's visits.
     pub fn visit(&mut self, friend_name: &FriendName) {
         let visits = self.visits(friend_name);
-        self.friends.set(&friend_name, visits + 1);
+        self.friends.set(friend_name, visits + 1);
     }
 
     /// Returns the total visits of the friend.
@@ -50,8 +50,8 @@ mod tests {
                 name: "Mantus".to_string()
             }
         );
-        assert_eq!(dog_contract.visits("Kuba".to_string()), 0);
-        dog_contract.visit("Kuba".to_string());
-        assert_eq!(dog_contract.visits("Kuba".to_string()), 1);
+        assert_eq!(dog_contract.visits(&"Kuba".to_string()), 0);
+        dog_contract.visit(&"Kuba".to_string());
+        assert_eq!(dog_contract.visits(&"Kuba".to_string()), 1);
     }
 }

--- a/examples/src/features/storage/mod.rs
+++ b/examples/src/features/storage/mod.rs
@@ -1,3 +1,4 @@
+//! This module contains examples of how to handle different storage types in Odra.
 pub mod list;
 pub mod mapping;
 pub mod variable;

--- a/examples/src/features/storage/variable.rs
+++ b/examples/src/features/storage/variable.rs
@@ -1,6 +1,7 @@
 use odra::prelude::*;
 use odra::Var;
 
+/// A simple contract that represents a dog.
 #[odra::module]
 pub struct DogContract {
     barks: Var<bool>,
@@ -11,6 +12,7 @@ pub struct DogContract {
 
 #[odra::module]
 impl DogContract {
+    /// Initializes the contract with the given parameters.
     pub fn init(&mut self, barks: bool, weight: u32, name: String) {
         self.barks.set(barks);
         self.weight.set(weight);
@@ -18,23 +20,28 @@ impl DogContract {
         self.walks.set(Vec::<u32>::default());
     }
 
+    /// Returns true if the dog barks.
     pub fn barks(&self) -> bool {
         self.barks.get_or_default()
     }
 
+    /// Returns the dog's weight.
     pub fn weight(&self) -> u32 {
         self.weight.get_or_default()
     }
 
+    /// Returns the dog's name.
     pub fn name(&self) -> String {
         self.name.get_or_default()
     }
 
+    /// Adds a walk to the dog's walks.
     pub fn walks_amount(&self) -> u32 {
         let walks = self.walks.get_or_default();
         walks.len() as u32
     }
 
+    /// Returns the total length of the dog's walks.
     pub fn walks_total_length(&self) -> u32 {
         let walks = self.walks.get_or_default();
         walks.iter().sum()

--- a/examples/src/features/storage/variable.rs
+++ b/examples/src/features/storage/variable.rs
@@ -1,3 +1,4 @@
+//! Module containing DogContract. It is used in docs to explain how to interact with the storage.
 use odra::prelude::*;
 use odra::Var;
 

--- a/examples/src/features/testing.rs
+++ b/examples/src/features/testing.rs
@@ -1,3 +1,4 @@
+//! This example shows how to test a contract.
 use odra::prelude::*;
 use odra::{Address, Var};
 

--- a/examples/src/features/testing.rs
+++ b/examples/src/features/testing.rs
@@ -1,6 +1,7 @@
 use odra::prelude::*;
 use odra::{Address, Var};
 
+/// Contract presenting the testing abilities of the Odra Framework
 #[odra::module]
 pub struct TestingContract {
     name: Var<String>,
@@ -8,22 +9,27 @@ pub struct TestingContract {
     created_by: Var<Address>
 }
 
+/// Implementation of the TestingContract
 #[odra::module]
 impl TestingContract {
+    /// Initializes the contract with the name
     pub fn init(&mut self, name: String) {
         self.name.set(name);
         self.created_at.set(self.env().get_block_time());
         self.created_by.set(self.env().caller())
     }
 
+    /// Returns the name of the contract
     pub fn name(&self) -> String {
         self.name.get_or_default()
     }
 
+    /// Returns the creation time of the contract
     pub fn created_at(&self) -> u64 {
         self.created_at.get().unwrap()
     }
 
+    /// Returns the address of the creator of the contract
     pub fn created_by(&self) -> Address {
         self.created_by.get().unwrap()
     }

--- a/examples/src/lib.rs
+++ b/examples/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc = "Examples of usages of Odra Framework"]
 #![no_std]
 extern crate alloc;
 

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -32,3 +32,6 @@ lto = true
 
 [profile.dev.package."*"]
 opt-level = 3
+
+[lints.rust]
+missing_docs = "warn"

--- a/modules/bin/build_contract.rs
+++ b/modules/bin/build_contract.rs
@@ -1,3 +1,4 @@
+#![doc = "Binary for building wasm files from odra contracts."]
 #![no_std]
 #![no_main]
 #![allow(unused_imports, clippy::single_component_path_imports)]

--- a/modules/bin/build_schema.rs
+++ b/modules/bin/build_schema.rs
@@ -1,3 +1,4 @@
+#![doc = "Binary for building schema definitions from odra contracts"]
 #[allow(unused_imports, clippy::single_component_path_imports)]
 use odra_modules;
 

--- a/modules/build.rs
+++ b/modules/build.rs
@@ -1,5 +1,7 @@
+//! Odra's contracts build script.
 use std::env;
 
+/// Uses the ENV variable `ODRA_MODULE` to set the `odra_module` cfg flag.
 pub fn main() {
     println!("cargo:rerun-if-env-changed=ODRA_MODULE");
     let module = env::var("ODRA_MODULE").unwrap_or_else(|_| "".to_string());

--- a/modules/src/access.rs
+++ b/modules/src/access.rs
@@ -1,3 +1,4 @@
+//! Access control module.
 mod access_control;
 pub mod errors;
 pub mod events;

--- a/modules/src/access/access_control.rs
+++ b/modules/src/access/access_control.rs
@@ -1,10 +1,13 @@
+//! Access Control module.
 use super::events::*;
 use crate::access::errors::Error::{MissingRole, RoleRenounceForAnotherAddress};
 use odra::prelude::*;
 use odra::{Address, Mapping};
 
+/// The role identifier.
 pub type Role = [u8; 32];
 
+/// The default admin role.
 pub const DEFAULT_ADMIN_ROLE: Role = [0u8; 32];
 
 /// This contract module enables the implementation of role-based access control mechanisms for children

--- a/modules/src/access/errors.rs
+++ b/modules/src/access/errors.rs
@@ -1,10 +1,17 @@
+//! Errors for Access Control module.
 use odra::OdraError;
 
+/// Access Control-related errors.
 #[derive(OdraError)]
 pub enum Error {
+    /// The owner is not set.
     OwnerNotSet = 20_000,
+    /// The caller is not the owner.
     CallerNotTheOwner = 20_001,
+    /// The caller is not the new owner.
     CallerNotTheNewOwner = 20_002,
+    /// The role is missing.
     MissingRole = 20_003,
+    /// The role cannot be renounced for another address.
     RoleRenounceForAnotherAddress = 20_004
 }

--- a/modules/src/access/events.rs
+++ b/modules/src/access/events.rs
@@ -1,16 +1,23 @@
+//! Events emitted by the AccessControl module.
 use super::access_control::Role;
 use odra::prelude::*;
 use odra::{Address, Event};
 
+/// Emitted when ownership of the contract is transferred.
 #[derive(Event, PartialEq, Eq, Debug)]
 pub struct OwnershipTransferred {
+    /// The previous owner.
     pub previous_owner: Option<Address>,
+    /// The new owner.
     pub new_owner: Option<Address>
 }
 
+/// Emitted when the ownership transfer is started.
 #[derive(Event, PartialEq, Eq, Debug)]
 pub struct OwnershipTransferStarted {
+    /// The previous owner.
     pub previous_owner: Option<Address>,
+    /// The new owner.
     pub new_owner: Option<Address>
 }
 
@@ -20,23 +27,32 @@ pub struct OwnershipTransferStarted {
 /// but `RoleAdminChanged` not being emitted signaling this.
 #[derive(Event, PartialEq, Eq, Debug)]
 pub struct RoleAdminChanged {
+    /// The role whose admin role is changed.
     pub role: Role,
+    /// The previous admin role.
     pub previous_admin_role: Role,
+    /// The new admin role.
     pub new_admin_role: Role
 }
 
 /// Informs `address` is granted `role`.
 #[derive(Event, PartialEq, Eq, Debug)]
 pub struct RoleGranted {
+    /// The role granted.
     pub role: Role,
+    /// The address granted the role.
     pub address: Address,
+    /// The address that granted the role.
     pub sender: Address
 }
 
 /// Informs `address` is revoked `role`.
 #[derive(Event, PartialEq, Eq, Debug)]
 pub struct RoleRevoked {
+    /// The role revoked.
     pub role: Role,
+    /// The address revoked the role.
     pub address: Address,
+    /// The address that revoked the role.
     pub sender: Address
 }

--- a/modules/src/access/ownable.rs
+++ b/modules/src/access/ownable.rs
@@ -1,3 +1,4 @@
+//! Ownable module.
 use crate::access::errors::Error::{CallerNotTheNewOwner, CallerNotTheOwner, OwnerNotSet};
 use crate::access::events::{OwnershipTransferStarted, OwnershipTransferred};
 use odra::prelude::*;
@@ -22,7 +23,6 @@ pub struct Ownable {
 #[odra::module]
 impl Ownable {
     /// Initializes the module setting the caller as the initial owner.
-    #[odra(init)]
     pub fn init(&mut self) {
         let caller = self.env().caller();
         let initial_owner = Some(caller);
@@ -61,10 +61,13 @@ impl Ownable {
         }
     }
 
+    /// Returns the optional address of the current owner.
     pub fn get_optional_owner(&self) -> Option<Address> {
         self.owner.get().flatten()
     }
 
+    /// Unchecked version of the ownership transfer. It emits an event and sets
+    /// the new owner.
     pub fn unchecked_transfer_ownership(&mut self, new_owner: Option<Address>) {
         let previous_owner = self.get_optional_owner();
         self.owner.set(new_owner);

--- a/modules/src/access/ownable.rs
+++ b/modules/src/access/ownable.rs
@@ -188,7 +188,7 @@ mod test {
 
         // when the current owner transfers ownership
         let new_owner = contract.env().get_account(1);
-        contract.transfer_ownership(new_owner);
+        contract.transfer_ownership(&new_owner);
 
         // then the new owner is set
         assert_eq!(new_owner, contract.get_owner());
@@ -209,7 +209,7 @@ mod test {
 
         // when the current owner transfers ownership
         let new_owner = contract.env().get_account(1);
-        contract.transfer_ownership(new_owner);
+        contract.transfer_ownership(&new_owner);
 
         // when the pending owner accepts the transfer
         contract.env().set_caller(new_owner);
@@ -246,7 +246,7 @@ mod test {
         contract.env().set_caller(caller);
 
         // then ownership transfer fails
-        let err = contract.try_transfer_ownership(new_owner).unwrap_err();
+        let err = contract.try_transfer_ownership(&new_owner).unwrap_err();
         assert_eq!(err, CallerNotTheOwner.into());
     }
 
@@ -260,12 +260,12 @@ mod test {
         contract.env().set_caller(caller);
 
         // then ownership transfer fails
-        let err = contract.try_transfer_ownership(new_owner).unwrap_err();
+        let err = contract.try_transfer_ownership(&new_owner).unwrap_err();
         assert_eq!(err, CallerNotTheOwner.into());
 
         // when the owner is the caller
         contract.env().set_caller(initial_owner);
-        contract.transfer_ownership(new_owner);
+        contract.transfer_ownership(&new_owner);
 
         // then the pending owner is set
         assert_eq!(contract.get_pending_owner(), Some(new_owner));

--- a/modules/src/erc1155/erc1155_base.rs
+++ b/modules/src/erc1155/erc1155_base.rs
@@ -12,7 +12,9 @@ use odra::{
 /// The ERC1155 base implementation.
 #[odra::module(events = [ApprovalForAll, TransferBatch, TransferSingle])]
 pub struct Erc1155Base {
+    /// The balances of the tokens.
     pub balances: Mapping<(Address, U256), U256>,
+    /// The approvals for the operators.
     pub approvals: Mapping<(Address, Address), bool>
 }
 

--- a/modules/src/erc1155/erc1155_base.rs
+++ b/modules/src/erc1155/erc1155_base.rs
@@ -6,7 +6,7 @@ use crate::erc1155_receiver::Erc1155ReceiverContractRef;
 use odra::prelude::*;
 use odra::{
     casper_types::{bytesrepr::Bytes, U256},
-    Address, Mapping
+    Address, ContractRef, Mapping
 };
 
 /// The ERC1155 base implementation.

--- a/modules/src/erc1155/erc1155_base.rs
+++ b/modules/src/erc1155/erc1155_base.rs
@@ -160,13 +160,8 @@ impl Erc1155Base {
         data: &Option<Bytes>
     ) {
         if to.is_contract() {
-            let response = Erc1155ReceiverContractRef::new(self.env(), *to).on_erc1155_received(
-                operator,
-                from,
-                id,
-                amount,
-                data
-            );
+            let response = Erc1155ReceiverContractRef::new(self.env(), *to)
+                .on_erc1155_received(operator, from, id, amount, data);
             if !response {
                 self.env().revert(Error::TransferRejected);
             }
@@ -186,13 +181,7 @@ impl Erc1155Base {
     ) {
         if to.is_contract() {
             let response = Erc1155ReceiverContractRef::new(self.env(), *to)
-                .on_erc1155_batch_received(
-                    operator,
-                    from,
-                    ids.to_vec(),
-                    amounts.to_vec(),
-                    data
-                );
+                .on_erc1155_batch_received(operator, from, ids.to_vec(), amounts.to_vec(), data);
             if !response {
                 self.env().revert(Error::TransferRejected);
             }

--- a/modules/src/erc1155/erc1155_base.rs
+++ b/modules/src/erc1155/erc1155_base.rs
@@ -23,7 +23,7 @@ impl Erc1155 for Erc1155Base {
         self.balances.get_or_default(&(*owner, *id))
     }
 
-    fn balance_of_batch(&self, owners: &[Address], ids: &[U256]) -> Vec<U256> {
+    fn balance_of_batch(&self, owners: Vec<Address>, ids: Vec<U256>) -> Vec<U256> {
         if owners.len() != ids.len() {
             self.env().revert(Error::AccountsAndIdsLengthMismatch);
         }
@@ -161,11 +161,11 @@ impl Erc1155Base {
     ) {
         if to.is_contract() {
             let response = Erc1155ReceiverContractRef::new(self.env(), *to).on_erc1155_received(
-                *operator,
-                *from,
-                *id,
-                *amount,
-                data.clone()
+                operator,
+                from,
+                id,
+                amount,
+                data
             );
             if !response {
                 self.env().revert(Error::TransferRejected);
@@ -187,11 +187,11 @@ impl Erc1155Base {
         if to.is_contract() {
             let response = Erc1155ReceiverContractRef::new(self.env(), *to)
                 .on_erc1155_batch_received(
-                    *operator,
-                    *from,
+                    operator,
+                    from,
                     ids.to_vec(),
                     amounts.to_vec(),
-                    data.clone()
+                    data
                 );
             if !response {
                 self.env().revert(Error::TransferRejected);

--- a/modules/src/erc1155/mod.rs
+++ b/modules/src/erc1155/mod.rs
@@ -16,7 +16,7 @@ pub trait Erc1155 {
     ///  Batched version of [Erc1155::balance_of](Self::balance_of).
     ///
     /// The length of `owners` and `ids` must be the same.
-    fn balance_of_batch(&self, owners: &[Address], ids: &[U256]) -> Vec<U256>;
+    fn balance_of_batch(&self, owners: Vec<Address>, ids: Vec<U256>) -> Vec<U256>;
     /// Allows or denials the `operator` to transfer the caller’s tokens.
     ///
     /// Emits [crate::erc1155::events::ApprovalForAll].

--- a/modules/src/erc1155/mod.rs
+++ b/modules/src/erc1155/mod.rs
@@ -60,28 +60,41 @@ pub mod events {
     /// Emitted when a single Erc1155 transfer is performed.
     #[derive(Event, PartialEq, Eq, Debug, Clone)]
     pub struct TransferSingle {
+        /// The operator that called the function.
         pub operator: Option<Address>,
+        /// The address from which the tokens are transferred.
         pub from: Option<Address>,
+        /// The address to which the tokens are transferred.
         pub to: Option<Address>,
+        /// The token id.
         pub id: U256,
+        /// The token amount.
         pub value: U256
     }
 
     /// Emitted when a batched Erc1155 transfer is performed.
     #[derive(Event, PartialEq, Eq, Debug, Clone)]
     pub struct TransferBatch {
+        /// The operator that called the function.
         pub operator: Option<Address>,
+        /// The address from which the tokens are transferred.
         pub from: Option<Address>,
+        /// The address to which the tokens are transferred.
         pub to: Option<Address>,
+        /// The token ids.
         pub ids: Vec<U256>,
+        /// The token amounts.
         pub values: Vec<U256>
     }
 
     /// Emitted when the `owner` approves or revokes the `operator`.
     #[derive(Event, PartialEq, Eq, Debug, Clone)]
     pub struct ApprovalForAll {
+        /// The owner of the tokens.
         pub owner: Address,
+        /// The operator that is approved.
         pub operator: Address,
+        /// The approval status.
         pub approved: bool
     }
 }

--- a/modules/src/erc1155/owned_erc1155.rs
+++ b/modules/src/erc1155/owned_erc1155.rs
@@ -31,7 +31,7 @@ pub trait OwnedErc1155 {
     ///  Batched version of [Erc1155::balance_of](Self::balance_of).
     ///
     /// The length of `owners` and `ids` must be the same.
-    fn balance_of_batch(&self, owners: &[Address], ids: &[U256]) -> Vec<U256>;
+    fn balance_of_batch(&self, owners: Vec<Address>, ids: Vec<U256>) -> Vec<U256>;
     /// Allows or denials the `operator` to transfer the caller’s tokens.
     ///
     /// Emits [crate::erc1155::events::ApprovalForAll].

--- a/modules/src/erc1155_receiver.rs
+++ b/modules/src/erc1155_receiver.rs
@@ -69,20 +69,30 @@ pub mod events {
     /// Emitted when the transferred token is accepted by the contract.
     #[derive(Event, PartialEq, Eq, Debug, Clone)]
     pub struct SingleReceived {
+        /// The operator that called the function.
         pub operator: Option<Address>,
+        /// The address of the sender.
         pub from: Option<Address>,
+        /// The token id.
         pub token_id: U256,
+        /// The token amount.
         pub amount: U256,
+        /// The token data.
         pub data: Option<Bytes>
     }
 
     /// Emitted when the transferred tokens are accepted by the contract.
     #[derive(Event, PartialEq, Eq, Debug, Clone)]
     pub struct BatchReceived {
+        /// The operator that called the function.
         pub operator: Option<Address>,
+        /// The address of the sender.
         pub from: Option<Address>,
+        /// The token ids.
         pub token_ids: Vec<U256>,
+        /// The token amounts.
         pub amounts: Vec<U256>,
+        /// The token data.
         pub data: Option<Bytes>
     }
 }

--- a/modules/src/erc1155_receiver.rs
+++ b/modules/src/erc1155_receiver.rs
@@ -18,11 +18,11 @@ impl Erc1155Receiver {
     /// Emits [SingleReceived].
     pub fn on_erc1155_received(
         &mut self,
-        #[allow(unused_variables)] operator: &Address,
-        #[allow(unused_variables)] from: &Address,
-        #[allow(unused_variables)] token_id: &U256,
-        #[allow(unused_variables)] amount: &U256,
-        #[allow(unused_variables)] data: &Option<Bytes>
+        operator: &Address,
+        from: &Address,
+        token_id: &U256,
+        amount: &U256,
+        data: &Option<Bytes>
     ) -> bool {
         self.env().emit_event(SingleReceived {
             operator: Some(*operator),
@@ -40,11 +40,11 @@ impl Erc1155Receiver {
     /// Emits [BatchReceived].
     pub fn on_erc1155_batch_received(
         &mut self,
-        #[allow(unused_variables)] operator: &Address,
-        #[allow(unused_variables)] from: &Address,
-        #[allow(unused_variables)] token_ids: Vec<U256>,
-        #[allow(unused_variables)] amounts: Vec<U256>,
-        #[allow(unused_variables)] data: &Option<Bytes>
+        operator: &Address,
+        from: &Address,
+        token_ids: Vec<U256>,
+        amounts: Vec<U256>,
+        data: &Option<Bytes>
     ) -> bool {
         self.env().emit_event(BatchReceived {
             operator: Some(*operator),

--- a/modules/src/erc1155_token.rs
+++ b/modules/src/erc1155_token.rs
@@ -184,6 +184,7 @@ mod tests {
     use crate::erc1155::errors::Error;
     use crate::erc1155::errors::Error::InsufficientBalance;
     use crate::erc1155::events::{ApprovalForAll, TransferBatch, TransferSingle};
+    use crate::erc1155::owned_erc1155::OwnedErc1155;
     use crate::erc1155_receiver::events::{BatchReceived, SingleReceived};
     use crate::erc1155_receiver::Erc1155ReceiverHostRef;
     use crate::erc1155_token::Erc1155TokenHostRef;
@@ -221,10 +222,10 @@ mod tests {
         let mut env = setup();
 
         // When we mint some tokens
-        env.token.mint(env.alice, U256::one(), 100.into(), None);
+        env.token.mint(&env.alice, &U256::one(), &100.into(), &None);
 
         // Then the balance is updated
-        assert_eq!(env.token.balance_of(env.alice, U256::one()), 100.into());
+        assert_eq!(env.token.balance_of(&env.alice, &U256::one()), 100.into());
 
         // And the event is emitted
         let contract = env.token;
@@ -247,10 +248,10 @@ mod tests {
 
         // When we mint some tokens in batch
         env.token.mint_batch(
-            env.alice,
-            [U256::one(), U256::from(2)].to_vec(),
-            [100.into(), 200.into()].to_vec(),
-            None
+            &env.alice,
+            vec![U256::one(), U256::from(2)],
+            vec![100.into(), 200.into()],
+            &None
         );
 
         // Then it emits the event
@@ -266,8 +267,8 @@ mod tests {
         );
 
         // And the balances are updated
-        assert_eq!(env.token.balance_of(env.alice, U256::one()), 100.into());
-        assert_eq!(env.token.balance_of(env.alice, U256::from(2)), 200.into());
+        assert_eq!(env.token.balance_of(&env.alice, &U256::one()), 100.into());
+        assert_eq!(env.token.balance_of(&env.alice, &U256::from(2)), 200.into());
     }
 
     #[test]
@@ -278,10 +279,10 @@ mod tests {
         let err = env
             .token
             .try_mint_batch(
-                env.alice,
+                &env.alice,
                 [U256::one(), U256::from(2)].to_vec(),
                 [100.into()].to_vec(),
-                None
+                &None
             )
             .unwrap_err();
         assert_eq!(err, Error::IdsAndAmountsLengthMismatch.into());
@@ -293,13 +294,13 @@ mod tests {
         let mut env = setup();
 
         // And some tokens minted
-        env.token.mint(env.alice, U256::one(), 100.into(), None);
+        env.token.mint(&env.alice, &U256::one(), &100.into(), &None);
 
         // When we burn some tokens
-        env.token.burn(env.alice, U256::one(), 50.into());
+        env.token.burn(&env.alice, &U256::one(), &50.into());
 
         // Then the balance is updated
-        assert_eq!(env.token.balance_of(env.alice, U256::one()), 50.into());
+        assert_eq!(env.token.balance_of(&env.alice, &U256::one()), 50.into());
 
         // And the event is emitted
         let contract = env.token;
@@ -321,11 +322,11 @@ mod tests {
         let mut env = setup();
 
         // And some tokens minted
-        env.token.mint(env.alice, U256::one(), 100.into(), None);
+        env.token.mint(&env.alice, &U256::one(), &100.into(), &None);
         // When we burn more tokens than we have it errors out
         let err = env
             .token
-            .try_burn(env.alice, U256::one(), 150.into())
+            .try_burn(&env.alice, &U256::one(), &150.into())
             .unwrap_err();
         assert_eq!(err, InsufficientBalance.into());
 
@@ -334,7 +335,7 @@ mod tests {
         // When we burn non-existing tokens it errors out
         let err = env
             .token
-            .try_burn(env.alice, U256::one(), 150.into())
+            .try_burn(&env.alice, &U256::one(), &150.into())
             .unwrap_err();
         assert_eq!(err, InsufficientBalance.into());
     }
@@ -346,22 +347,22 @@ mod tests {
 
         // And some tokens minted
         env.token.mint_batch(
-            env.alice,
+            &env.alice,
             [U256::one(), U256::from(2)].to_vec(),
             [100.into(), 200.into()].to_vec(),
-            None
+            &None
         );
 
         // When we burn some tokens in batch
         env.token.burn_batch(
-            env.alice,
+            &env.alice,
             [U256::one(), U256::from(2)].to_vec(),
             [50.into(), 100.into()].to_vec()
         );
 
         // Then the balances are updated
-        assert_eq!(env.token.balance_of(env.alice, U256::one()), 50.into());
-        assert_eq!(env.token.balance_of(env.alice, U256::from(2)), 100.into());
+        assert_eq!(env.token.balance_of(&env.alice, &U256::one()), 50.into());
+        assert_eq!(env.token.balance_of(&env.alice, &U256::from(2)), 100.into());
 
         // And the event is emitted
         let contract = env.token;
@@ -384,17 +385,17 @@ mod tests {
 
         // And some tokens minted
         env.token.mint_batch(
-            env.alice,
+            &env.alice,
             [U256::one(), U256::from(2)].to_vec(),
             [100.into(), 200.into()].to_vec(),
-            None
+            &None
         );
 
         // When we burn some tokens in batch with mismatching ids and amounts it errors out
         let err = env
             .token
             .try_burn_batch(
-                env.alice,
+                &env.alice,
                 [U256::one(), U256::from(2)].to_vec(),
                 [50.into()].to_vec()
             )
@@ -406,17 +407,17 @@ mod tests {
 
         // And some tokens minted
         env.token.mint_batch(
-            env.alice,
+            &env.alice,
             [U256::one(), U256::from(2)].to_vec(),
             [100.into(), 200.into()].to_vec(),
-            None
+            &None
         );
 
         // When we burn more tokens than we have it errors out
         let err = env
             .token
             .try_burn_batch(
-                env.alice,
+                &env.alice,
                 [U256::one(), U256::from(2)].to_vec(),
                 [150.into(), 300.into()].to_vec()
             )
@@ -430,7 +431,7 @@ mod tests {
         let err = env
             .token
             .try_burn_batch(
-                env.alice,
+                &env.alice,
                 [U256::one(), U256::from(2)].to_vec(),
                 [150.into(), 300.into()].to_vec()
             )
@@ -444,15 +445,16 @@ mod tests {
         let mut env = setup();
 
         // And some tokens minted
-        env.token.mint(env.alice, U256::one(), 100.into(), None);
-        env.token.mint(env.alice, U256::from(2), 200.into(), None);
-        env.token.mint(env.bob, U256::one(), 300.into(), None);
+        env.token.mint(&env.alice, &U256::one(), &100.into(), &None);
+        env.token
+            .mint(&env.alice, &U256::from(2), &200.into(), &None);
+        env.token.mint(&env.bob, &U256::one(), &300.into(), &None);
 
         // Then it returns the correct balance
-        assert_eq!(env.token.balance_of(env.alice, U256::one()), 100.into());
-        assert_eq!(env.token.balance_of(env.alice, U256::from(2)), 200.into());
-        assert_eq!(env.token.balance_of(env.bob, U256::one()), 300.into());
-        assert_eq!(env.token.balance_of(env.bob, U256::from(2)), 0.into());
+        assert_eq!(env.token.balance_of(&env.alice, &U256::one()), 100.into());
+        assert_eq!(env.token.balance_of(&env.alice, &U256::from(2)), 200.into());
+        assert_eq!(env.token.balance_of(&env.bob, &U256::one()), 300.into());
+        assert_eq!(env.token.balance_of(&env.bob, &U256::from(2)), 0.into());
     }
 
     #[test]
@@ -462,16 +464,16 @@ mod tests {
 
         // And some tokens minted
         env.token.mint_batch(
-            env.alice,
+            &env.alice,
             [U256::one(), U256::from(2)].to_vec(),
             [100.into(), 200.into()].to_vec(),
-            None
+            &None
         );
         env.token.mint_batch(
-            env.bob,
+            &env.bob,
             [U256::one(), U256::from(2)].to_vec(),
             [300.into(), 400.into()].to_vec(),
-            None
+            &None
         );
 
         // Then it returns the correct balances
@@ -508,10 +510,10 @@ mod tests {
 
         // And some tokens minted
         env.token.mint_batch(
-            env.alice,
+            &env.alice,
             [U256::one(), U256::from(2)].to_vec(),
             [100.into(), 200.into()].to_vec(),
-            None
+            &None
         );
 
         // When we query balances with mismatching ids and addresses it errors out
@@ -532,10 +534,10 @@ mod tests {
 
         // When we set approval for all
         env.env.set_caller(env.alice);
-        env.token.set_approval_for_all(env.bob, true);
+        env.token.set_approval_for_all(&env.bob, true);
 
         // Then the approval is set
-        assert!(env.token.is_approved_for_all(env.alice, env.bob));
+        assert!(env.token.is_approved_for_all(&env.alice, &env.bob));
 
         // And the event is emitted
         env.env.emitted_event(
@@ -555,14 +557,14 @@ mod tests {
 
         // And approval for all set
         env.env.set_caller(env.alice);
-        env.token.set_approval_for_all(env.bob, true);
+        env.token.set_approval_for_all(&env.bob, true);
 
         // When we unset approval for all
         env.env.set_caller(env.alice);
-        env.token.set_approval_for_all(env.bob, false);
+        env.token.set_approval_for_all(&env.bob, false);
 
         // Then the approval is unset
-        assert!(!env.token.is_approved_for_all(env.alice, env.bob));
+        assert!(!env.token.is_approved_for_all(&env.alice, &env.bob));
 
         // And the event is emitted
         let contract = env.token;
@@ -585,7 +587,7 @@ mod tests {
         env.env.set_caller(env.alice);
         let err = env
             .token
-            .try_set_approval_for_all(env.alice, true)
+            .try_set_approval_for_all(&env.alice, true)
             .unwrap_err();
         assert_eq!(err, Error::ApprovalForSelf.into());
     }
@@ -596,16 +598,16 @@ mod tests {
         let mut env = setup();
 
         // And some tokens minted
-        env.token.mint(env.alice, U256::one(), 100.into(), None);
+        env.token.mint(&env.alice, &U256::one(), &100.into(), &None);
 
         // When we transfer tokens
         env.env.set_caller(env.alice);
         env.token
-            .safe_transfer_from(env.alice, env.bob, U256::one(), 50.into(), None);
+            .safe_transfer_from(&env.alice, &env.bob, &U256::one(), &50.into(), &None);
 
         // Then the tokens are transferred
-        assert_eq!(env.token.balance_of(env.alice, U256::one()), 50.into());
-        assert_eq!(env.token.balance_of(env.bob, U256::one()), 50.into());
+        assert_eq!(env.token.balance_of(&env.alice, &U256::one()), 50.into());
+        assert_eq!(env.token.balance_of(&env.bob, &U256::one()), 50.into());
 
         // And the event is emitted
         let contract = env.token;
@@ -627,20 +629,20 @@ mod tests {
         let mut env = setup();
 
         // And some tokens minted
-        env.token.mint(env.alice, U256::one(), 100.into(), None);
+        env.token.mint(&env.alice, &U256::one(), &100.into(), &None);
 
         // And approval for all set
         env.env.set_caller(env.alice);
-        env.token.set_approval_for_all(env.bob, true);
+        env.token.set_approval_for_all(&env.bob, true);
 
         // When we transfer tokens
         env.env.set_caller(env.bob);
         env.token
-            .safe_transfer_from(env.alice, env.bob, U256::one(), 50.into(), None);
+            .safe_transfer_from(&env.alice, &env.bob, &U256::one(), &50.into(), &None);
 
         // Then the tokens are transferred
-        assert_eq!(env.token.balance_of(env.alice, U256::one()), 50.into());
-        assert_eq!(env.token.balance_of(env.bob, U256::one()), 50.into());
+        assert_eq!(env.token.balance_of(&env.alice, &U256::one()), 50.into());
+        assert_eq!(env.token.balance_of(&env.bob, &U256::one()), 50.into());
 
         // And the event is emitted
         let contract = env.token;
@@ -662,13 +664,13 @@ mod tests {
         let mut env = setup();
 
         // And some tokens minted
-        env.token.mint(env.alice, U256::one(), 100.into(), None);
+        env.token.mint(&env.alice, &U256::one(), &100.into(), &None);
 
         // When we transfer more tokens than we have it errors out
         env.env.set_caller(env.alice);
         let err = env
             .token
-            .try_safe_transfer_from(env.alice, env.bob, U256::one(), 200.into(), None)
+            .try_safe_transfer_from(&env.alice, &env.bob, &U256::one(), &200.into(), &None)
             .unwrap_err();
         assert_eq!(err, Error::InsufficientBalance.into());
 
@@ -676,13 +678,13 @@ mod tests {
         // env.env.set_caller(test_env::get_account(0));
         let mut env = setup();
         // And some tokens minted
-        env.token.mint(env.alice, U256::one(), 100.into(), None);
+        env.token.mint(&env.alice, &U256::one(), &100.into(), &None);
 
         // When we transfer not our tokens it errors out
         env.env.set_caller(env.bob);
         let err = env
             .token
-            .try_safe_transfer_from(env.alice, env.bob, U256::one(), 100.into(), None)
+            .try_safe_transfer_from(&env.alice, &env.bob, &U256::one(), &100.into(), &None)
             .unwrap_err();
         assert_eq!(err, Error::NotAnOwnerOrApproved.into());
     }
@@ -693,24 +695,25 @@ mod tests {
         let mut env = setup();
 
         // And some tokens minted
-        env.token.mint(env.alice, U256::one(), 100.into(), None);
-        env.token.mint(env.alice, U256::from(2), 200.into(), None);
+        env.token.mint(&env.alice, &U256::one(), &100.into(), &None);
+        env.token
+            .mint(&env.alice, &U256::from(2), &200.into(), &None);
 
         // When we transfer tokens
         env.env.set_caller(env.alice);
         env.token.safe_batch_transfer_from(
-            env.alice,
-            env.bob,
+            &env.alice,
+            &env.bob,
             [U256::one(), U256::from(2)].to_vec(),
             [50.into(), 100.into()].to_vec(),
-            None
+            &None
         );
 
         // Then the tokens are transferred
-        assert_eq!(env.token.balance_of(env.alice, U256::one()), 50.into());
-        assert_eq!(env.token.balance_of(env.alice, U256::from(2)), 100.into());
-        assert_eq!(env.token.balance_of(env.bob, U256::one()), 50.into());
-        assert_eq!(env.token.balance_of(env.bob, U256::from(2)), 100.into());
+        assert_eq!(env.token.balance_of(&env.alice, &U256::one()), 50.into());
+        assert_eq!(env.token.balance_of(&env.alice, &U256::from(2)), 100.into());
+        assert_eq!(env.token.balance_of(&env.bob, &U256::one()), 50.into());
+        assert_eq!(env.token.balance_of(&env.bob, &U256::from(2)), 100.into());
 
         // And the event is emitted
         let contract = env.token;
@@ -732,28 +735,29 @@ mod tests {
         let mut env = setup();
 
         // And some tokens minted
-        env.token.mint(env.alice, U256::one(), 100.into(), None);
-        env.token.mint(env.alice, U256::from(2), 200.into(), None);
+        env.token.mint(&env.alice, &U256::one(), &100.into(), &None);
+        env.token
+            .mint(&env.alice, &U256::from(2), &200.into(), &None);
 
         // And approval for all set
         env.env.set_caller(env.alice);
-        env.token.set_approval_for_all(env.bob, true);
+        env.token.set_approval_for_all(&env.bob, true);
 
         // When we transfer tokens
         env.env.set_caller(env.bob);
         env.token.safe_batch_transfer_from(
-            env.alice,
-            env.bob,
+            &env.alice,
+            &env.bob,
             [U256::one(), U256::from(2)].to_vec(),
             [50.into(), 100.into()].to_vec(),
-            None
+            &None
         );
 
         // Then the tokens are transferred
-        assert_eq!(env.token.balance_of(env.alice, U256::one()), 50.into());
-        assert_eq!(env.token.balance_of(env.alice, U256::from(2)), 100.into());
-        assert_eq!(env.token.balance_of(env.bob, U256::one()), 50.into());
-        assert_eq!(env.token.balance_of(env.bob, U256::from(2)), 100.into());
+        assert_eq!(env.token.balance_of(&env.alice, &U256::one()), 50.into());
+        assert_eq!(env.token.balance_of(&env.alice, &U256::from(2)), 100.into());
+        assert_eq!(env.token.balance_of(&env.bob, &U256::one()), 50.into());
+        assert_eq!(env.token.balance_of(&env.bob, &U256::from(2)), 100.into());
 
         // And the event is emitted
         let contract = env.token;
@@ -775,18 +779,19 @@ mod tests {
         let mut env = setup();
 
         // And some tokens minted
-        env.token.mint(env.alice, U256::one(), 100.into(), None);
-        env.token.mint(env.alice, U256::from(2), 200.into(), None);
+        env.token.mint(&env.alice, &U256::one(), &100.into(), &None);
+        env.token
+            .mint(&env.alice, &U256::from(2), &200.into(), &None);
         // When we transfer more tokens than we have it errors out
         env.env.set_caller(env.alice);
         let err = env
             .token
             .try_safe_batch_transfer_from(
-                env.alice,
-                env.bob,
+                &env.alice,
+                &env.bob,
                 [U256::one(), U256::from(2)].to_vec(),
                 [50.into(), 300.into()].to_vec(),
-                None
+                &None
             )
             .unwrap_err();
         assert_eq!(err, Error::InsufficientBalance.into());
@@ -795,18 +800,19 @@ mod tests {
         let mut env = setup();
 
         // And some tokens minted
-        env.token.mint(env.alice, U256::one(), 100.into(), None);
-        env.token.mint(env.alice, U256::from(2), 200.into(), None);
+        env.token.mint(&env.alice, &U256::one(), &100.into(), &None);
+        env.token
+            .mint(&env.alice, &U256::from(2), &200.into(), &None);
         // When we transfer not our tokens it errors out
         env.env.set_caller(env.bob);
         let err = env
             .token
             .try_safe_batch_transfer_from(
-                env.alice,
-                env.bob,
+                &env.alice,
+                &env.bob,
                 [U256::one(), U256::from(2)].to_vec(),
                 [50.into(), 100.into()].to_vec(),
-                None
+                &None
             )
             .unwrap_err();
         assert_eq!(err, Error::NotAnOwnerOrApproved.into());
@@ -820,22 +826,22 @@ mod tests {
 
         let receiver = Erc1155ReceiverHostRef::deploy(&env.env, NoArgs);
         // And some tokens minted
-        env.token.mint(env.alice, U256::one(), 100.into(), None);
+        env.token.mint(&env.alice, &U256::one(), &100.into(), &None);
 
         // When we transfer tokens to a valid receiver
         env.env.set_caller(env.alice);
         env.token.safe_transfer_from(
-            env.alice,
-            *receiver.address(),
-            U256::one(),
-            100.into(),
-            None
+            &env.alice,
+            receiver.address(),
+            &U256::one(),
+            &100.into(),
+            &None
         );
 
         // Then the tokens are transferred
-        assert_eq!(env.token.balance_of(env.alice, U256::one()), 0.into());
+        assert_eq!(env.token.balance_of(&env.alice, &U256::one()), 0.into());
         assert_eq!(
-            env.token.balance_of(*receiver.address(), U256::one()),
+            env.token.balance_of(receiver.address(), &U256::one()),
             100.into()
         );
 
@@ -859,22 +865,22 @@ mod tests {
         // And a valid receiver
         let receiver = Erc1155ReceiverHostRef::deploy(&env.env, NoArgs);
         // And some tokens minted
-        env.token.mint(env.alice, U256::one(), 100.into(), None);
+        env.token.mint(&env.alice, &U256::one(), &100.into(), &None);
 
         // When we transfer tokens to a valid receiver
         env.env.set_caller(env.alice);
         env.token.safe_transfer_from(
-            env.alice,
-            *receiver.address(),
-            U256::one(),
-            100.into(),
-            Some(Bytes::from(b"data".to_vec()))
+            &env.alice,
+            receiver.address(),
+            &U256::one(),
+            &100.into(),
+            &Some(Bytes::from(b"data".to_vec()))
         );
 
         // Then the tokens are transferred
-        assert_eq!(env.token.balance_of(env.alice, U256::one()), 0.into());
+        assert_eq!(env.token.balance_of(&env.alice, &U256::one()), 0.into());
         assert_eq!(
-            env.token.balance_of(*receiver.address(), U256::one()),
+            env.token.balance_of(receiver.address(), &U256::one()),
             100.into()
         );
 
@@ -898,17 +904,17 @@ mod tests {
         // And an invalid receiver
         let receiver = WrappedNativeTokenHostRef::deploy(&env.env, NoArgs);
         // And some tokens minted
-        env.token.mint(env.alice, U256::one(), 100.into(), None);
+        env.token.mint(&env.alice, &U256::one(), &100.into(), &None);
 
         // When we transfer tokens to an invalid receiver
         // Then it errors out
         env.env.set_caller(env.alice);
         let err = env.token.try_safe_transfer_from(
-            env.alice,
-            *receiver.address(),
-            U256::one(),
-            100.into(),
-            None
+            &env.alice,
+            receiver.address(),
+            &U256::one(),
+            &100.into(),
+            &None
         );
         assert_eq!(
             err,
@@ -925,28 +931,29 @@ mod tests {
         // And a valid receiver
         let receiver = Erc1155ReceiverHostRef::deploy(&env.env, NoArgs);
         // And some tokens minted
-        env.token.mint(env.alice, U256::one(), 100.into(), None);
-        env.token.mint(env.alice, U256::from(2), 100.into(), None);
+        env.token.mint(&env.alice, &U256::one(), &100.into(), &None);
+        env.token
+            .mint(&env.alice, &U256::from(2), &100.into(), &None);
 
         // When we transfer tokens to a valid receiver
         env.env.set_caller(env.alice);
         env.token.safe_batch_transfer_from(
-            env.alice,
-            *receiver.address(),
+            &env.alice,
+            receiver.address(),
             [U256::one(), U256::from(2)].to_vec(),
             [100.into(), 100.into()].to_vec(),
-            None
+            &None
         );
 
         // Then the tokens are transferred
-        assert_eq!(env.token.balance_of(env.alice, U256::one()), 0.into());
+        assert_eq!(env.token.balance_of(&env.alice, &U256::one()), 0.into());
         assert_eq!(
-            env.token.balance_of(*receiver.address(), U256::one()),
+            env.token.balance_of(receiver.address(), &U256::one()),
             100.into()
         );
-        assert_eq!(env.token.balance_of(env.alice, U256::from(2)), 0.into());
+        assert_eq!(env.token.balance_of(&env.alice, &U256::from(2)), 0.into());
         assert_eq!(
-            env.token.balance_of(*receiver.address(), U256::from(2)),
+            env.token.balance_of(receiver.address(), &U256::from(2)),
             100.into()
         );
 
@@ -970,28 +977,29 @@ mod tests {
         // And a valid receiver
         let receiver = Erc1155ReceiverHostRef::deploy(&env.env, NoArgs);
         // And some tokens minted
-        env.token.mint(env.alice, U256::one(), 100.into(), None);
-        env.token.mint(env.alice, U256::from(2), 100.into(), None);
+        env.token.mint(&env.alice, &U256::one(), &100.into(), &None);
+        env.token
+            .mint(&env.alice, &U256::from(2), &100.into(), &None);
 
         // When we transfer tokens to a valid receiver
         env.env.set_caller(env.alice);
         env.token.safe_batch_transfer_from(
-            env.alice,
-            *receiver.address(),
+            &env.alice,
+            receiver.address(),
             [U256::one(), U256::from(2)].to_vec(),
             [100.into(), 100.into()].to_vec(),
-            Some(Bytes::from(b"data".to_vec()))
+            &Some(Bytes::from(b"data".to_vec()))
         );
 
         // Then the tokens are transferred
-        assert_eq!(env.token.balance_of(env.alice, U256::one()), 0.into());
+        assert_eq!(env.token.balance_of(&env.alice, &U256::one()), 0.into());
         assert_eq!(
-            env.token.balance_of(*receiver.address(), U256::one()),
+            env.token.balance_of(receiver.address(), &U256::one()),
             100.into()
         );
-        assert_eq!(env.token.balance_of(env.alice, U256::from(2)), 0.into());
+        assert_eq!(env.token.balance_of(&env.alice, &U256::from(2)), 0.into());
         assert_eq!(
-            env.token.balance_of(*receiver.address(), U256::from(2)),
+            env.token.balance_of(receiver.address(), &U256::from(2)),
             100.into()
         );
 
@@ -1015,8 +1023,9 @@ mod tests {
         // And an invalid receiver
         let receiver = WrappedNativeTokenHostRef::deploy(&env.env, NoArgs);
         // And some tokens minted
-        env.token.mint(env.alice, U256::one(), 100.into(), None);
-        env.token.mint(env.alice, U256::from(2), 100.into(), None);
+        env.token.mint(&env.alice, &U256::one(), &100.into(), &None);
+        env.token
+            .mint(&env.alice, &U256::from(2), &100.into(), &None);
 
         // When we transfer tokens to an invalid receiver
         // Then it errors out
@@ -1024,11 +1033,11 @@ mod tests {
         let err = env
             .token
             .try_safe_batch_transfer_from(
-                env.alice,
-                *receiver.address(),
-                [U256::one(), U256::from(2)].to_vec(),
-                [100.into(), 100.into()].to_vec(),
-                None
+                &env.alice,
+                receiver.address(),
+                vec![U256::one(), U256::from(2)],
+                vec![100.into(), 100.into()],
+                &None
             )
             .unwrap_err();
         assert_eq!(

--- a/modules/src/erc1155_token.rs
+++ b/modules/src/erc1155_token.rs
@@ -28,7 +28,7 @@ impl OwnedErc1155 for Erc1155Token {
     fn balance_of(&self, owner: &Address, id: &U256) -> U256 {
         self.core.balance_of(owner, id)
     }
-    fn balance_of_batch(&self, owners: &[Address], ids: &[U256]) -> Vec<U256> {
+    fn balance_of_batch(&self, owners: Vec<Address>, ids: Vec<U256>) -> Vec<U256> {
         self.core.balance_of_batch(owners, ids)
     }
     fn set_approval_for_all(&mut self, operator: &Address, approved: bool) {

--- a/modules/src/erc20.rs
+++ b/modules/src/erc20.rs
@@ -274,16 +274,16 @@ mod tests {
         let sender = env.get_account(0);
         let recipient = env.get_account(1);
         let amount = 1_000.into();
-        erc20.transfer(recipient, amount);
+        erc20.transfer(&recipient, &amount);
 
         // Then the sender balance is deducted.
         assert_eq!(
-            erc20.balance_of(sender),
+            erc20.balance_of(&sender),
             U256::from(INITIAL_SUPPLY) - amount
         );
 
         // Then the recipient balance is updated.
-        assert_eq!(erc20.balance_of(recipient), amount);
+        assert_eq!(erc20.balance_of(&recipient), amount);
 
         // Then Transfer event was emitted.
         assert!(env.emitted_event(
@@ -306,7 +306,7 @@ mod tests {
         let amount = U256::from(INITIAL_SUPPLY) + U256::one();
 
         // Then an error occurs.
-        assert!(erc20.try_transfer(recipient, amount).is_err());
+        assert!(erc20.try_transfer(&recipient, &amount).is_err());
     }
 
     #[test]
@@ -318,13 +318,13 @@ mod tests {
         let approved_amount = 3_000.into();
         let transfer_amount = 1_000.into();
 
-        assert_eq!(erc20.balance_of(owner), U256::from(INITIAL_SUPPLY));
+        assert_eq!(erc20.balance_of(&owner), U256::from(INITIAL_SUPPLY));
 
         // Owner approves Spender.
-        erc20.approve(spender, approved_amount);
+        erc20.approve(&spender, &approved_amount);
 
         // Allowance was recorded.
-        assert_eq!(erc20.allowance(owner, spender), approved_amount);
+        assert_eq!(erc20.allowance(&owner, &spender), approved_amount);
         assert!(env.emitted_event(
             erc20.address(),
             &Approval {
@@ -336,14 +336,14 @@ mod tests {
 
         // Spender transfers tokens from Owner to Recipient.
         env.set_caller(spender);
-        erc20.transfer_from(owner, recipient, transfer_amount);
+        erc20.transfer_from(&owner, &recipient, &transfer_amount);
 
         // Tokens are transferred and allowance decremented.
         assert_eq!(
-            erc20.balance_of(owner),
+            erc20.balance_of(&owner),
             U256::from(INITIAL_SUPPLY) - transfer_amount
         );
-        assert_eq!(erc20.balance_of(recipient), transfer_amount);
+        assert_eq!(erc20.balance_of(&recipient), transfer_amount);
         assert!(env.emitted_event(
             erc20.address(),
             &Approval {
@@ -375,7 +375,7 @@ mod tests {
 
         // Then transfer fails.
         assert_eq!(
-            erc20.try_transfer_from(owner, recipient, amount),
+            erc20.try_transfer_from(&owner, &recipient, &amount),
             Err(Error::InsufficientAllowance.into())
         );
     }

--- a/modules/src/erc20.rs
+++ b/modules/src/erc20.rs
@@ -1,8 +1,10 @@
+//! ERC20 token standard implementation.
 use crate::erc20::errors::Error::*;
 use crate::erc20::events::*;
 use odra::prelude::*;
 use odra::{casper_types::U256, Address, Mapping, Var};
 
+/// ERC20 token module
 #[odra::module(events = [Approval, Transfer])]
 pub struct Erc20 {
     decimals: Var<u8>,
@@ -15,6 +17,7 @@ pub struct Erc20 {
 
 #[odra::module]
 impl Erc20 {
+    /// Initializes the contract with the given metadata and initial supply.
     pub fn init(
         &mut self,
         symbol: String,
@@ -41,11 +44,13 @@ impl Erc20 {
         }
     }
 
+    /// Transfers tokens from the caller to the recipient.
     pub fn transfer(&mut self, recipient: &Address, amount: &U256) {
         let caller = self.env().caller();
         self.raw_transfer(&caller, recipient, amount);
     }
 
+    /// Transfers tokens from the owner to the recipient using the spender's allowance.
     pub fn transfer_from(&mut self, owner: &Address, recipient: &Address, amount: &U256) {
         let spender = self.env().caller();
 
@@ -53,6 +58,7 @@ impl Erc20 {
         self.raw_transfer(owner, recipient, amount);
     }
 
+    /// Approves the spender to spend the given amount of tokens on behalf of the caller.
     pub fn approve(&mut self, spender: &Address, amount: &U256) {
         let owner = self.env().caller();
 
@@ -64,30 +70,37 @@ impl Erc20 {
         });
     }
 
+    /// Returns the name of the token.
     pub fn name(&self) -> String {
         self.name.get_or_revert_with(NameNotSet)
     }
 
+    /// Returns the symbol of the token.
     pub fn symbol(&self) -> String {
         self.symbol.get_or_revert_with(SymbolNotSet)
     }
 
+    /// Returns the number of decimals the token uses.
     pub fn decimals(&self) -> u8 {
         self.decimals.get_or_revert_with(DecimalsNotSet)
     }
 
+    /// Returns the total supply of the token.
     pub fn total_supply(&self) -> U256 {
         self.total_supply.get_or_default()
     }
 
+    /// Returns the balance of the given address.
     pub fn balance_of(&self, address: &Address) -> U256 {
         self.balances.get_or_default(address)
     }
 
+    /// Returns the amount of tokens the owner has allowed the spender to spend.
     pub fn allowance(&self, owner: &Address, spender: &Address) -> U256 {
         self.allowances.get_or_default(&(*owner, *spender))
     }
 
+    /// Mints new tokens and assigns them to the given address.
     pub fn mint(&mut self, address: &Address, amount: &U256) {
         self.total_supply.add(*amount);
         self.balances.add(address, *amount);
@@ -99,6 +112,7 @@ impl Erc20 {
         });
     }
 
+    /// Burns the given amount of tokens from the given address.
     pub fn burn(&mut self, address: &Address, amount: &U256) {
         if self.balance_of(address) < *amount {
             self.env().revert(InsufficientBalance);
@@ -145,34 +159,50 @@ impl Erc20 {
     }
 }
 
+/// ERC20 Events
 pub mod events {
     use odra::casper_event_standard::{self, Event};
     use odra::{casper_types::U256, Address};
 
+    /// Transfer event
     #[derive(Event, Eq, PartialEq, Debug)]
     pub struct Transfer {
+        /// Sender of the tokens.
         pub from: Option<Address>,
+        /// Recipient of the tokens.
         pub to: Option<Address>,
+        /// Amount of tokens transferred.
         pub amount: U256
     }
 
+    /// Approval event
     #[derive(Event, Eq, PartialEq, Debug)]
     pub struct Approval {
+        /// Owner of the tokens.
         pub owner: Address,
+        /// Spender of the tokens.
         pub spender: Address,
+        /// Amount of tokens approved.
         pub value: U256
     }
 }
 
+/// ERC20 Errors
 pub mod errors {
     use odra::OdraError;
 
+    /// ERC20 errors
     #[derive(OdraError)]
     pub enum Error {
+        /// Insufficient balance
         InsufficientBalance = 30_000,
+        /// Insufficient allowance
         InsufficientAllowance = 30_001,
+        /// Name not set
         NameNotSet = 30_002,
+        /// Symbol not set
         SymbolNotSet = 30_003,
+        /// Decimals not set
         DecimalsNotSet = 30_004
     }
 }

--- a/modules/src/erc721/erc721_base.rs
+++ b/modules/src/erc721/erc721_base.rs
@@ -9,7 +9,7 @@ use crate::erc721_receiver::Erc721ReceiverContractRef;
 use odra::prelude::*;
 use odra::{
     casper_types::{bytesrepr::Bytes, U256},
-    Address, Mapping, UnwrapOrRevert
+    Address, ContractRef, Mapping, UnwrapOrRevert
 };
 /// The ERC721 base implementation.
 #[odra::module(events = [Approval, ApprovalForAll, Transfer])]

--- a/modules/src/erc721/erc721_base.rs
+++ b/modules/src/erc721/erc721_base.rs
@@ -14,10 +14,13 @@ use odra::{
 /// The ERC721 base implementation.
 #[odra::module(events = [Approval, ApprovalForAll, Transfer])]
 pub struct Erc721Base {
-    // Erc721 base fields.
+    /// The token balances.
     pub balances: Mapping<Address, U256>,
+    /// The token owners.
     pub owners: Mapping<U256, Option<Address>>,
+    /// The token approvals.
     pub token_approvals: Mapping<U256, Option<Address>>,
+    /// The operator approvals.
     pub operator_approvals: Mapping<(Address, Address), bool>
 }
 

--- a/modules/src/erc721/erc721_base.rs
+++ b/modules/src/erc721/erc721_base.rs
@@ -3,6 +3,7 @@ use crate::erc721::errors::Error::{
     ApprovalToCurrentOwner, ApproveToCaller, InvalidTokenId, NotAnOwnerOrApproved, TransferFailed
 };
 use crate::erc721::events::{Approval, ApprovalForAll, Transfer};
+use crate::erc721::extensions::erc721_receiver::Erc721Receiver;
 use crate::erc721::Erc721;
 use crate::erc721_receiver::Erc721ReceiverContractRef;
 use odra::prelude::*;
@@ -10,7 +11,6 @@ use odra::{
     casper_types::{bytesrepr::Bytes, U256},
     Address, Mapping, UnwrapOrRevert
 };
-
 /// The ERC721 base implementation.
 #[odra::module(events = [Approval, ApprovalForAll, Transfer])]
 pub struct Erc721Base {
@@ -129,10 +129,10 @@ impl Erc721Base {
         self.transfer(from, to, token_id);
         if to.is_contract() {
             let response = Erc721ReceiverContractRef::new(self.env(), *to).on_erc721_received(
-                self.env().caller(),
-                *from,
-                *token_id,
-                data.clone()
+                &self.env().caller(),
+                from,
+                token_id,
+                data
             );
 
             if !response {

--- a/modules/src/erc721/extensions/erc721_metadata.rs
+++ b/modules/src/erc721/extensions/erc721_metadata.rs
@@ -17,6 +17,7 @@ pub trait Erc721Metadata {
     fn base_uri(&self) -> String;
 }
 
+/// The ERC721 Metadata extension.
 #[odra::module]
 pub struct Erc721MetadataExtension {
     name: Var<String>,
@@ -45,6 +46,7 @@ impl Erc721Metadata for Erc721MetadataExtension {
 }
 
 impl Erc721MetadataExtension {
+    /// Initializes the ERC721 metadata extension.
     pub fn init(&mut self, name: String, symbol: String, base_uri: String) {
         self.name.set(name);
         self.symbol.set(symbol);
@@ -52,13 +54,18 @@ impl Erc721MetadataExtension {
     }
 }
 
+/// Erc721Metadata-related errors.
 pub mod errors {
     use odra::OdraError;
 
+    /// Possible errors in the context of Erc721 metadata.
     #[derive(OdraError)]
     pub enum Error {
+        /// The name is not set.
         NameNotSet = 31_000,
+        /// The symbol is not set.
         SymbolNotSet = 31_001,
+        /// The base URI is not set.
         BaseUriNotSet = 31_002
     }
 }

--- a/modules/src/erc721/mod.rs
+++ b/modules/src/erc721/mod.rs
@@ -62,24 +62,33 @@ pub mod events {
     /// Emitted when the `token_id` token is transferred (also minted or burned).
     #[derive(Event)]
     pub struct Transfer {
+        /// The address of the sender.
         pub from: Option<Address>,
+        /// The address of the receiver.
         pub to: Option<Address>,
+        /// The token id.
         pub token_id: U256
     }
 
     /// Emitted when the `owner` approves `approved` to operate on the `token_id` token.
     #[derive(Event)]
     pub struct Approval {
+        /// The owner of the tokens.
         pub owner: Address,
+        /// The operator that is approved.
         pub approved: Option<Address>,
+        /// The token id.
         pub token_id: U256
     }
 
     /// Emitted when the `owner` approves or revokes `operator`.
     #[derive(Event)]
     pub struct ApprovalForAll {
+        /// The owner of the tokens.
         pub owner: Address,
+        /// The operator that is approved or revoked.
         pub operator: Address,
+        /// The approval status.
         pub approved: bool
     }
 }

--- a/modules/src/erc721/mod.rs
+++ b/modules/src/erc721/mod.rs
@@ -33,6 +33,7 @@ pub trait Erc721 {
         token_id: &U256,
         data: &Bytes
     );
+    /// Transfers a specific NFT `tokenId` from one account `from` to another `to`.
     fn transfer_from(&mut self, from: &Address, to: &Address, token_id: &U256);
     /// Grants permission to `approved` to transfer `token_id` token. The approval is cleared when the token is transferred.
     ///

--- a/modules/src/erc721/owned_erc721_with_metadata.rs
+++ b/modules/src/erc721/owned_erc721_with_metadata.rs
@@ -48,6 +48,8 @@ pub trait OwnedErc721WithMetadata {
         token_id: &U256,
         data: &Bytes
     );
+    /// Transfers a specific NFT `tokenId` from one account `from` to another `to`.
+    /// Emits a [Transfer](crate::erc721::events::Transfer) event.
     fn transfer_from(&mut self, from: &Address, to: &Address, token_id: &U256);
     /// Grants permission to `approved` to transfer `token_id` token. The approval is cleared when the token is transferred.
     ///

--- a/modules/src/erc721_receiver.rs
+++ b/modules/src/erc721_receiver.rs
@@ -43,9 +43,13 @@ pub mod events {
     /// Emitted when the transfer is accepted by the contract.
     #[derive(Event, PartialEq, Eq, Debug, Clone)]
     pub struct Received {
+        /// The operator that called the function.
         pub operator: Option<Address>,
+        /// The address of of the sender.
         pub from: Option<Address>,
+        /// The token id.
         pub token_id: U256,
+        /// The token data.
         pub data: Option<Bytes>
     }
 }

--- a/modules/src/erc721_receiver.rs
+++ b/modules/src/erc721_receiver.rs
@@ -1,7 +1,7 @@
 //! A pluggable Odra module implementing Erc721Receiver.
 use crate::erc721::extensions::erc721_receiver::Erc721Receiver as Erc721ReceiverTrait;
+use crate::erc721::owned_erc721_with_metadata::OwnedErc721WithMetadata;
 use crate::erc721_receiver::events::Received;
- use crate::erc721::owned_erc721_with_metadata::OwnedErc721WithMetadata;
 use crate::erc721_token::Erc721TokenContractRef;
 use odra::prelude::*;
 use odra::{

--- a/modules/src/erc721_receiver.rs
+++ b/modules/src/erc721_receiver.rs
@@ -6,7 +6,7 @@ use crate::erc721_token::Erc721TokenContractRef;
 use odra::prelude::*;
 use odra::{
     casper_types::{bytesrepr::Bytes, U256},
-    Address
+    Address, ContractRef
 };
 
 /// The ERC721 receiver implementation.

--- a/modules/src/erc721_receiver.rs
+++ b/modules/src/erc721_receiver.rs
@@ -1,6 +1,7 @@
 //! A pluggable Odra module implementing Erc721Receiver.
 use crate::erc721::extensions::erc721_receiver::Erc721Receiver as Erc721ReceiverTrait;
 use crate::erc721_receiver::events::Received;
+ use crate::erc721::owned_erc721_with_metadata::OwnedErc721WithMetadata;
 use crate::erc721_token::Erc721TokenContractRef;
 use odra::prelude::*;
 use odra::{
@@ -16,10 +17,10 @@ pub struct Erc721Receiver;
 impl Erc721ReceiverTrait for Erc721Receiver {
     fn on_erc721_received(
         &mut self,
-        #[allow(unused_variables)] operator: &Address,
-        #[allow(unused_variables)] from: &Address,
+        operator: &Address,
+        from: &Address,
         token_id: &U256,
-        #[allow(unused_variables)] data: &Option<Bytes>
+        data: &Option<Bytes>
     ) -> bool {
         self.env().emit_event(Received {
             operator: Some(*operator),
@@ -27,7 +28,7 @@ impl Erc721ReceiverTrait for Erc721Receiver {
             token_id: *token_id,
             data: data.clone()
         });
-        Erc721TokenContractRef::new(self.env(), self.env().caller()).owner_of(*token_id)
+        Erc721TokenContractRef::new(self.env(), self.env().caller()).owner_of(token_id)
             == self.env().self_address()
     }
 }

--- a/modules/src/erc721_token.rs
+++ b/modules/src/erc721_token.rs
@@ -13,6 +13,7 @@ use odra::{
     Address, SubModule
 };
 
+
 /// The ERC721 token implementation.
 ///
 /// It uses the [ERC721](Erc721Base) base implementation, the [ERC721 metadata](Erc721MetadataExtension) extension

--- a/modules/src/erc721_token.rs
+++ b/modules/src/erc721_token.rs
@@ -146,13 +146,13 @@ mod tests {
     use crate::access::errors::Error as AccessError;
     use crate::erc20::{Erc20HostRef, Erc20InitArgs};
     use crate::erc721::errors::Error::{InvalidTokenId, NotAnOwnerOrApproved};
+    use crate::erc721::owned_erc721_with_metadata::OwnedErc721WithMetadata;
     use crate::erc721_receiver::events::Received;
     use crate::erc721_receiver::Erc721ReceiverHostRef;
     use crate::erc721_token::errors::Error::TokenAlreadyExists;
     use odra::host::{Deployer, HostEnv, HostRef, NoArgs};
     use odra::prelude::*;
     use odra::{casper_types::U256, Address, OdraError, VmError};
-
     const NAME: &str = "PlascoinNFT";
     const SYMBOL: &str = "PLSNFT";
     const BASE_URI: &str = "https://plascoin.org/";
@@ -189,14 +189,14 @@ mod tests {
         let mut erc721_env = setup();
 
         // And mint a token to Alice.
-        erc721_env.token.mint(erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, &U256::from(1));
 
         // Then Alice has a balance of 1 and Bob has a balance of 0.
-        assert_eq!(erc721_env.token.balance_of(erc721_env.alice), U256::from(1));
-        assert_eq!(erc721_env.token.balance_of(erc721_env.bob), U256::from(0));
+        assert_eq!(erc721_env.token.balance_of(&erc721_env.alice), U256::from(1));
+        assert_eq!(erc721_env.token.balance_of(&erc721_env.bob), U256::from(0));
 
         // And the owner of the token is Alice.
-        assert_eq!(erc721_env.token.owner_of(U256::from(1)), erc721_env.alice);
+        assert_eq!(erc721_env.token.owner_of(&U256::from(1)), erc721_env.alice);
     }
 
     #[test]
@@ -205,16 +205,16 @@ mod tests {
         let mut erc721_env = setup();
 
         // And mint a token to Alice.
-        erc721_env.token.mint(erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, &U256::from(1));
 
         // Then Alice has a balance of 1 and Bob has a balance of 0.
-        assert_eq!(erc721_env.token.balance_of(erc721_env.alice), U256::from(1));
+        assert_eq!(erc721_env.token.balance_of(&erc721_env.alice), U256::from(1));
 
         // When we mint another token to Alice.
-        erc721_env.token.mint(erc721_env.alice, U256::from(2));
+        erc721_env.token.mint(&erc721_env.alice, &U256::from(2));
 
         // Then Alice has a balance of 2.
-        assert_eq!(erc721_env.token.balance_of(erc721_env.alice), U256::from(2));
+        assert_eq!(erc721_env.token.balance_of(&erc721_env.alice), U256::from(2));
     }
 
     #[test]
@@ -223,12 +223,12 @@ mod tests {
         let mut erc721_env = setup();
 
         // And mint a token to Alice.
-        erc721_env.token.mint(erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, &U256::from(1));
 
         // Then minting the same token again throws an error.
         let err = erc721_env
             .token
-            .try_mint(erc721_env.alice, U256::from(1))
+            .try_mint(&erc721_env.alice, &U256::from(1))
             .unwrap_err();
         assert_eq!(err, TokenAlreadyExists.into());
     }
@@ -239,10 +239,10 @@ mod tests {
         let mut erc721_env = setup();
 
         // And mint a token to Alice.
-        erc721_env.token.mint(erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, &U256::from(1));
 
         // Then the owner of the token is Alice.
-        assert_eq!(erc721_env.token.owner_of(U256::from(1)), erc721_env.alice);
+        assert_eq!(erc721_env.token.owner_of(&U256::from(1)), erc721_env.alice);
     }
 
     #[test]
@@ -252,7 +252,7 @@ mod tests {
 
         // Then the owner of the token is Alice.
         assert_eq!(
-            erc721_env.token.try_owner_of(U256::from(1)).unwrap_err(),
+            erc721_env.token.try_owner_of(&U256::from(1)).unwrap_err(),
             InvalidTokenId.into()
         );
     }
@@ -263,17 +263,17 @@ mod tests {
         let mut erc721_env = setup();
 
         // And mint a token to Alice.
-        erc721_env.token.mint(erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, &U256::from(1));
 
         // And approve Bob to transfer the token.
         erc721_env.env.set_caller(erc721_env.alice);
         erc721_env
             .token
-            .approve(Some(erc721_env.bob), U256::from(1));
+            .approve(&Some(erc721_env.bob), &U256::from(1));
 
         // Then Bob is approved to transfer the token.
         assert_eq!(
-            erc721_env.token.get_approved(U256::from(1)),
+            erc721_env.token.get_approved(&U256::from(1)),
             Some(erc721_env.bob)
         );
     }
@@ -284,20 +284,20 @@ mod tests {
         let mut erc721_env = setup();
 
         // And mint a token to Alice.
-        erc721_env.token.mint(erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, &U256::from(1));
 
         // And approve Bob to transfer the token.
         erc721_env.env.set_caller(erc721_env.alice);
         erc721_env
             .token
-            .approve(Some(erc721_env.bob), U256::from(1));
+            .approve(&Some(erc721_env.bob), &U256::from(1));
 
         // And cancel the approval.
         erc721_env.env.set_caller(erc721_env.alice);
-        erc721_env.token.approve(None, U256::from(1));
+        erc721_env.token.approve(&None, &U256::from(1));
 
         // Then Bob is not approved to transfer the token.
-        assert_eq!(erc721_env.token.get_approved(U256::from(1)), None);
+        assert_eq!(erc721_env.token.get_approved(&U256::from(1)), None);
     }
 
     #[test]
@@ -309,7 +309,7 @@ mod tests {
         assert_eq!(
             erc721_env
                 .token
-                .try_approve(Some(erc721_env.bob), U256::from(1))
+                .try_approve(&Some(erc721_env.bob), &U256::from(1))
                 .unwrap_err(),
             InvalidTokenId.into()
         );
@@ -321,13 +321,13 @@ mod tests {
         let mut erc721_env = setup();
 
         // And mint a token to Alice.
-        erc721_env.token.mint(erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, &U256::from(1));
 
         // Then approving a token that is not owned by the caller throws an error.
         assert_eq!(
             erc721_env
                 .token
-                .try_approve(Some(erc721_env.bob), U256::from(1))
+                .try_approve(&Some(erc721_env.bob), &U256::from(1))
                 .unwrap_err(),
             NotAnOwnerOrApproved.into()
         );
@@ -339,16 +339,16 @@ mod tests {
         let mut erc721_env = setup();
 
         // And mint a token to Alice.
-        erc721_env.token.mint(erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, U256::from(1));
 
         // And set Bob as an operator.
         erc721_env.env.set_caller(erc721_env.alice);
-        erc721_env.token.set_approval_for_all(erc721_env.bob, true);
+        erc721_env.token.set_approval_for_all(&erc721_env.bob, true);
 
         // Then Bob is an operator.
         assert!(erc721_env
             .token
-            .is_approved_for_all(erc721_env.alice, erc721_env.bob));
+            .is_approved_for_all(&erc721_env.alice, erc721_env.bob));
     }
 
     #[test]
@@ -357,20 +357,20 @@ mod tests {
         let mut erc721_env = setup();
 
         // And mint a token to Alice.
-        erc721_env.token.mint(erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, U256::from(1));
 
         // And set Bob as an operator.
         erc721_env.env.set_caller(erc721_env.alice);
-        erc721_env.token.set_approval_for_all(erc721_env.bob, true);
+        erc721_env.token.set_approval_for_all(&erc721_env.bob, true);
 
         // And cancel Bob as an operator.
         erc721_env.env.set_caller(erc721_env.alice);
-        erc721_env.token.set_approval_for_all(erc721_env.bob, false);
+        erc721_env.token.set_approval_for_all(&erc721_env.bob, false);
 
         // Then Bob is not an operator.
         assert!(!erc721_env
             .token
-            .is_approved_for_all(erc721_env.alice, erc721_env.bob));
+            .is_approved_for_all(&erc721_env.alice, erc721_env.bob));
     }
 
     #[test]
@@ -379,16 +379,16 @@ mod tests {
         let mut erc721_env = setup();
 
         // And mint a token to Alice.
-        erc721_env.token.mint(erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, U256::from(1));
 
         // And transfer the token to Bob.
         erc721_env.env.set_caller(erc721_env.alice);
         erc721_env
             .token
-            .transfer_from(erc721_env.alice, erc721_env.bob, U256::from(1));
+            .transfer_from(&erc721_env.alice, erc721_env.bob, U256::from(1));
 
         // Then the owner of the token is Bob.
-        assert_eq!(erc721_env.token.owner_of(U256::from(1)), erc721_env.bob);
+        assert_eq!(erc721_env.token.owner_of(&U256::from(1)), erc721_env.bob);
     }
 
     #[test]
@@ -397,22 +397,22 @@ mod tests {
         let mut erc721_env = setup();
 
         // And mint a token to Alice.
-        erc721_env.token.mint(erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, U256::from(1));
 
         // And approve Bob to transfer the token.
         erc721_env.env.set_caller(erc721_env.alice);
         erc721_env
             .token
-            .approve(Some(erc721_env.bob), U256::from(1));
+            .approve(&Some(erc721_env.bob), U256::from(1));
 
         // And transfer the token to Carol.
         erc721_env.env.set_caller(erc721_env.bob);
         erc721_env
             .token
-            .transfer_from(erc721_env.alice, erc721_env.carol, U256::from(1));
+            .transfer_from(&erc721_env.alice, erc721_env.carol, U256::from(1));
 
         // Then the owner of the token is Carol.
-        assert_eq!(erc721_env.token.owner_of(U256::from(1)), erc721_env.carol);
+        assert_eq!(erc721_env.token.owner_of(&U256::from(1)), erc721_env.carol);
     }
 
     #[test]
@@ -421,20 +421,20 @@ mod tests {
         let mut erc721_env = setup();
 
         // And mint a token to Alice.
-        erc721_env.token.mint(erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, U256::from(1));
 
         // And set Bob as an operator.
         erc721_env.env.set_caller(erc721_env.alice);
-        erc721_env.token.set_approval_for_all(erc721_env.bob, true);
+        erc721_env.token.set_approval_for_all(&erc721_env.bob, true);
 
         // And transfer the token to Carol.
         erc721_env.env.set_caller(erc721_env.bob);
         erc721_env
             .token
-            .transfer_from(erc721_env.alice, erc721_env.carol, U256::from(1));
+            .transfer_from(&erc721_env.alice, erc721_env.carol, U256::from(1));
 
         // Then the owner of the token is Carol.
-        assert_eq!(erc721_env.token.owner_of(U256::from(1)), erc721_env.carol);
+        assert_eq!(erc721_env.token.owner_of(&U256::from(1)), erc721_env.carol);
     }
 
     #[test]
@@ -443,13 +443,13 @@ mod tests {
         let mut erc721_env = setup();
 
         // And mint a token to Alice.
-        erc721_env.token.mint(erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, U256::from(1));
 
         // Then transferring a token that is not owned by the caller throws an error.
         erc721_env.env.set_caller(erc721_env.bob);
         let err = erc721_env
             .token
-            .try_transfer_from(erc721_env.alice, erc721_env.carol, U256::from(1))
+            .try_transfer_from(&erc721_env.alice, erc721_env.carol, U256::from(1))
             .unwrap_err();
         assert_eq!(err, NotAnOwnerOrApproved.into());
     }
@@ -462,7 +462,7 @@ mod tests {
         // Then transferring a token that does not exist throws an error.
         let err = erc721_env
             .token
-            .try_transfer_from(erc721_env.alice, erc721_env.carol, U256::from(1))
+            .try_transfer_from(&erc721_env.alice, erc721_env.carol, U256::from(1))
             .unwrap_err();
         assert_eq!(err, InvalidTokenId.into());
     }
@@ -476,16 +476,16 @@ mod tests {
         assert!(!erc721_env.alice.is_contract());
 
         // And mint a token to Alice.
-        erc721_env.token.mint(erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, U256::from(1));
 
         // And safe transfer the token to Bob.
         erc721_env.env.set_caller(erc721_env.alice);
         erc721_env
             .token
-            .safe_transfer_from(erc721_env.alice, erc721_env.bob, U256::from(1));
+            .safe_transfer_from(&erc721_env.alice, erc721_env.bob, U256::from(1));
 
         // Then the owner of the token is Bob.
-        assert_eq!(erc721_env.token.owner_of(U256::from(1)), erc721_env.bob);
+        assert_eq!(erc721_env.token.owner_of(&U256::from(1)), erc721_env.bob);
     }
 
     #[test]
@@ -504,7 +504,7 @@ mod tests {
         );
 
         // And mint a token to Alice.
-        erc721_env.token.mint(erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, U256::from(1));
 
         // Then safe transfer the token to the contract which does not support nfts throws an error.
         erc721_env.env.set_caller(erc721_env.alice);
@@ -514,9 +514,9 @@ mod tests {
                 "on_erc721_received".to_string()
             ))),
             erc721_env.token.try_safe_transfer_from(
-                erc721_env.alice,
-                *erc20.address(),
-                U256::from(1)
+                &erc721_env.alice,
+                erc20.address(),
+                &U256::from(1)
             )
         );
     }
@@ -529,17 +529,17 @@ mod tests {
         let receiver = Erc721ReceiverHostRef::deploy(&erc721_env.env, NoArgs);
 
         // And mint a token to Alice.
-        erc721_env.token.mint(erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, U256::from(1));
 
         // And transfer the token to the contract which does support nfts
         erc721_env.env.set_caller(erc721_env.alice);
         erc721_env
             .token
-            .safe_transfer_from(erc721_env.alice, *receiver.address(), U256::from(1));
+            .safe_transfer_from(&erc721_env.alice, *receiver.address(), U256::from(1));
 
         // Then the owner of the token is the contract
         assert_eq!(
-            erc721_env.token.owner_of(U256::from(1)),
+            erc721_env.token.owner_of(&U256::from(1)),
             *receiver.address()
         );
         // And the receiver contract is aware of the transfer
@@ -562,7 +562,7 @@ mod tests {
         let receiver = Erc721ReceiverHostRef::deploy(&erc721_env.env, NoArgs);
 
         // And mint a token to Alice.
-        erc721_env.token.mint(erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, U256::from(1));
 
         // And transfer the token to the contract which does support nfts
         erc721_env.env.set_caller(erc721_env.alice);
@@ -602,7 +602,7 @@ mod tests {
         erc721_env.token.burn(U256::from(1));
 
         // Then the owner of throws an error.
-        let err = erc721_env.token.try_owner_of(U256::from(1)).unwrap_err();
+        let err = erc721_env.token.try_owner_of(&U256::from(1)).unwrap_err();
         assert_eq!(err, InvalidTokenId.into());
     }
 
@@ -612,11 +612,11 @@ mod tests {
         let mut erc721_env = setup();
 
         // And mint a token to Alice.
-        erc721_env.token.mint(erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, &U256::from(1));
 
         // Then burn the token as Alice errors out
         erc721_env.env.set_caller(erc721_env.alice);
-        let err = erc721_env.token.try_burn(U256::from(1)).unwrap_err();
+        let err = erc721_env.token.try_burn(&U256::from(1)).unwrap_err();
         assert_eq!(err, AccessError::CallerNotTheOwner.into());
     }
 
@@ -626,7 +626,7 @@ mod tests {
         let mut erc721_env = setup();
 
         // Then burning a token that does not exist throws an error.
-        let err = erc721_env.token.try_burn(U256::from(1)).unwrap_err();
+        let err = erc721_env.token.try_burn(&U256::from(1)).unwrap_err();
         assert_eq!(err, InvalidTokenId.into());
     }
 
@@ -650,7 +650,7 @@ mod tests {
         erc721_env.env.set_caller(erc721_env.bob);
         let err = erc721_env
             .token
-            .try_mint(erc721_env.alice, U256::from(1))
+            .try_mint(&erc721_env.alice, &U256::from(1))
             .unwrap_err();
         assert_eq!(err, AccessError::CallerNotTheOwner.into());
     }

--- a/modules/src/erc721_token.rs
+++ b/modules/src/erc721_token.rs
@@ -13,7 +13,6 @@ use odra::{
     Address, SubModule
 };
 
-
 /// The ERC721 token implementation.
 ///
 /// It uses the [ERC721](Erc721Base) base implementation, the [ERC721 metadata](Erc721MetadataExtension) extension
@@ -192,7 +191,10 @@ mod tests {
         erc721_env.token.mint(&erc721_env.alice, &U256::from(1));
 
         // Then Alice has a balance of 1 and Bob has a balance of 0.
-        assert_eq!(erc721_env.token.balance_of(&erc721_env.alice), U256::from(1));
+        assert_eq!(
+            erc721_env.token.balance_of(&erc721_env.alice),
+            U256::from(1)
+        );
         assert_eq!(erc721_env.token.balance_of(&erc721_env.bob), U256::from(0));
 
         // And the owner of the token is Alice.
@@ -208,13 +210,19 @@ mod tests {
         erc721_env.token.mint(&erc721_env.alice, &U256::from(1));
 
         // Then Alice has a balance of 1 and Bob has a balance of 0.
-        assert_eq!(erc721_env.token.balance_of(&erc721_env.alice), U256::from(1));
+        assert_eq!(
+            erc721_env.token.balance_of(&erc721_env.alice),
+            U256::from(1)
+        );
 
         // When we mint another token to Alice.
         erc721_env.token.mint(&erc721_env.alice, &U256::from(2));
 
         // Then Alice has a balance of 2.
-        assert_eq!(erc721_env.token.balance_of(&erc721_env.alice), U256::from(2));
+        assert_eq!(
+            erc721_env.token.balance_of(&erc721_env.alice),
+            U256::from(2)
+        );
     }
 
     #[test]
@@ -339,7 +347,7 @@ mod tests {
         let mut erc721_env = setup();
 
         // And mint a token to Alice.
-        erc721_env.token.mint(&erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, &U256::from(1));
 
         // And set Bob as an operator.
         erc721_env.env.set_caller(erc721_env.alice);
@@ -348,7 +356,7 @@ mod tests {
         // Then Bob is an operator.
         assert!(erc721_env
             .token
-            .is_approved_for_all(&erc721_env.alice, erc721_env.bob));
+            .is_approved_for_all(&erc721_env.alice, &erc721_env.bob));
     }
 
     #[test]
@@ -357,7 +365,7 @@ mod tests {
         let mut erc721_env = setup();
 
         // And mint a token to Alice.
-        erc721_env.token.mint(&erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, &U256::from(1));
 
         // And set Bob as an operator.
         erc721_env.env.set_caller(erc721_env.alice);
@@ -365,12 +373,14 @@ mod tests {
 
         // And cancel Bob as an operator.
         erc721_env.env.set_caller(erc721_env.alice);
-        erc721_env.token.set_approval_for_all(&erc721_env.bob, false);
+        erc721_env
+            .token
+            .set_approval_for_all(&erc721_env.bob, false);
 
         // Then Bob is not an operator.
         assert!(!erc721_env
             .token
-            .is_approved_for_all(&erc721_env.alice, erc721_env.bob));
+            .is_approved_for_all(&erc721_env.alice, &erc721_env.bob));
     }
 
     #[test]
@@ -379,13 +389,13 @@ mod tests {
         let mut erc721_env = setup();
 
         // And mint a token to Alice.
-        erc721_env.token.mint(&erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, &U256::from(1));
 
         // And transfer the token to Bob.
         erc721_env.env.set_caller(erc721_env.alice);
         erc721_env
             .token
-            .transfer_from(&erc721_env.alice, erc721_env.bob, U256::from(1));
+            .transfer_from(&erc721_env.alice, &erc721_env.bob, &U256::from(1));
 
         // Then the owner of the token is Bob.
         assert_eq!(erc721_env.token.owner_of(&U256::from(1)), erc721_env.bob);
@@ -397,19 +407,19 @@ mod tests {
         let mut erc721_env = setup();
 
         // And mint a token to Alice.
-        erc721_env.token.mint(&erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, &U256::from(1));
 
         // And approve Bob to transfer the token.
         erc721_env.env.set_caller(erc721_env.alice);
         erc721_env
             .token
-            .approve(&Some(erc721_env.bob), U256::from(1));
+            .approve(&Some(erc721_env.bob), &U256::from(1));
 
         // And transfer the token to Carol.
         erc721_env.env.set_caller(erc721_env.bob);
         erc721_env
             .token
-            .transfer_from(&erc721_env.alice, erc721_env.carol, U256::from(1));
+            .transfer_from(&erc721_env.alice, &erc721_env.carol, &U256::from(1));
 
         // Then the owner of the token is Carol.
         assert_eq!(erc721_env.token.owner_of(&U256::from(1)), erc721_env.carol);
@@ -421,7 +431,7 @@ mod tests {
         let mut erc721_env = setup();
 
         // And mint a token to Alice.
-        erc721_env.token.mint(&erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, &U256::from(1));
 
         // And set Bob as an operator.
         erc721_env.env.set_caller(erc721_env.alice);
@@ -431,7 +441,7 @@ mod tests {
         erc721_env.env.set_caller(erc721_env.bob);
         erc721_env
             .token
-            .transfer_from(&erc721_env.alice, erc721_env.carol, U256::from(1));
+            .transfer_from(&erc721_env.alice, &erc721_env.carol, &U256::from(1));
 
         // Then the owner of the token is Carol.
         assert_eq!(erc721_env.token.owner_of(&U256::from(1)), erc721_env.carol);
@@ -443,13 +453,13 @@ mod tests {
         let mut erc721_env = setup();
 
         // And mint a token to Alice.
-        erc721_env.token.mint(&erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, &U256::from(1));
 
         // Then transferring a token that is not owned by the caller throws an error.
         erc721_env.env.set_caller(erc721_env.bob);
         let err = erc721_env
             .token
-            .try_transfer_from(&erc721_env.alice, erc721_env.carol, U256::from(1))
+            .try_transfer_from(&erc721_env.alice, &erc721_env.carol, &U256::from(1))
             .unwrap_err();
         assert_eq!(err, NotAnOwnerOrApproved.into());
     }
@@ -462,7 +472,7 @@ mod tests {
         // Then transferring a token that does not exist throws an error.
         let err = erc721_env
             .token
-            .try_transfer_from(&erc721_env.alice, erc721_env.carol, U256::from(1))
+            .try_transfer_from(&erc721_env.alice, &erc721_env.carol, &U256::from(1))
             .unwrap_err();
         assert_eq!(err, InvalidTokenId.into());
     }
@@ -476,13 +486,13 @@ mod tests {
         assert!(!erc721_env.alice.is_contract());
 
         // And mint a token to Alice.
-        erc721_env.token.mint(&erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, &U256::from(1));
 
         // And safe transfer the token to Bob.
         erc721_env.env.set_caller(erc721_env.alice);
         erc721_env
             .token
-            .safe_transfer_from(&erc721_env.alice, erc721_env.bob, U256::from(1));
+            .safe_transfer_from(&erc721_env.alice, &erc721_env.bob, &U256::from(1));
 
         // Then the owner of the token is Bob.
         assert_eq!(erc721_env.token.owner_of(&U256::from(1)), erc721_env.bob);
@@ -504,7 +514,7 @@ mod tests {
         );
 
         // And mint a token to Alice.
-        erc721_env.token.mint(&erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, &U256::from(1));
 
         // Then safe transfer the token to the contract which does not support nfts throws an error.
         erc721_env.env.set_caller(erc721_env.alice);
@@ -529,13 +539,13 @@ mod tests {
         let receiver = Erc721ReceiverHostRef::deploy(&erc721_env.env, NoArgs);
 
         // And mint a token to Alice.
-        erc721_env.token.mint(&erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, &U256::from(1));
 
         // And transfer the token to the contract which does support nfts
         erc721_env.env.set_caller(erc721_env.alice);
         erc721_env
             .token
-            .safe_transfer_from(&erc721_env.alice, *receiver.address(), U256::from(1));
+            .safe_transfer_from(&erc721_env.alice, receiver.address(), &U256::from(1));
 
         // Then the owner of the token is the contract
         assert_eq!(
@@ -562,20 +572,20 @@ mod tests {
         let receiver = Erc721ReceiverHostRef::deploy(&erc721_env.env, NoArgs);
 
         // And mint a token to Alice.
-        erc721_env.token.mint(&erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, &U256::from(1));
 
         // And transfer the token to the contract which does support nfts
         erc721_env.env.set_caller(erc721_env.alice);
         erc721_env.token.safe_transfer_from_with_data(
-            erc721_env.alice,
-            *receiver.address(),
-            U256::from(1),
-            b"data".to_vec().into()
+            &erc721_env.alice,
+            receiver.address(),
+            &U256::from(1),
+            &b"data".to_vec().into()
         );
 
         // Then the owner of the token is the contract
         assert_eq!(
-            erc721_env.token.owner_of(U256::from(1)),
+            erc721_env.token.owner_of(&U256::from(1)),
             receiver.address().clone()
         );
         // And the receiver contract is aware of the transfer
@@ -596,10 +606,10 @@ mod tests {
         let mut erc721_env = setup();
 
         // And mint a token to Alice.
-        erc721_env.token.mint(erc721_env.alice, U256::from(1));
+        erc721_env.token.mint(&erc721_env.alice, &U256::from(1));
 
         // And burn the token.
-        erc721_env.token.burn(U256::from(1));
+        erc721_env.token.burn(&U256::from(1));
 
         // Then the owner of throws an error.
         let err = erc721_env.token.try_owner_of(&U256::from(1)).unwrap_err();

--- a/modules/src/lib.rs
+++ b/modules/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc = "Odra's library of plug and play modules"]
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(not(test), no_main)]
 

--- a/modules/src/security/errors.rs
+++ b/modules/src/security/errors.rs
@@ -1,7 +1,11 @@
+//! Errors implementation for the security module.
 use odra::OdraError;
 
+/// Errors for the security module.
 #[derive(OdraError)]
 pub enum Error {
+    /// Contract needs to be paused first.
     PausedRequired = 21_000,
+    /// Contract needs to be unpaused first.
     UnpausedRequired = 21_001
 }

--- a/modules/src/security/events.rs
+++ b/modules/src/security/events.rs
@@ -1,3 +1,4 @@
+//! Security module events implementation.
 use odra::prelude::*;
 use odra::{Address, Event};
 
@@ -5,11 +6,13 @@ use odra::{Address, Event};
 
 #[derive(Event, PartialEq, Eq, Debug)]
 pub struct Paused {
+    /// The account that stopped the contract.
     pub account: Address
 }
 
 /// Informs the contract has been unstopped by `account`.
 #[derive(Event, PartialEq, Eq, Debug)]
 pub struct Unpaused {
+    /// The account that unstopped the contract.
     pub account: Address
 }

--- a/modules/src/security/mod.rs
+++ b/modules/src/security/mod.rs
@@ -1,3 +1,4 @@
+//! Security module
 pub mod errors;
 pub mod events;
 mod pauseable;

--- a/modules/src/security/pauseable.rs
+++ b/modules/src/security/pauseable.rs
@@ -1,15 +1,16 @@
-use crate::security::errors::Error::{PausedRequired, UnpausedRequired};
-use crate::security::events::{Paused, Unpaused};
-use odra::prelude::*;
-use odra::Var;
-
-/// A module allowing to implement an emergency stop mechanism that can be triggered by any account.
+//! A module allowing to implement an emergency stop mechanism that can be triggered by any account.
 ///
 /// You can use this module in a custom module by adding it as a field.
 ///
 /// It will make available `require_not_paused()` and `require_paused()` functions,
 /// which can be used in the functions of your contract to ensure the contract is
 /// in the correct state.
+use crate::security::errors::Error::{PausedRequired, UnpausedRequired};
+use crate::security::events::{Paused, Unpaused};
+use odra::prelude::*;
+use odra::Var;
+
+/// The Pauseable module.
 #[odra::module]
 pub struct Pauseable {
     is_paused: Var<bool>

--- a/modules/src/wrapped_native.rs
+++ b/modules/src/wrapped_native.rs
@@ -186,7 +186,7 @@ mod tests {
         assert_eq!(account_balance - deposit_amount, env.balance_of(&account));
 
         // Then the contract balance is updated.
-        assert_eq!(token.balance_of(account), deposit_amount.into());
+        assert_eq!(token.balance_of(&account), deposit_amount.into());
 
         // The events were emitted.
         assert!(env.emitted_event(
@@ -260,7 +260,7 @@ mod tests {
 
         // When withdraw some tokens.
         let withdrawal_amount: U256 = 1_000.into();
-        token.withdraw(withdrawal_amount);
+        token.withdraw(&withdrawal_amount);
 
         // Then the user has the withdrawn tokens back.
         assert_eq!(
@@ -269,7 +269,7 @@ mod tests {
         );
         // Then the balance in the contract is deducted.
         assert_eq!(
-            token.balance_of(account),
+            token.balance_of(&account),
             deposit_amount.to_u256().unwrap() - withdrawal_amount
         );
 
@@ -298,7 +298,7 @@ mod tests {
         // When the user withdraws amount exceeds the user's deposit
         // Then an error occurs.
         assert_eq!(
-            token.try_withdraw(U256::one()),
+            token.try_withdraw(&U256::one()),
             Err(InsufficientBalance.into())
         );
     }

--- a/modules/src/wrapped_native.rs
+++ b/modules/src/wrapped_native.rs
@@ -1,22 +1,27 @@
+//! Wrapped CSPR token implementation
 use crate::erc20::Erc20;
 use crate::wrapped_native::events::{Deposit, Withdrawal};
 use odra::prelude::*;
 use odra::uints::{ToU256, ToU512};
 use odra::{casper_types::U256, Address, SubModule, UnwrapOrRevert};
 
+/// The WrappedNativeToken module.
 #[odra::module(events = [Deposit, Withdrawal])]
 pub struct WrappedNativeToken {
     erc20: SubModule<Erc20>
 }
 
+/// The WrappedNativeToken module implementation.
 #[odra::module]
 impl WrappedNativeToken {
+    /// Initializes the contract with the metadata.
     pub fn init(&mut self) {
         let symbol = "WCSPR".to_string();
         let name = "Wrapped CSPR".to_string();
         self.erc20.init(symbol, name, 9, None);
     }
 
+    /// Deposits native tokens into the contract.
     #[odra(payable)]
     pub fn deposit(&mut self) {
         let caller = self.env().caller();
@@ -32,6 +37,7 @@ impl WrappedNativeToken {
         });
     }
 
+    /// Withdraws native tokens from the contract.
     pub fn withdraw(&mut self, amount: &U256) {
         let caller = self.env().caller();
 
@@ -44,56 +50,72 @@ impl WrappedNativeToken {
         });
     }
 
+    /// Sets the allowance for `spender` to spend `amount` of the caller's tokens.
     pub fn allowance(&self, owner: &Address, spender: &Address) -> U256 {
         self.erc20.allowance(owner, spender)
     }
 
+    /// Returns the balance of `address`.
     pub fn balance_of(&self, address: &Address) -> U256 {
         self.erc20.balance_of(address)
     }
 
+    /// Returns the total supply of the token.
     pub fn total_supply(&self) -> U256 {
         self.erc20.total_supply()
     }
 
+    /// Returns the number of decimals used by the token.
     pub fn decimals(&self) -> u8 {
         self.erc20.decimals()
     }
 
+    /// Returns the symbol of the token.
     pub fn symbol(&self) -> String {
         self.erc20.symbol()
     }
 
+    /// Returns the name of the token.
     pub fn name(&self) -> String {
         self.erc20.name()
     }
 
+    /// Approves `spender` to spend `amount` of the caller's tokens.
     pub fn approve(&mut self, spender: &Address, amount: &U256) {
         self.erc20.approve(spender, amount)
     }
 
+    /// Transfers `amount` of the owners tokens to `recipient` using allowance.
     pub fn transfer_from(&mut self, owner: &Address, recipient: &Address, amount: &U256) {
         self.erc20.transfer_from(owner, recipient, amount)
     }
 
+    /// Transfers `amount` of the caller's tokens to `recipient`.
     pub fn transfer(&mut self, recipient: &Address, amount: &U256) {
         self.erc20.transfer(recipient, amount)
     }
 }
 
+/// Events emitted by the WrappedNativeToken module.
 pub mod events {
     use odra::casper_event_standard::{self, Event};
     use odra::{casper_types::U256, Address};
 
+    /// Event emitted when native tokens are deposited into the contract.
     #[derive(Event, Debug, Eq, PartialEq)]
     pub struct Deposit {
+        /// An Address of the account that deposited the tokens.
         pub account: Address,
+        /// The amount of tokens deposited.
         pub value: U256
     }
 
+    /// Event emitted when native tokens are withdrawn from the contract.
     #[derive(Event, Debug, Eq, PartialEq)]
     pub struct Withdrawal {
+        /// An Address of the account that withdrew the tokens.
         pub account: Address,
+        /// The amount of tokens withdrawn.
         pub value: U256
     }
 }

--- a/odra-casper/livenet-env/Cargo.toml
+++ b/odra-casper/livenet-env/Cargo.toml
@@ -13,3 +13,6 @@ odra-core = { workspace = true }
 odra-casper-rpc-client = { workspace = true }
 blake2 = { workspace = true }
 log = { workspace = true }
+
+[lints.rust]
+missing_docs = "warn"

--- a/odra-casper/proxy-caller/Cargo.toml
+++ b/odra-casper/proxy-caller/Cargo.toml
@@ -24,3 +24,6 @@ path = "bin/proxy_caller_with_return.rs"
 bench = false
 doctest = false
 test = false
+
+[lints.rust]
+missing_docs = "warn"

--- a/odra-casper/proxy-caller/bin/proxy_caller.rs
+++ b/odra-casper/proxy-caller/bin/proxy_caller.rs
@@ -1,3 +1,4 @@
+#![doc = "Proxy Caller binary - to be compiled into the WASM"]
 #![no_std]
 #![no_main]
 

--- a/odra-casper/proxy-caller/bin/proxy_caller_with_return.rs
+++ b/odra-casper/proxy-caller/bin/proxy_caller_with_return.rs
@@ -1,3 +1,4 @@
+#![doc = "Proxy Caller with return binary - to be compiled into the WASM"]
 #![no_std]
 #![no_main]
 

--- a/odra-casper/proxy-caller/src/lib.rs
+++ b/odra-casper/proxy-caller/src/lib.rs
@@ -1,3 +1,6 @@
+#![doc = "Proxy caller contract used by the Odra Framework."]
+#![doc = "It allows calling other contracts and saving the return values to the named key"]
+#![doc = "of the Proxy Caller."]
 #![no_std]
 
 extern crate alloc;
@@ -26,14 +29,18 @@ use odra_core::prelude::*;
 
 /// Contract call definition.
 pub struct ProxyCall {
+    /// Contract package hash.
     pub contract_package_hash: ContractPackageHash,
+    /// Entry point name.
     pub entry_point_name: String,
+    /// Runtime arguments.
     pub runtime_args: RuntimeArgs,
+    /// Attached value.
     pub attached_value: U512
 }
 
 impl ProxyCall {
-    /// Load proxy call arguments from the runtime.
+    /// Load proxy call arguments from the runtime.
     pub fn load_from_args() -> ProxyCall {
         let contract_package_hash = get_named_arg(CONTRACT_PACKAGE_HASH_ARG);
         let entry_point_name = get_named_arg(ENTRY_POINT_ARG);

--- a/odra-casper/rpc-client/Cargo.toml
+++ b/odra-casper/rpc-client/Cargo.toml
@@ -26,6 +26,3 @@ dotenv = "0.15.0"
 prettycli = "0.1.1"
 thiserror = "1.0.40"
 bytes = "1.5.0"
-
-[lints.rust]
-missing_docs = "warn"

--- a/odra-casper/rpc-client/Cargo.toml
+++ b/odra-casper/rpc-client/Cargo.toml
@@ -26,3 +26,6 @@ dotenv = "0.15.0"
 prettycli = "0.1.1"
 thiserror = "1.0.40"
 bytes = "1.5.0"
+
+[lints.rust]
+missing_docs = "warn"

--- a/odra-casper/test-vm/Cargo.toml
+++ b/odra-casper/test-vm/Cargo.toml
@@ -20,3 +20,6 @@ casper-contract = { workspace = true }
 ink_allocator = { version = "4.2.1", default-features = false }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 casper-contract = { version = "3.0.0", default-features = false, features = ["test-support"] }
+
+[lints.rust]
+missing_docs = "warn"

--- a/odra-casper/test-vm/src/casper_host.rs
+++ b/odra-casper/test-vm/src/casper_host.rs
@@ -30,6 +30,7 @@ use odra_core::{Address, OdraResult, VmError};
 
 /// HostContext utilizing the Casper test virtual machine.
 pub struct CasperHost {
+    /// The Casper VM used by the host.
     pub vm: Rc<RefCell<CasperVm>>
 }
 

--- a/odra-casper/test-vm/src/lib.rs
+++ b/odra-casper/test-vm/src/lib.rs
@@ -1,3 +1,5 @@
+#![doc = "TestVM for Odra Framework."]
+#![doc = "It uses CasperVM as a backend for running the tests."]
 #![allow(dead_code)]
 #![allow(unused_imports)]
 #![allow(unused_variables)]

--- a/odra-casper/wasm-env/Cargo.toml
+++ b/odra-casper/wasm-env/Cargo.toml
@@ -18,3 +18,6 @@ ink_allocator = { version = "4.2.1", default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 casper-contract = { version = "3.0.0", default-features = false, features = ["test-support"] }
+
+[lints.rust]
+missing_docs = "warn"

--- a/odra-casper/wasm-env/src/lib.rs
+++ b/odra-casper/wasm-env/src/lib.rs
@@ -1,3 +1,6 @@
+#![doc = "WASM environment for Odra Framework"]
+#![doc = "It is an implementation of the contract environment used by the contracts written in Odra,"]
+#![doc = "which are compiled to the WASM target architecture."]
 #![no_std]
 #![allow(internal_features)]
 #![cfg_attr(not(test), feature(core_intrinsics))]
@@ -18,6 +21,7 @@ pub use wasm_contract_env::WasmContractEnv;
 #[allow(unused_imports)]
 use ink_allocator;
 
+/// Panic handler for the WASM target architecture.
 #[cfg(target_arch = "wasm32")]
 #[panic_handler]
 #[no_mangle]

--- a/odra-macros/Cargo.toml
+++ b/odra-macros/Cargo.toml
@@ -28,3 +28,6 @@ casper-types = { workspace = true }
 
 [lib]
 proc-macro = true
+
+[lints.rust]
+missing_docs = "warn"

--- a/odra-macros/src/ast/clone.rs
+++ b/odra-macros/src/ast/clone.rs
@@ -1,4 +1,4 @@
-use crate::ast::fn_utils::SelfFnItem;
+use crate::ast::fn_utils::FnItem;
 use crate::ast::utils::{ImplItem, Named};
 use crate::ir::TypeIR;
 use crate::utils;
@@ -16,7 +16,7 @@ pub struct CloneItem {
     #[syn(in = braces)]
     inline_attr: syn::Attribute,
     #[syn(in = braces)]
-    fn_item: SelfFnItem
+    fn_item: FnItem
 }
 
 impl TryFrom<&'_ TypeIR> for CloneItem {
@@ -50,7 +50,7 @@ impl TryFrom<&'_ TypeIR> for CloneItem {
             impl_item: ImplItem::clone(ir)?,
             braces: Default::default(),
             inline_attr: utils::attr::inline(),
-            fn_item: SelfFnItem::new(&ident_clone, ret_ty(), block)
+            fn_item: FnItem::new(&ident_clone, vec![], ret_ty(), block).instanced()
         })
     }
 }

--- a/odra-macros/src/ast/contract_ref_item.rs
+++ b/odra-macros/src/ast/contract_ref_item.rs
@@ -97,7 +97,7 @@ struct ContractRefTraitImplItem {
     #[syn(in = brace_token)]
     new_fn: NewFnItem,
     #[syn(in = brace_token)]
-    address_fn: AddressFnItem,
+    address_fn: AddressFnItem
 }
 
 impl TryFrom<&'_ ModuleImplIR> for ContractRefTraitImplItem {
@@ -111,7 +111,7 @@ impl TryFrom<&'_ ModuleImplIR> for ContractRefTraitImplItem {
             ref_ident: module.contract_ref_ident()?,
             brace_token: Default::default(),
             new_fn: NewFnItem::new(),
-            address_fn: AddressFnItem::new(),
+            address_fn: AddressFnItem::new()
         })
     }
 }
@@ -161,7 +161,7 @@ impl TryFrom<&'_ ModuleImplIR> for ContractRefImplItem {
 pub struct RefItem {
     struct_item: ContractRefStructItem,
     trait_impl_item: ContractRefTraitImplItem,
-    impl_item: ContractRefImplItem,
+    impl_item: ContractRefImplItem
 }
 
 #[cfg(test)]

--- a/odra-macros/src/ast/deployer_item.rs
+++ b/odra-macros/src/ast/deployer_item.rs
@@ -52,6 +52,7 @@ pub struct ContractEpcFn {
 }
 
 struct InitArgsItem {
+    missing_docs: syn::Attribute,
     docs: syn::Attribute,
     attr: syn::Attribute,
     vis: syn::Visibility,
@@ -65,6 +66,7 @@ struct InitArgsItem {
 
 impl quote::ToTokens for InitArgsItem {
     fn to_tokens(&self, tokens: &mut ::proc_macro2::TokenStream) {
+        self.missing_docs.to_tokens(tokens);
         self.docs.to_tokens(tokens);
         self.attr.to_tokens(tokens);
         self.vis.to_tokens(tokens);
@@ -100,6 +102,7 @@ impl TryFrom<&'_ ModuleImplIR> for InitArgsItem {
             false => (Some(Default::default()), None)
         };
         Ok(Self {
+            missing_docs: utils::attr::missing_docs(),
             docs: utils::attr::init_args_docs(module.module_str()?),
             attr: utils::attr::derive_into_runtime_args(),
             vis: utils::syn::visibility_pub(),

--- a/odra-macros/src/ast/deployer_item.rs
+++ b/odra-macros/src/ast/deployer_item.rs
@@ -191,6 +191,7 @@ mod deployer_impl {
     fn deployer_impl() {
         let module = test_utils::mock::module_impl();
         let expected = quote! {
+            #[allow(missing_docs)]
             /// [Erc20] contract constructor arguments.
             #[derive(odra::IntoRuntimeArgs)]
             pub struct Erc20InitArgs {

--- a/odra-macros/src/ast/exec_parts.rs
+++ b/odra-macros/src/ast/exec_parts.rs
@@ -3,7 +3,6 @@ use crate::{
     ir::{FnIR, ModuleImplIR},
     utils
 };
-use derive_try_from_ref::TryFromRef;
 use quote::TokenStreamExt;
 use syn::parse_quote;
 
@@ -167,14 +166,24 @@ impl TryFrom<&'_ FnIR> for ExecFnSignature {
     }
 }
 
-#[derive(syn_derive::ToTokens, TryFromRef)]
-#[source(ModuleImplIR)]
-#[err(syn::Error)]
+#[derive(syn_derive::ToTokens)]
 struct ExecPartsModuleItem {
-    #[default]
+    missing_docs_attr: syn::Attribute,
     mod_token: syn::token::Mod,
-    #[expr(input.exec_parts_mod_ident()?)]
     ident: syn::Ident
+}
+
+impl TryFrom<&'_ ModuleImplIR> for ExecPartsModuleItem {
+    type Error = syn::Error;
+
+    fn try_from(module: &'_ ModuleImplIR) -> Result<Self, Self::Error> {
+        let ident = module.exec_parts_mod_ident()?;
+        Ok(Self {
+            missing_docs_attr: utils::attr::missing_docs(),
+            mod_token: Default::default(),
+            ident
+        })
+    }
 }
 
 #[derive(syn_derive::ToTokens)]

--- a/odra-macros/src/ast/exec_parts.rs
+++ b/odra-macros/src/ast/exec_parts.rs
@@ -232,6 +232,7 @@ mod test {
         let actual = ExecPartsItem::try_from(&module).unwrap();
 
         let expected = quote::quote! {
+            #[allow(missing_docs)]
             mod __erc20_exec_parts {
                 use super::*;
                 use odra::prelude::*;
@@ -300,6 +301,7 @@ mod test {
         let actual = ExecPartsItem::try_from(&module).unwrap();
 
         let expected = quote::quote! {
+            #[allow(missing_docs)]
             mod __erc20_exec_parts {
                 use super::*;
                 use odra::prelude::*;
@@ -334,6 +336,7 @@ mod test {
         let actual = ExecPartsItem::try_from(&module).unwrap();
 
         let expected = quote::quote! {
+            #[allow(missing_docs)]
             mod __erc20_exec_parts {
                 use super::*;
                 use odra::prelude::*;

--- a/odra-macros/src/ast/external_contract_item.rs
+++ b/odra-macros/src/ast/external_contract_item.rs
@@ -1,6 +1,6 @@
+use crate::ast::contract_ref_item::RefItem;
 use crate::ast::host_ref_item::HostRefItem;
 use crate::ast::parts_utils::{UsePreludeItem, UseSuperItem};
-use crate::ast::contract_ref_item::RefItem;
 use crate::ast::test_parts::{PartsModuleItem, TestPartsReexportItem};
 use crate::ir::ModuleImplIR;
 use derive_try_from_ref::TryFromRef;

--- a/odra-macros/src/ast/external_contract_item.rs
+++ b/odra-macros/src/ast/external_contract_item.rs
@@ -49,20 +49,23 @@ mod test {
                 fn balance_of(&self, owner: Address) -> U256;
             }
 
+            /// [Token] Contract Ref.
             pub struct TokenContractRef {
                 env: odra::prelude::Rc<odra::ContractEnv>,
                 address: odra::Address,
             }
 
-            impl TokenContractRef {
-                pub fn new(env: odra::prelude::Rc<odra::ContractEnv>, address: odra::Address) -> Self {
+            impl odra::ContractRef for TokenContractRef {
+                fn new(env: odra::prelude::Rc<odra::ContractEnv>, address: odra::Address) -> Self {
                     Self { env, address }
                 }
 
-                pub fn address(&self) -> &odra::Address {
+                fn address(&self) -> &odra::Address {
                     &self.address
                 }
+            }
 
+            impl TokenContractRef {
                 pub fn balance_of(&self, owner: Address) -> U256 {
                     self.env.call_contract(
                         self.address,
@@ -71,7 +74,7 @@ mod test {
                             false,
                             {
                                 let mut named_args = odra::casper_types::RuntimeArgs::new();
-                                let _ = named_args.insert("owner", owner);
+                                let _ = named_args.insert("owner", owner.clone());
                                 named_args
                             }
                         ),
@@ -84,6 +87,7 @@ mod test {
                 use super::*;
                 use odra::prelude::*;
 
+                /// [Token] Host Ref.
                 pub struct TokenHostRef {
                     address: odra::Address,
                     env: odra::host::HostEnv,
@@ -128,6 +132,13 @@ mod test {
                 }
 
                 impl TokenHostRef {
+                    pub fn balance_of(&self, owner: Address) -> U256 {
+                        self.try_balance_of(owner).unwrap()
+                    }
+                }
+
+                impl TokenHostRef {
+                    /// Does not fail in case of error, returns `odra::OdraResult` instead.
                     pub fn try_balance_of(&self, owner: Address) -> odra::OdraResult<U256> {
                         self.env.call_contract(
                             self.address,
@@ -139,15 +150,11 @@ mod test {
                                     if self.attached_value > odra::casper_types::U512::zero() {
                                         let _ = named_args.insert("amount", self.attached_value);
                                     }
-                                    let _ = named_args.insert("owner", owner);
+                                    let _ = named_args.insert("owner", owner.clone());
                                     named_args
                                 }
                             ).with_amount(self.attached_value),
                         )
-                    }
-
-                    pub fn balance_of(&self, owner: Address) -> U256 {
-                        self.try_balance_of(owner).unwrap()
                     }
                 }
             }

--- a/odra-macros/src/ast/external_contract_item.rs
+++ b/odra-macros/src/ast/external_contract_item.rs
@@ -1,6 +1,6 @@
 use crate::ast::host_ref_item::HostRefItem;
 use crate::ast::parts_utils::{UsePreludeItem, UseSuperItem};
-use crate::ast::ref_item::RefItem;
+use crate::ast::contract_ref_item::RefItem;
 use crate::ast::test_parts::{PartsModuleItem, TestPartsReexportItem};
 use crate::ir::ModuleImplIR;
 use derive_try_from_ref::TryFromRef;

--- a/odra-macros/src/ast/fn_utils.rs
+++ b/odra-macros/src/ast/fn_utils.rs
@@ -63,7 +63,7 @@ impl FnItem {
         }
     }
 
-    pub fn public(mut self, comment: String) -> FnItem {
+    pub fn _public(mut self, comment: String) -> FnItem {
         let comment = format!(" {}", comment);
         self.comment = Some(parse_quote!(#[doc = #comment]));
         self.vis_token = Some(Pub::default());
@@ -89,7 +89,7 @@ impl SingleArgFnItem {
     }
 
     pub fn _make_pub(mut self, comment: String) -> Self {
-        self.fn_item = self.fn_item.public(comment);
+        self.fn_item = self.fn_item._public(comment);
         self
     }
 

--- a/odra-macros/src/ast/fn_utils.rs
+++ b/odra-macros/src/ast/fn_utils.rs
@@ -64,6 +64,7 @@ impl FnItem {
     }
 
     pub fn public(mut self, comment: String) -> FnItem {
+        let comment = format!(" {}", comment);
         self.comment = Some(parse_quote!(#[doc = #comment]));
         self.vis_token = Some(Pub::default());
         self

--- a/odra-macros/src/ast/host_ref_item.rs
+++ b/odra-macros/src/ast/host_ref_item.rs
@@ -11,6 +11,7 @@ use super::{fn_utils::FnItem, ref_utils};
 
 #[derive(syn_derive::ToTokens)]
 struct HostRefStructItem {
+    doc: syn::Attribute,
     vis: syn::Visibility,
     struct_token: syn::token::Struct,
     ident: syn::Ident,
@@ -34,7 +35,12 @@ impl TryFrom<&'_ ModuleImplIR> for HostRefStructItem {
             #env: #ty_host_env,
             #attached_value: #ty_u512
         });
+
+        let comment = format!(" [{}] Host Ref.", module.module_str()?);
+        let doc = parse_quote!(#[doc = #comment]);
+
         Ok(Self {
+            doc,
             vis: utils::syn::visibility_pub(),
             struct_token: Default::default(),
             ident: module.host_ref_ident()?,
@@ -305,6 +311,7 @@ mod ref_item_tests {
     fn host_ref() {
         let module = test_utils::mock::module_impl();
         let expected = quote! {
+            /// [Erc20] Host Ref.
             pub struct Erc20HostRef {
                 address: odra::Address,
                 env: odra::host::HostEnv,
@@ -349,6 +356,8 @@ mod ref_item_tests {
             }
 
             impl Erc20HostRef {
+                /// Returns the total supply of the token.
+                /// Does not fail in case of error, returns `odra::OdraResult` instead.
                 pub fn try_total_supply(&self) -> odra::OdraResult<U256> {
                     self.env.call_contract(
                         self.address,
@@ -366,10 +375,13 @@ mod ref_item_tests {
                     )
                 }
 
+                /// Returns the total supply of the token.
                 pub fn total_supply(&self) -> U256 {
                     self.try_total_supply().unwrap()
                 }
 
+                /// Pay to mint.
+                /// Does not fail in case of error, returns `odra::OdraResult` instead.
                 pub fn try_pay_to_mint(&mut self) -> odra::OdraResult<()> {
                     self.env
                         .call_contract(
@@ -389,10 +401,13 @@ mod ref_item_tests {
                         )
                 }
 
+                /// Pay to mint.
                 pub fn pay_to_mint(&mut self) {
                     self.try_pay_to_mint().unwrap()
                 }
 
+                /// Approve.
+                /// Does not fail in case of error, returns `odra::OdraResult` instead.
                 pub fn try_approve(
                     &mut self,
                     to: Address,
@@ -418,10 +433,13 @@ mod ref_item_tests {
                         )
                 }
 
+                /// Approve.
                 pub fn approve(&mut self, to: Address, amount: U256) {
                     self.try_approve(to, amount).unwrap()
                 }
 
+                /// Airdrops the given amount to the given addresses.
+                /// Does not fail in case of error, returns `odra::OdraResult` instead.
                 pub fn try_airdrop(&self, to: odra::prelude::vec::Vec<Address>, amount: U256) -> odra::OdraResult<()> {
                     self.env.call_contract(
                         self.address,
@@ -441,6 +459,7 @@ mod ref_item_tests {
                     )
                 }
 
+                /// Airdrops the given amount to the given addresses.
                 pub fn airdrop(&self, to: odra::prelude::vec::Vec<Address>, amount: U256) {
                     self.try_airdrop(to, amount).unwrap()
                 }
@@ -454,6 +473,7 @@ mod ref_item_tests {
     fn host_trait_impl_ref() {
         let module = test_utils::mock::module_trait_impl();
         let expected = quote! {
+            /// [Erc20] Host Ref.
             pub struct Erc20HostRef {
                 address: odra::Address,
                 env: odra::host::HostEnv,
@@ -498,6 +518,7 @@ mod ref_item_tests {
             }
 
             impl Erc20HostRef {
+                /// Does not fail in case of error, returns `odra::OdraResult` instead.
                 pub fn try_total_supply(&self) -> odra::OdraResult<U256> {
                     self.env.call_contract(
                         self.address,
@@ -519,6 +540,7 @@ mod ref_item_tests {
                     self.try_total_supply().unwrap()
                 }
 
+                /// Does not fail in case of error, returns `odra::OdraResult` instead.
                 pub fn try_pay_to_mint(&mut self) -> odra::OdraResult<()>  {
                     self.env
                         .call_contract(

--- a/odra-macros/src/ast/host_ref_item.rs
+++ b/odra-macros/src/ast/host_ref_item.rs
@@ -137,11 +137,11 @@ impl TryFrom<&'_ ModuleImplIR> for HostRefImplItem {
     fn try_from(module: &'_ ModuleImplIR) -> Result<Self, Self::Error> {
         // If module implements a trait, set trait name
         let trait_name = module.impl_trait_ident();
-        let for_token: Option<syn::token::For> = match module.is_trait_impl() {  
+        let for_token: Option<syn::token::For> = match module.is_trait_impl() {
             true => Some(Default::default()),
             false => None
         };
-        
+
         Ok(Self {
             impl_token: Default::default(),
             trait_name,
@@ -151,11 +151,7 @@ impl TryFrom<&'_ ModuleImplIR> for HostRefImplItem {
             functions: module
                 .host_functions()?
                 .iter()
-                .flat_map(|f| {
-                    vec![
-                        ref_utils::host_function_item(f, module.is_trait_impl()),
-                    ]
-                })
+                .flat_map(|f| vec![ref_utils::host_function_item(f, module.is_trait_impl())])
                 .collect()
         })
     }
@@ -176,7 +172,6 @@ impl TryFrom<&'_ ModuleImplIR> for HostRefTryImplItem {
     type Error = syn::Error;
 
     fn try_from(module: &'_ ModuleImplIR) -> Result<Self, Self::Error> {
-        
         Ok(Self {
             impl_token: Default::default(),
             ref_ident: module.host_ref_ident()?,
@@ -184,11 +179,7 @@ impl TryFrom<&'_ ModuleImplIR> for HostRefTryImplItem {
             functions: module
                 .host_functions()?
                 .iter()
-                .flat_map(|f| {
-                    vec![
-                        ref_utils::host_try_function_item(f),
-                    ]
-                })
+                .flat_map(|f| vec![ref_utils::host_try_function_item(f)])
                 .collect()
         })
     }

--- a/odra-macros/src/ast/host_ref_item.rs
+++ b/odra-macros/src/ast/host_ref_item.rs
@@ -390,6 +390,56 @@ mod ref_item_tests {
             }
 
             impl Erc20HostRef {
+                /// Initializes the contract with the given parameters.
+                pub fn init(&mut self, total_supply: Option<U256>) {
+                    self.try_init(total_supply).unwrap()
+                }
+
+                /// Returns the total supply of the token.
+                pub fn total_supply(&self) -> U256 {
+                    self.try_total_supply().unwrap()
+                }
+
+                /// Pay to mint.
+                pub fn pay_to_mint(&mut self) {
+                    self.try_pay_to_mint().unwrap()
+                }
+
+                /// Approve.
+                pub fn approve(&mut self, to: &Address, amount: &U256) {
+                    self.try_approve(to, amount).unwrap()
+                }
+
+                /// Airdrops the given amount to the given addresses.
+                pub fn airdrop(&self, to: &[Address], amount: &U256) {
+                    self.try_airdrop(to, amount).unwrap()
+                }
+            }
+
+            impl Erc20HostRef {
+                /// Initializes the contract with the given parameters.
+                /// Does not fail in case of error, returns `odra::OdraResult` instead.
+                pub fn try_init(&mut self, total_supply: Option<U256>) -> odra::OdraResult<()> {
+                    self.env
+                        .call_contract(
+                            self.address,
+                            odra::CallDef::new(
+                                String::from("init"),
+                                true,
+                                {
+                                    let mut named_args = odra::casper_types::RuntimeArgs::new();
+                                    if self.attached_value > odra::casper_types::U512::zero() {
+                                        let _ = named_args.insert("amount", self.attached_value);
+                                    }
+                                    let _ = named_args
+                                        .insert("total_supply", total_supply.clone());
+                                    named_args
+                                },
+                            )
+                            .with_amount(self.attached_value),
+                        )
+                }
+
                 /// Returns the total supply of the token.
                 /// Does not fail in case of error, returns `odra::OdraResult` instead.
                 pub fn try_total_supply(&self) -> odra::OdraResult<U256> {
@@ -408,12 +458,6 @@ mod ref_item_tests {
                         ).with_amount(self.attached_value),
                     )
                 }
-
-                /// Returns the total supply of the token.
-                pub fn total_supply(&self) -> U256 {
-                    self.try_total_supply().unwrap()
-                }
-
                 /// Pay to mint.
                 /// Does not fail in case of error, returns `odra::OdraResult` instead.
                 pub fn try_pay_to_mint(&mut self) -> odra::OdraResult<()> {
@@ -434,18 +478,12 @@ mod ref_item_tests {
                                 .with_amount(self.attached_value),
                         )
                 }
-
-                /// Pay to mint.
-                pub fn pay_to_mint(&mut self) {
-                    self.try_pay_to_mint().unwrap()
-                }
-
                 /// Approve.
                 /// Does not fail in case of error, returns `odra::OdraResult` instead.
                 pub fn try_approve(
                     &mut self,
-                    to: Address,
-                    amount: U256,
+                    to: &Address,
+                    amount: &U256,
                 ) -> odra::OdraResult<()> {
                     self.env
                         .call_contract(
@@ -458,23 +496,17 @@ mod ref_item_tests {
                                         if self.attached_value > odra::casper_types::U512::zero() {
                                             let _ = named_args.insert("amount", self.attached_value);
                                         }
-                                        let _ = named_args.insert("to", to);
-                                        let _ = named_args.insert("amount", amount);
+                                        let _ = named_args.insert("to", to.clone());
+                                        let _ = named_args.insert("amount", amount.clone());
                                         named_args
                                     },
                                 )
                                 .with_amount(self.attached_value),
                         )
                 }
-
-                /// Approve.
-                pub fn approve(&mut self, to: Address, amount: U256) {
-                    self.try_approve(to, amount).unwrap()
-                }
-
                 /// Airdrops the given amount to the given addresses.
                 /// Does not fail in case of error, returns `odra::OdraResult` instead.
-                pub fn try_airdrop(&self, to: odra::prelude::vec::Vec<Address>, amount: U256) -> odra::OdraResult<()> {
+                pub fn try_airdrop(&self, to: &[Address], amount: &U256) -> odra::OdraResult<()> {
                     self.env.call_contract(
                         self.address,
                         odra::CallDef::new(
@@ -485,17 +517,12 @@ mod ref_item_tests {
                                 if self.attached_value > odra::casper_types::U512::zero() {
                                     let _ = named_args.insert("amount", self.attached_value);
                                 }
-                                let _ = named_args.insert("to", to);
-                                let _ = named_args.insert("amount", amount);
+                                let _ = named_args.insert("to", to.clone());
+                                let _ = named_args.insert("amount", amount.clone());
                                 named_args
                             }
                         ).with_amount(self.attached_value),
                     )
-                }
-
-                /// Airdrops the given amount to the given addresses.
-                pub fn airdrop(&self, to: odra::prelude::vec::Vec<Address>, amount: U256) {
-                    self.try_airdrop(to, amount).unwrap()
                 }
             }
         };
@@ -551,6 +578,16 @@ mod ref_item_tests {
                 }
             }
 
+            impl IErc20 for Erc20HostRef {
+                fn total_supply(&self) -> U256 {
+                    self.try_total_supply().unwrap()
+                }
+
+                fn pay_to_mint(&mut self) {
+                    self.try_pay_to_mint().unwrap()
+                }
+            }
+
             impl Erc20HostRef {
                 /// Does not fail in case of error, returns `odra::OdraResult` instead.
                 pub fn try_total_supply(&self) -> odra::OdraResult<U256> {
@@ -570,9 +607,6 @@ mod ref_item_tests {
                     )
                 }
 
-                pub fn total_supply(&self) -> U256 {
-                    self.try_total_supply().unwrap()
-                }
 
                 /// Does not fail in case of error, returns `odra::OdraResult` instead.
                 pub fn try_pay_to_mint(&mut self) -> odra::OdraResult<()>  {
@@ -592,10 +626,6 @@ mod ref_item_tests {
                                 )
                                 .with_amount(self.attached_value),
                         )
-                }
-
-                pub fn pay_to_mint(&mut self) {
-                    self.try_pay_to_mint().unwrap()
                 }
             }
         };
@@ -653,6 +683,33 @@ mod ref_item_tests {
 
             impl Erc20HostRef {
                 /// Returns the total supply of the token.
+                pub fn total_supply(&self) -> U256 {
+                    self.try_total_supply().unwrap()
+                }
+
+                /// Delegated. See `self.ownable.get_owner()` for details.
+                pub fn get_owner(&self) -> Address {
+                    self.try_get_owner().unwrap()
+                }
+
+                /// Delegated. See `self.ownable.set_owner()` for details.
+                pub fn set_owner(&mut self, new_owner: Address) {
+                    self.try_set_owner(new_owner).unwrap()
+                }
+
+                /// Delegated. See `self.metadata.name()` for details.
+                pub fn name(&self) -> String {
+                    self.try_name().unwrap()
+                }
+
+                /// Delegated. See `self.metadata.symbol()` for details.
+                pub fn symbol(&self) -> String {
+                    self.try_symbol().unwrap()
+                 }
+            }
+
+            impl Erc20HostRef {
+                /// Returns the total supply of the token.
                 /// Does not fail in case of error, returns `odra::OdraResult` instead.
                 pub fn try_total_supply(&self) -> odra::OdraResult<U256> {
                     self.env.call_contract(
@@ -671,11 +728,7 @@ mod ref_item_tests {
                     )
                 }
 
-                /// Returns the total supply of the token.
-                pub fn total_supply(&self) -> U256 {
-                    self.try_total_supply().unwrap()
-                }
-
+                /// Delegated. See `self.ownable.get_owner()` for details.
                 /// Does not fail in case of error, returns `odra::OdraResult` instead.
                 pub fn try_get_owner(&self) -> odra::OdraResult<Address> {
                     self.env
@@ -696,10 +749,7 @@ mod ref_item_tests {
                         )
                 }
 
-                pub fn get_owner(&self) -> Address {
-                    self.try_get_owner().unwrap()
-                }
-
+                /// Delegated. See `self.ownable.set_owner()` for details.
                 /// Does not fail in case of error, returns `odra::OdraResult` instead.
                 pub fn try_set_owner(&mut self, new_owner: Address) -> odra::OdraResult<()> {
                     self.env
@@ -713,7 +763,7 @@ mod ref_item_tests {
                                         if self.attached_value > odra::casper_types::U512::zero() {
                                             let _ = named_args.insert("amount", self.attached_value);
                                         }
-                                        let _ = named_args.insert("new_owner", new_owner);
+                                        let _ = named_args.insert("new_owner", new_owner.clone());
                                         named_args
                                     },
                                 )
@@ -721,10 +771,7 @@ mod ref_item_tests {
                         )
                 }
 
-                pub fn set_owner(&mut self, new_owner: Address) {
-                    self.try_set_owner(new_owner).unwrap()
-                }
-
+                /// Delegated. See `self.metadata.name()` for details.
                 /// Does not fail in case of error, returns `odra::OdraResult` instead.
                 pub fn try_name(&self) -> odra::OdraResult<String> {
                     self.env
@@ -745,10 +792,7 @@ mod ref_item_tests {
                         )
                 }
 
-                pub fn name(&self) -> String {
-                    self.try_name().unwrap()
-                }
-
+                /// Delegated. See `self.metadata.symbol()` for details.
                 /// Does not fail in case of error, returns `odra::OdraResult` instead.
                 pub fn try_symbol(&self) -> odra::OdraResult<String> {
                     self.env
@@ -769,9 +813,6 @@ mod ref_item_tests {
                         )
                 }
 
-                pub fn symbol(&self) -> String {
-                    self.try_symbol().unwrap()
-                 }
             }
         };
         let actual = HostRefItem::try_from(&module).unwrap();

--- a/odra-macros/src/ast/host_ref_item.rs
+++ b/odra-macros/src/ast/host_ref_item.rs
@@ -153,7 +153,7 @@ impl TryFrom<&'_ ModuleImplIR> for HostRefImplItem {
                 .iter()
                 .flat_map(|f| {
                     vec![
-                        ref_utils::host_function_item(f),
+                        ref_utils::host_function_item(f, module.is_trait_impl()),
                     ]
                 })
                 .collect()

--- a/odra-macros/src/ast/host_ref_item.rs
+++ b/odra-macros/src/ast/host_ref_item.rs
@@ -573,6 +573,7 @@ mod ref_item_tests {
     fn host_ref_delegation() {
         let module = test_utils::mock::module_delegation();
         let expected = quote! {
+            /// [Erc20] Host Ref.
             pub struct Erc20HostRef {
                 address: odra::Address,
                 env: odra::host::HostEnv,
@@ -617,6 +618,8 @@ mod ref_item_tests {
             }
 
             impl Erc20HostRef {
+                /// Returns the total supply of the token.
+                /// Does not fail in case of error, returns `odra::OdraResult` instead.
                 pub fn try_total_supply(&self) -> odra::OdraResult<U256> {
                     self.env.call_contract(
                         self.address,
@@ -634,10 +637,12 @@ mod ref_item_tests {
                     )
                 }
 
+                /// Returns the total supply of the token.
                 pub fn total_supply(&self) -> U256 {
                     self.try_total_supply().unwrap()
                 }
 
+                /// Does not fail in case of error, returns `odra::OdraResult` instead.
                 pub fn try_get_owner(&self) -> odra::OdraResult<Address> {
                     self.env
                         .call_contract(
@@ -661,6 +666,7 @@ mod ref_item_tests {
                     self.try_get_owner().unwrap()
                 }
 
+                /// Does not fail in case of error, returns `odra::OdraResult` instead.
                 pub fn try_set_owner(&mut self, new_owner: Address) -> odra::OdraResult<()> {
                     self.env
                         .call_contract(
@@ -685,6 +691,7 @@ mod ref_item_tests {
                     self.try_set_owner(new_owner).unwrap()
                 }
 
+                /// Does not fail in case of error, returns `odra::OdraResult` instead.
                 pub fn try_name(&self) -> odra::OdraResult<String> {
                     self.env
                         .call_contract(
@@ -708,6 +715,7 @@ mod ref_item_tests {
                     self.try_name().unwrap()
                 }
 
+                /// Does not fail in case of error, returns `odra::OdraResult` instead.
                 pub fn try_symbol(&self) -> odra::OdraResult<String> {
                     self.env
                         .call_contract(

--- a/odra-macros/src/ast/mod.rs
+++ b/odra-macros/src/ast/mod.rs
@@ -1,5 +1,6 @@
 mod blueprint;
 mod clone;
+mod contract_ref_item;
 mod deployer_item;
 mod deployer_utils;
 mod entrypoints_item;
@@ -16,7 +17,6 @@ mod module_item;
 mod module_struct_item;
 mod odra_type_item;
 mod parts_utils;
-mod contract_ref_item;
 mod ref_utils;
 mod test_parts;
 mod utils;

--- a/odra-macros/src/ast/mod.rs
+++ b/odra-macros/src/ast/mod.rs
@@ -16,7 +16,7 @@ mod module_item;
 mod module_struct_item;
 mod odra_type_item;
 mod parts_utils;
-mod ref_item;
+mod contract_ref_item;
 mod ref_utils;
 mod test_parts;
 mod utils;

--- a/odra-macros/src/ast/module_impl_item.rs
+++ b/odra-macros/src/ast/module_impl_item.rs
@@ -1,7 +1,7 @@
 use crate::ast::blueprint::BlueprintItem;
 use crate::ast::entrypoints_item::HasEntrypointsImplItem;
 use crate::ast::exec_parts::ExecPartsItem;
-use crate::ast::ref_item::RefItem;
+use crate::ast::contract_ref_item::RefItem;
 use crate::ast::test_parts::{TestPartsItem, TestPartsReexportItem};
 use crate::ast::wasm_parts::WasmPartsModuleItem;
 use crate::ir::ModuleImplIR;

--- a/odra-macros/src/ast/module_impl_item.rs
+++ b/odra-macros/src/ast/module_impl_item.rs
@@ -1,7 +1,7 @@
 use crate::ast::blueprint::BlueprintItem;
+use crate::ast::contract_ref_item::RefItem;
 use crate::ast::entrypoints_item::HasEntrypointsImplItem;
 use crate::ast::exec_parts::ExecPartsItem;
-use crate::ast::contract_ref_item::RefItem;
 use crate::ast::test_parts::{TestPartsItem, TestPartsReexportItem};
 use crate::ast::wasm_parts::WasmPartsModuleItem;
 use crate::ir::ModuleImplIR;

--- a/odra-macros/src/ast/odra_type_item.rs
+++ b/odra-macros/src/ast/odra_type_item.rs
@@ -1,6 +1,6 @@
 use crate::ast::clone::CloneItem;
 use crate::ast::events_item::HasEventsImplItem;
-use crate::ast::fn_utils::{FnItem, SelfFnItem, SingleArgFnItem};
+use crate::ast::fn_utils::{FnItem, SingleArgFnItem};
 use crate::ast::utils::{ImplItem, Named};
 use crate::ir::TypeIR;
 use crate::utils;
@@ -189,7 +189,7 @@ impl FromBytesFnItem {
 
 #[derive(syn_derive::ToTokens)]
 struct ToBytesFnItem {
-    fn_item: SelfFnItem
+    fn_item: FnItem
 }
 
 impl_from_ir!(ToBytesFnItem);
@@ -220,7 +220,7 @@ impl ToBytesFnItem {
             Ok(#ident_result)
         });
         Ok(Self {
-            fn_item: SelfFnItem::new(&name, ret_ty, block)
+            fn_item: FnItem::new(&name, vec![], ret_ty, block).instanced()
         })
     }
 
@@ -236,14 +236,14 @@ impl ToBytesFnItem {
         let block = utils::expr::to_bytes(&as_u32).as_block();
 
         Ok(Self {
-            fn_item: SelfFnItem::new(&name, ret_ty, block)
+            fn_item: FnItem::new(&name, vec![], ret_ty, block).instanced()
         })
     }
 }
 
 #[derive(syn_derive::ToTokens)]
 struct SerializedLengthFnItem {
-    fn_item: SelfFnItem
+    fn_item: FnItem
 }
 
 impl_from_ir!(SerializedLengthFnItem);
@@ -268,7 +268,7 @@ impl SerializedLengthFnItem {
             #ident_result
         });
         Ok(Self {
-            fn_item: SelfFnItem::new(&name, ret_ty, block)
+            fn_item: FnItem::new(&name, vec![], ret_ty, block).instanced()
         })
     }
 
@@ -282,7 +282,7 @@ impl SerializedLengthFnItem {
         let ret_ty = utils::misc::ret_ty(&ty_usize);
         let block = utils::expr::serialized_length(&as_u32).as_block();
         Ok(Self {
-            fn_item: SelfFnItem::new(&name, ret_ty, block)
+            fn_item: FnItem::new(&name, vec![], ret_ty, block).instanced()
         })
     }
 }

--- a/odra-macros/src/ast/ref_item.rs
+++ b/odra-macros/src/ast/ref_item.rs
@@ -28,7 +28,7 @@ impl TryFrom<&'_ ModuleImplIR> for ContractRefStructItem {
             #address: #ty_address,
         });
 
-        let comment = format!("[{}] Contract Ref.", module.module_str()?);
+        let comment = format!(" [{}] Contract Ref.", module.module_str()?);
         let doc_attr = parse_quote!(#[doc = #comment]);
 
         Ok(Self {
@@ -81,7 +81,7 @@ impl NewFnItem {
         ];
         let ret_expr: syn::Expr = parse_quote!(Self { #m_env, #m_address });
         let fn_item = FnItem::new(&utils::ident::new(), args, ret_ty, ret_expr.as_block())
-            .public("Creates a new instance of the contract reference.".to_string());
+            .public("Creates a new instance of the Contract Ref.".to_string());
         Self { fn_item }
     }
 }
@@ -138,20 +138,24 @@ mod ref_item_tests {
     fn contract_ref() {
         let module = test_utils::mock::module_impl();
         let expected = quote! {
+            /// [Erc20] Contract Ref.
             pub struct Erc20ContractRef {
                 env: odra::prelude::Rc<odra::ContractEnv>,
                 address: odra::Address,
             }
 
             impl Erc20ContractRef {
+                /// Creates a new instance of the Contract Ref.
                 pub fn new(env: odra::prelude::Rc<odra::ContractEnv>, address: odra::Address) -> Self {
                     Self { env, address }
                 }
 
+                /// Returns the address of the contract.
                 pub fn address(&self) -> &odra::Address {
                     &self.address
                 }
 
+                /// Initializes the contract with the given parameters.
                 pub fn init(&mut self, total_supply: Option<U256>) {
                     self.env.call_contract(
                         self.address,
@@ -167,6 +171,7 @@ mod ref_item_tests {
                     )
                 }
 
+                /// Returns the total supply of the token.
                 pub fn total_supply(&self) -> U256 {
                     self.env.call_contract(
                         self.address,
@@ -181,6 +186,7 @@ mod ref_item_tests {
                     )
                 }
 
+                /// Pay to mint.
                 pub fn pay_to_mint(&mut self) {
                     self.env
                         .call_contract(
@@ -196,6 +202,7 @@ mod ref_item_tests {
                         )
                 }
 
+                /// Approve.
                 pub fn approve(&mut self, to: Address, amount: U256) {
                     self.env
                         .call_contract(
@@ -213,6 +220,7 @@ mod ref_item_tests {
                         )
                 }
 
+                /// Airdrops the given amount to the given addresses.
                 pub fn airdrop(&self, to: odra::prelude::vec::Vec<Address>, amount: U256) {
                     self.env
                         .call_contract(
@@ -239,16 +247,19 @@ mod ref_item_tests {
     fn contract_trait_impl_ref() {
         let module = test_utils::mock::module_trait_impl();
         let expected = quote! {
+            /// [Erc20] Contract Ref.
             pub struct Erc20ContractRef {
                 env: odra::prelude::Rc<odra::ContractEnv>,
                 address: odra::Address,
             }
 
             impl Erc20ContractRef {
+                /// Creates a new instance of the Contract Ref.
                 pub fn new(env: odra::prelude::Rc<odra::ContractEnv>, address: odra::Address) -> Self {
                     Self { env, address }
                 }
 
+                /// Returns the address of the contract.
                 pub fn address(&self) -> &odra::Address {
                     &self.address
                 }
@@ -291,20 +302,24 @@ mod ref_item_tests {
     fn contract_ref_delegate() {
         let module = test_utils::mock::module_delegation();
         let expected = quote! {
+            /// [Erc20] Contract Ref.
             pub struct Erc20ContractRef {
                 env: odra::prelude::Rc<odra::ContractEnv>,
                 address: odra::Address,
             }
 
             impl Erc20ContractRef {
+                /// Creates a new instance of the Contract Ref.
                 pub fn new(env: odra::prelude::Rc<odra::ContractEnv>, address: odra::Address) -> Self {
                     Self { env, address }
                 }
 
+                /// Returns the address of the contract.
                 pub fn address(&self) -> &odra::Address {
                     &self.address
                 }
 
+                /// Returns the total supply of the token.
                 pub fn total_supply(&self) -> U256 {
                     self.env.call_contract(
                         self.address,

--- a/odra-macros/src/ast/ref_utils.rs
+++ b/odra-macros/src/ast/ref_utils.rs
@@ -72,7 +72,7 @@ fn call_def_with_amount(fun: &FnIR) -> syn::Expr {
 
 fn function_signature(fun: &FnIR) -> syn::Signature {
     let fun_name = fun.name();
-    let args = fun.raw_typed_args();
+    let args = fun.typed_args();
     let return_type = fun.return_type();
     let mutability = fun.is_mut().then(|| quote::quote!(mut));
 
@@ -89,7 +89,7 @@ fn function_docs(fun: &FnIR) -> Vec<syn::Attribute> {
 
 fn try_function_signature(fun: &FnIR) -> syn::Signature {
     let fun_name = fun.try_name();
-    let args = fun.raw_typed_args();
+    let args = fun.typed_args();
     let return_type = fun.try_return_type();
     let mutability = fun.is_mut().then(|| quote::quote!(mut));
 
@@ -131,5 +131,5 @@ pub fn insert_arg_stmt(arg: &FnArgIR) -> syn::Stmt {
     let name = ident.to_string();
     let args = utils::ident::named_args();
 
-    syn::parse_quote!(let _ = #args.insert(#name, #ident);)
+    syn::parse_quote!(let _ = #args.insert(#name, #ident.clone());)
 }

--- a/odra-macros/src/ast/ref_utils.rs
+++ b/odra-macros/src/ast/ref_utils.rs
@@ -1,10 +1,10 @@
+use crate::utils::syn::visibility_default;
 use crate::{
     ast::fn_utils,
     ir::{FnArgIR, FnIR},
     utils::{self, syn::visibility_pub}
 };
 use syn::{parse_quote, Attribute, Visibility};
-use crate::utils::syn::visibility_default;
 
 pub fn host_try_function_item(fun: &FnIR) -> syn::ItemFn {
     let signature = try_function_signature(fun);
@@ -44,7 +44,12 @@ pub fn contract_function_item(fun: &FnIR, is_trait_impl: bool) -> syn::ItemFn {
     env_call(signature, call_def_expr, attrs, vis)
 }
 
-fn env_call(sig: syn::Signature, call_def_expr: syn::Expr, docs: Vec<Attribute>, vis: Visibility) -> syn::ItemFn {
+fn env_call(
+    sig: syn::Signature,
+    call_def_expr: syn::Expr,
+    docs: Vec<Attribute>,
+    vis: Visibility
+) -> syn::ItemFn {
     let m_env = utils::member::env();
     let m_address = utils::member::address();
 

--- a/odra-macros/src/ast/test_parts.rs
+++ b/odra-macros/src/ast/test_parts.rs
@@ -84,6 +84,7 @@ mod test {
                 use super::*;
                 use odra::prelude::*;
 
+                /// [Erc20] Host Ref.
                 pub struct Erc20HostRef {
                     address: odra::Address,
                     env: odra::host::HostEnv,
@@ -128,6 +129,58 @@ mod test {
                 }
 
                 impl Erc20HostRef {
+                    /// Initializes the contract with the given parameters.
+                    pub fn init(&mut self, total_supply: Option<U256>) {
+                        self.try_init(total_supply).unwrap()
+                    }
+
+                    /// Returns the total supply of the token.
+                    pub fn total_supply(&self) -> U256 {
+                        self.try_total_supply().unwrap()
+                    }
+
+                    /// Pay to mint.
+                    pub fn pay_to_mint(&mut self) {
+                        self.try_pay_to_mint().unwrap()
+                    }
+
+                    /// Approve.
+                    pub fn approve(&mut self, to: &Address, amount: &U256) {
+                        self.try_approve(to, amount).unwrap()
+                    }
+
+                    /// Airdrops the given amount to the given addresses.
+                    pub fn airdrop(&self, to: &[Address], amount: &U256) {
+                        self.try_airdrop(to, amount).unwrap()
+                    }
+                }
+
+                impl Erc20HostRef {
+                    /// Initializes the contract with the given parameters.
+                    /// Does not fail in case of error, returns `odra::OdraResult` instead.
+                    pub fn try_init(&mut self, total_supply: Option<U256>) -> odra::OdraResult<()> {
+                        self.env
+                            .call_contract(
+                                self.address,
+                                odra::CallDef::new(
+                                    String::from("init"),
+                                    true,
+                                    {
+                                        let mut named_args = odra::casper_types::RuntimeArgs::new();
+                                        if self.attached_value > odra::casper_types::U512::zero() {
+                                            let _ = named_args.insert("amount", self.attached_value);
+                                        }
+                                        let _ = named_args
+                                            .insert("total_supply", total_supply.clone());
+                                        named_args
+                                    },
+                                )
+                                .with_amount(self.attached_value),
+                            )
+                    }
+
+                    /// Returns the total supply of the token.
+                    /// Does not fail in case of error, returns `odra::OdraResult` instead.
                     pub fn try_total_supply(&self) -> odra::OdraResult<U256> {
                         self.env.call_contract(
                             self.address,
@@ -144,56 +197,55 @@ mod test {
                             ).with_amount(self.attached_value),
                         )
                     }
-
-                    pub fn total_supply(&self) -> U256 {
-                        self.try_total_supply().unwrap()
-                    }
-
+                    /// Pay to mint.
+                    /// Does not fail in case of error, returns `odra::OdraResult` instead.
                     pub fn try_pay_to_mint(&mut self) -> odra::OdraResult<()> {
-                        self.env.call_contract(
-                            self.address,
-                            odra::CallDef::new(
-                                String::from("pay_to_mint"),
-                                true,
-                                {
-                                    let mut named_args = odra::casper_types::RuntimeArgs::new();
-                                    if self.attached_value > odra::casper_types::U512::zero() {
-                                        let _ = named_args.insert("amount", self.attached_value);
-                                    }
-                                    named_args
-                                }
-                            ).with_amount(self.attached_value),
-                        )
+                        self.env
+                            .call_contract(
+                                self.address,
+                                odra::CallDef::new(
+                                        String::from("pay_to_mint"),
+                                        true,
+                                        {
+                                            let mut named_args = odra::casper_types::RuntimeArgs::new();
+                                            if self.attached_value > odra::casper_types::U512::zero() {
+                                                let _ = named_args.insert("amount", self.attached_value);
+                                            }
+                                            named_args
+                                        },
+                                    )
+                                    .with_amount(self.attached_value),
+                            )
                     }
-
-                    pub fn pay_to_mint(&mut self) {
-                        self.try_pay_to_mint().unwrap()
+                    /// Approve.
+                    /// Does not fail in case of error, returns `odra::OdraResult` instead.
+                    pub fn try_approve(
+                        &mut self,
+                        to: &Address,
+                        amount: &U256,
+                    ) -> odra::OdraResult<()> {
+                        self.env
+                            .call_contract(
+                                self.address,
+                                odra::CallDef::new(
+                                        String::from("approve"),
+                                        true,
+                                        {
+                                            let mut named_args = odra::casper_types::RuntimeArgs::new();
+                                            if self.attached_value > odra::casper_types::U512::zero() {
+                                                let _ = named_args.insert("amount", self.attached_value);
+                                            }
+                                            let _ = named_args.insert("to", to.clone());
+                                            let _ = named_args.insert("amount", amount.clone());
+                                            named_args
+                                        },
+                                    )
+                                    .with_amount(self.attached_value),
+                            )
                     }
-
-                    pub fn try_approve(&mut self, to: Address, amount: U256) -> odra::OdraResult<()> {
-                        self.env.call_contract(
-                            self.address,
-                            odra::CallDef::new(
-                                String::from("approve"),
-                                true,
-                                {
-                                    let mut named_args = odra::casper_types::RuntimeArgs::new();
-                                    if self.attached_value > odra::casper_types::U512::zero() {
-                                        let _ = named_args.insert("amount", self.attached_value);
-                                    }
-                                    let _ = named_args.insert("to", to);
-                                    let _ = named_args.insert("amount", amount);
-                                    named_args
-                                }
-                            ).with_amount(self.attached_value),
-                        )
-                    }
-
-                    pub fn approve(&mut self, to: Address, amount: U256) {
-                        self.try_approve(to, amount).unwrap()
-                    }
-
-                    pub fn try_airdrop(&self, to: odra::prelude::vec::Vec<Address>, amount: U256) -> odra::OdraResult<()> {
+                    /// Airdrops the given amount to the given addresses.
+                    /// Does not fail in case of error, returns `odra::OdraResult` instead.
+                    pub fn try_airdrop(&self, to: &[Address], amount: &U256) -> odra::OdraResult<()> {
                         self.env.call_contract(
                             self.address,
                             odra::CallDef::new(
@@ -204,16 +256,12 @@ mod test {
                                     if self.attached_value > odra::casper_types::U512::zero() {
                                         let _ = named_args.insert("amount", self.attached_value);
                                     }
-                                    let _ = named_args.insert("to", to);
-                                    let _ = named_args.insert("amount", amount);
+                                    let _ = named_args.insert("to", to.clone());
+                                    let _ = named_args.insert("amount", amount.clone());
                                     named_args
                                 }
                             ).with_amount(self.attached_value),
                         )
-                    }
-
-                    pub fn airdrop(&self, to: odra::prelude::vec::Vec<Address>, amount: U256) {
-                        self.try_airdrop(to, amount).unwrap()
                     }
                 }
 
@@ -223,6 +271,7 @@ mod test {
                     }
                 }
 
+                #[allow(missing_docs)]
                 /// [Erc20] contract constructor arguments.
                 #[derive(odra::IntoRuntimeArgs)]
                 pub struct Erc20InitArgs {
@@ -298,6 +347,7 @@ mod test {
                 use super::*;
                 use odra::prelude::*;
 
+                /// [Erc20] Host Ref.
                 pub struct Erc20HostRef {
                     address: odra::Address,
                     env: odra::host::HostEnv,
@@ -341,7 +391,19 @@ mod test {
                     }
                 }
 
+
+                impl IErc20 for Erc20HostRef {
+                    fn total_supply(&self) -> U256 {
+                        self.try_total_supply().unwrap()
+                    }
+
+                    fn pay_to_mint(&mut self) {
+                        self.try_pay_to_mint().unwrap()
+                    }
+                }
+
                 impl Erc20HostRef {
+                    /// Does not fail in case of error, returns `odra::OdraResult` instead.
                     pub fn try_total_supply(&self) -> odra::OdraResult<U256> {
                         self.env.call_contract(
                             self.address,
@@ -359,29 +421,24 @@ mod test {
                         )
                     }
 
-                    pub fn total_supply(&self) -> U256 {
-                        self.try_total_supply().unwrap()
-                    }
-
+                    /// Does not fail in case of error, returns `odra::OdraResult` instead.
                     pub fn try_pay_to_mint(&mut self) -> odra::OdraResult<()> {
-                        self.env.call_contract(
-                            self.address,
-                            odra::CallDef::new(
-                                String::from("pay_to_mint"),
-                                true,
-                                {
-                                    let mut named_args = odra::casper_types::RuntimeArgs::new();
-                                    if self.attached_value > odra::casper_types::U512::zero() {
-                                        let _ = named_args.insert("amount", self.attached_value);
-                                    }
-                                    named_args
-                                }
-                            ).with_amount(self.attached_value),
-                        )
-                    }
-
-                    pub fn pay_to_mint(&mut self) {
-                        self.try_pay_to_mint().unwrap()
+                        self.env
+                            .call_contract(
+                                self.address,
+                                odra::CallDef::new(
+                                        String::from("pay_to_mint"),
+                                        true,
+                                        {
+                                            let mut named_args = odra::casper_types::RuntimeArgs::new();
+                                            if self.attached_value > odra::casper_types::U512::zero() {
+                                                let _ = named_args.insert("amount", self.attached_value);
+                                            }
+                                            named_args
+                                        },
+                                    )
+                                    .with_amount(self.attached_value),
+                            )
                     }
                 }
 

--- a/odra-macros/src/ir/delegate.rs
+++ b/odra-macros/src/ir/delegate.rs
@@ -28,7 +28,7 @@ impl syn::parse::Parse for Delegate {
                         _ => None
                     })
                     .collect::<syn::punctuated::Punctuated<syn::Ident, syn::Token![,]>>();
-                
+
                 let mut attrs = fn_item.attrs.clone();
                 attrs.push(syn::parse_quote!(#[allow(missing_docs)]));
 

--- a/odra-macros/src/ir/delegate.rs
+++ b/odra-macros/src/ir/delegate.rs
@@ -1,4 +1,5 @@
 use crate::utils;
+use quote::ToTokens;
 
 mod kw {
     syn::custom_keyword!(to);
@@ -30,7 +31,16 @@ impl syn::parse::Parse for Delegate {
                     .collect::<syn::punctuated::Punctuated<syn::Ident, syn::Token![,]>>();
 
                 let mut attrs = fn_item.attrs.clone();
-                attrs.push(syn::parse_quote!(#[allow(missing_docs)]));
+
+                let comment = format!(
+                    " Delegated. See `{}.{}.{}()` for details.",
+                    delegate_to.base.to_token_stream(),
+                    delegate_to.member.to_token_stream(),
+                    fn_ident
+                );
+
+                let attr = syn::parse_quote!(#[doc = #comment]);
+                attrs.push(attr);
 
                 functions.push(syn::ImplItemFn {
                     attrs,

--- a/odra-macros/src/ir/delegate.rs
+++ b/odra-macros/src/ir/delegate.rs
@@ -28,9 +28,12 @@ impl syn::parse::Parse for Delegate {
                         _ => None
                     })
                     .collect::<syn::punctuated::Punctuated<syn::Ident, syn::Token![,]>>();
+                
+                let mut attrs = fn_item.attrs.clone();
+                attrs.push(syn::parse_quote!(#[allow(missing_docs)]));
 
                 functions.push(syn::ImplItemFn {
-                    attrs: fn_item.attrs,
+                    attrs,
                     vis: utils::syn::visibility_pub(),
                     defaultness: None,
                     sig: fn_item.sig,

--- a/odra-macros/src/ir/mod.rs
+++ b/odra-macros/src/ir/mod.rs
@@ -354,6 +354,15 @@ pub enum FnIR {
     Def(FnTraitIR)
 }
 
+impl FnIR {
+    pub fn attributes(&self) -> &[syn::Attribute] {
+        match self {
+            FnIR::Impl(ir) => ir.attrs(),
+            FnIR::Def(ir) => ir.attrs()
+        }
+    }
+}
+
 const PROTECTED_FUNCTIONS: [&str; 3] = ["new", "env", "address"];
 
 fn validate_fn_name<T: ToTokens>(name: &str, ctx: T) -> syn::Result<()> {

--- a/odra-macros/src/ir/mod.rs
+++ b/odra-macros/src/ir/mod.rs
@@ -263,7 +263,6 @@ impl ModuleImplIR {
         Ok(self
             .functions()?
             .into_iter()
-            .filter(|f| f.name_str() != CONSTRUCTOR_NAME)
             .collect())
     }
 

--- a/odra-macros/src/ir/mod.rs
+++ b/odra-macros/src/ir/mod.rs
@@ -174,6 +174,24 @@ impl ModuleImplIR {
         }
     }
 
+    pub fn is_trait_impl(&self) -> bool {
+        match self {
+            ModuleImplIR::Impl(ir) => {
+                ir.code.trait_.is_some()
+            }
+            ModuleImplIR::Trait(_) => false
+        }
+    }
+
+    pub fn impl_trait_ident(&self) -> Option<Ident> {
+        match self {
+            ModuleImplIR::Impl(ir) => {
+                ir.code.trait_.clone().map(|(_, path, _)| path.get_ident().unwrap().clone())
+            }
+            ModuleImplIR::Trait(_) => None
+        }
+    }
+
     pub fn module_str(&self) -> syn::Result<String> {
         self.module_ident().map(|i| i.to_string())
     }

--- a/odra-macros/src/ir/mod.rs
+++ b/odra-macros/src/ir/mod.rs
@@ -176,18 +176,18 @@ impl ModuleImplIR {
 
     pub fn is_trait_impl(&self) -> bool {
         match self {
-            ModuleImplIR::Impl(ir) => {
-                ir.code.trait_.is_some()
-            }
+            ModuleImplIR::Impl(ir) => ir.code.trait_.is_some(),
             ModuleImplIR::Trait(_) => false
         }
     }
 
     pub fn impl_trait_ident(&self) -> Option<Ident> {
         match self {
-            ModuleImplIR::Impl(ir) => {
-                ir.code.trait_.clone().map(|(_, path, _)| path.get_ident().unwrap().clone())
-            }
+            ModuleImplIR::Impl(ir) => ir
+                .code
+                .trait_
+                .clone()
+                .map(|(_, path, _)| path.get_ident().unwrap().clone()),
             ModuleImplIR::Trait(_) => None
         }
     }
@@ -260,10 +260,7 @@ impl ModuleImplIR {
     }
 
     pub fn host_functions(&self) -> syn::Result<Vec<FnIR>> {
-        Ok(self
-            .functions()?
-            .into_iter()
-            .collect())
+        Ok(self.functions()?.into_iter().collect())
     }
 
     pub fn constructor(&self) -> Option<FnIR> {

--- a/odra-macros/src/lib.rs
+++ b/odra-macros/src/lib.rs
@@ -1,5 +1,6 @@
+#![doc = "This crate provides a set of macros and derive attributes to simplify the process of writing"]
+#![doc = "smart contracts for the Odra platform."]
 #![feature(box_patterns, result_flattening)]
-
 use crate::utils::IntoCode;
 use ast::*;
 use ir::{ModuleImplIR, ModuleStructIR, TypeIR};

--- a/odra-macros/src/test_utils.rs
+++ b/odra-macros/src/test_utils.rs
@@ -7,6 +7,7 @@ pub mod mock {
     pub fn module_impl() -> ModuleImplIR {
         let module = quote! {
             impl Erc20 {
+                /// Initializes the contract with the given parameters.
                 pub fn init(&mut self, total_supply: Option<U256>) {
                     if let Some(total_supply) = total_supply {
                         self.total_supply.set(total_supply);
@@ -14,10 +15,12 @@ pub mod mock {
                     }
                 }
 
+                /// Returns the total supply of the token.
                 pub fn total_supply(&self) -> U256 {
                     self.total_supply.get_or_default()
                 }
 
+                /// Pay to mint.
                 #[odra(payable)]
                 pub fn pay_to_mint(&mut self) {
                     let attached_value = self.env().attached_value();
@@ -25,6 +28,7 @@ pub mod mock {
                         .set(self.total_supply() + U256::from(attached_value.as_u64()));
                 }
 
+                /// Approve.
                 #[odra(non_reentrant)]
                 pub fn approve(&mut self, to: &Address, amount: &U256) {
                     self.env.emit_event(Approval {
@@ -34,6 +38,7 @@ pub mod mock {
                     });
                 }
 
+                /// Airdrops the given amount to the given addresses.
                 pub fn airdrop(to: &[Address], amount: &U256) {
                 }
 

--- a/odra-macros/src/test_utils.rs
+++ b/odra-macros/src/test_utils.rs
@@ -75,6 +75,7 @@ pub mod mock {
     pub fn module_delegation() -> ModuleImplIR {
         let module = quote! {
             impl Erc20 {
+                /// Returns the total supply of the token.
                 pub fn total_supply(&self) -> U256 {
                     self.total_supply.get_or_default()
                 }

--- a/odra-macros/src/utils/attr.rs
+++ b/odra-macros/src/utils/attr.rs
@@ -32,3 +32,7 @@ pub fn init_args_docs(name: String) -> syn::Attribute {
     let name = format!(" [{}] contract constructor arguments.", name);
     parse_quote!(#[doc = #name])
 }
+
+pub fn missing_docs() -> syn::Attribute {
+    parse_quote!(#[allow(missing_docs)])
+}

--- a/odra-macros/src/utils/syn.rs
+++ b/odra-macros/src/utils/syn.rs
@@ -20,9 +20,7 @@ pub fn function_arg_names(sig: &syn::Signature) -> Vec<syn::Ident> {
             syn::FnArg::Typed(syn::PatType {
                 pat: box syn::Pat::Ident(pat),
                 ..
-            }) => {
-                Some(pat.ident.clone())
-            },
+            }) => Some(pat.ident.clone()),
             _ => None
         })
         .collect()

--- a/odra-macros/src/utils/syn.rs
+++ b/odra-macros/src/utils/syn.rs
@@ -20,7 +20,9 @@ pub fn function_arg_names(sig: &syn::Signature) -> Vec<syn::Ident> {
             syn::FnArg::Typed(syn::PatType {
                 pat: box syn::Pat::Ident(pat),
                 ..
-            }) => Some(pat.ident.clone()),
+            }) => {
+                Some(pat.ident.clone())
+            },
             _ => None
         })
         .collect()

--- a/odra-macros/src/utils/ty.rs
+++ b/odra-macros/src/utils/ty.rs
@@ -273,6 +273,10 @@ pub fn host_ref() -> syn::Type {
     parse_quote!(odra::host::HostRef)
 }
 
+pub fn contract_ref() -> syn::Type {
+    parse_quote!(odra::ContractRef)
+}
+
 pub fn init_args() -> syn::Type {
     parse_quote!(odra::host::InitArgs)
 }

--- a/odra-test/Cargo.toml
+++ b/odra-test/Cargo.toml
@@ -12,3 +12,6 @@ repository = { workspace = true }
 odra-core = { workspace = true }
 odra-casper-test-vm = { workspace = true }
 odra-vm = { workspace = true }
+
+[lints.rust]
+missing_docs = "warn"

--- a/odra-vm/Cargo.toml
+++ b/odra-vm/Cargo.toml
@@ -13,3 +13,6 @@ odra-core = { workspace = true }
 anyhow = "1.0.75"
 url = "2.4.1"
 blake2 = { workspace = true }
+
+[lints.rust]
+missing_docs = "warn"

--- a/odra-vm/src/lib.rs
+++ b/odra-vm/src/lib.rs
@@ -1,3 +1,7 @@
+#![doc = "OdraVM is a mock VM for testing contracts written id Odra Framework."]
+#![doc = "It is a simple implementation of a mock backend with a minimal set of features"]
+#![doc = "that allows testing the code written in Odra without compiling the contract"]
+#![doc = "to the target architecture and spinning up the blockchain."]
 #![allow(dead_code)]
 #![allow(unused_imports)]
 #![allow(unused_variables)]

--- a/odra/Cargo.toml
+++ b/odra/Cargo.toml
@@ -14,3 +14,6 @@ odra-macros = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 odra-casper-wasm-env = { workspace = true }
+
+[lints.rust]
+missing_docs = "warn"

--- a/odra/src/lib.rs
+++ b/odra/src/lib.rs
@@ -41,8 +41,9 @@ pub use odra_core::{arithmetic, contract_def, entry_point_callback, host, module
 pub use odra_core::{casper_event_standard, casper_event_standard::Event, casper_types};
 pub use odra_core::{
     Address, AddressError, CallDef, CollectionError, ContractCallResult, ContractContext,
-    ContractEnv, DeployReport, EventError, ExecutionEnv, ExecutionError, GasReport, List, ListIter,
-    Mapping, OdraError, OdraResult, Sequence, SubModule, UnwrapOrRevert, Var, VmError
+    ContractEnv, ContractRef, DeployReport, EventError, ExecutionEnv, ExecutionError, GasReport,
+    List, ListIter, Mapping, OdraError, OdraResult, Sequence, SubModule, UnwrapOrRevert, Var,
+    VmError
 };
 
 pub use odra_macros::*;

--- a/templates/blank/bin/build_contract.rs
+++ b/templates/blank/bin/build_contract.rs
@@ -1,3 +1,4 @@
+#![doc = "Binary for building wasm files from odra contracts."]
 #![no_std]
 #![no_main]
 #![allow(unused_imports, clippy::single_component_path_imports)]

--- a/templates/blank/bin/build_schema.rs
+++ b/templates/blank/bin/build_schema.rs
@@ -1,3 +1,4 @@
+#![doc = "Binary for building schema definitions from odra contracts."]
 #[allow(unused_imports)]
 use {{project-name}};
 

--- a/templates/full/bin/build_contract.rs
+++ b/templates/full/bin/build_contract.rs
@@ -1,3 +1,4 @@
+#![doc = "Binary for building wasm files from odra contracts."]
 #![no_std]
 #![no_main]
 #![allow(unused_imports, clippy::single_component_path_imports)]

--- a/templates/full/bin/build_schema.rs
+++ b/templates/full/bin/build_schema.rs
@@ -1,3 +1,4 @@
+#![doc = "Binary for building schema definitions from odra contracts."]
 #[allow(unused_imports)]
 use {{project-name}};
 

--- a/templates/workspace/flapper/bin/build_contract.rs
+++ b/templates/workspace/flapper/bin/build_contract.rs
@@ -1,3 +1,4 @@
+#![doc = "Binary for building wasm files from odra contracts."]
 #![no_std]
 #![no_main]
 #![allow(unused_imports, clippy::single_component_path_imports)]

--- a/templates/workspace/flapper/bin/build_schema.rs
+++ b/templates/workspace/flapper/bin/build_schema.rs
@@ -1,3 +1,4 @@
+#![doc = "Binary for building schema definitions from odra contracts."]
 #[allow(unused_imports)]
 use {{project-name}};
 

--- a/templates/workspace/flipper/bin/build_contract.rs
+++ b/templates/workspace/flipper/bin/build_contract.rs
@@ -1,3 +1,4 @@
+#![doc = "Binary for building wasm files from odra contracts."]
 #![no_std]
 #![no_main]
 #![allow(unused_imports, clippy::single_component_path_imports)]

--- a/templates/workspace/flipper/bin/build_schema.rs
+++ b/templates/workspace/flipper/bin/build_schema.rs
@@ -1,3 +1,4 @@
+#![doc = "Binary for building schema definitions from odra contracts."]
 #[allow(unused_imports)]
 use {{project-name}};
 


### PR DESCRIPTION
Adds a lint check to each crate. Sadly, this cannot be done workspace-wise.
This is a rustc check, so no need for changes in the justfile.
Closes #189 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced contract functionalities with explicit documentation across modules and examples for improved clarity.
  - Introduced new methods like `verify_signature`, `get_token`, and owner-related operations in the `Ownable` module.
  - Implemented new structs and methods for handling trait and contract references, enhancing development capabilities.

- **Refactor**
  - Optimized performance by updating function signatures in ERC1155 and OwnedERC1155 traits to use owned vectors instead of slices.
  - Streamlined code and imports in various files to improve module dependencies and code maintainability.

- **Documentation**
  - Expanded and added comprehensive documentation comments and attributes throughout the project, from core macros to contract examples, ensuring developer guidance.

- **Chores**
  - Clarified the purpose and usage of build scripts with added documentation attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->