### PR TITLE
Fix for infinite loop when transferring tokens

### DIFF
--- a/odra-vm/src/vm/odra_vm_state.rs
+++ b/odra-vm/src/vm/odra_vm_state.rs
@@ -197,12 +197,8 @@ impl OdraVmState {
             .set_balance(address, AccountBalance::new(amount));
     }
 
-    pub fn increase_balance(&mut self, address: &Address, amount: &U512) -> Result<()> {
-        self.storage.increase_balance(address, amount)
-    }
-
-    pub fn reduce_balance(&mut self, address: &Address, amount: &U512) -> Result<()> {
-        self.storage.reduce_balance(address, amount)
+    pub fn transfer(&mut self, from: &Address, to: &Address, amount: &U512) -> Result<()> {
+        self.storage.transfer(from, to, amount)
     }
 
     pub fn public_key(&self, address: &Address) -> PublicKey {

--- a/odra-vm/src/vm/storage.rs
+++ b/odra-vm/src/vm/storage.rs
@@ -39,14 +39,11 @@ impl Storage {
         self.balances.insert(address, balance);
     }
 
-    pub fn increase_balance(&mut self, address: &Address, amount: &U512) -> Result<()> {
-        let balance = self.balances.get_mut(address).context("Unknown address")?;
-        balance.increase(*amount)
-    }
-
-    pub fn reduce_balance(&mut self, address: &Address, amount: &U512) -> Result<()> {
-        let balance = self.balances.get_mut(address).context("Unknown address")?;
-        balance.reduce(*amount)
+    pub fn transfer(&mut self, from: &Address, to: &Address, amount: &U512) -> Result<()> {
+        let from_balance = self.balances.get_mut(from).context("Unknown address")?;
+        from_balance.reduce(*amount)?;
+        let to_balance = self.balances.get_mut(to).context("Unknown address")?;
+        to_balance.increase(*amount)
     }
 
     pub fn get_value(&self, address: &Address, key: &[u8]) -> Result<Option<Bytes>, Error> {


### PR DESCRIPTION
Now the state lock is released before reverting.
Closes #168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved error handling in balance transfer operations to enhance reliability.
	- Consolidated balance manipulation functionality into a single `transfer` method for efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->