### PR TITLE
Fixed Workflow badge - the filenames were changed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     </p>
     <p>
         <a href="https://github.com/odradev/odra/actions">
-            <img src="https://img.shields.io/github/actions/workflow/status/odradev/odra/test.yml?branch=release%2F0.3.0" alt="GitHub Workflow Status" />
+            <img src="https://img.shields.io/github/actions/workflow/status/odradev/odra/test.yml?branch=release%2F0.9.0" alt="GitHub Workflow Status" />
         </a>
         <a href="https://codecov.io/gh/odradev/odra">
             <img src="https://codecov.io/gh/odradev/odra/graph/badge.svg?token=8AT1UNOJMS" alt="Code coverage">

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     </p>
     <p>
         <a href="https://github.com/odradev/odra/actions">
-            <img src="https://img.shields.io/github/actions/workflow/status/odradev/odra/odra-ci.yml?branch=release%2F0.3.0" alt="GitHub Workflow Status" />
+            <img src="https://img.shields.io/github/actions/workflow/status/odradev/odra/test.yml?branch=release%2F0.3.0" alt="GitHub Workflow Status" />
         </a>
         <a href="https://codecov.io/gh/odradev/odra">
             <img src="https://codecov.io/gh/odradev/odra/graph/badge.svg?token=8AT1UNOJMS" alt="Code coverage">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated the GitHub Actions workflow status badge link in the README to reflect the new workflow file name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->