### PR TITLE
Update enum conversion from u32 to u8

### DIFF
--- a/odra-macros/src/utils/expr.rs
+++ b/odra-macros/src/utils/expr.rs
@@ -119,15 +119,18 @@ pub fn serialized_length<T: ToTokens>(caller: &T) -> syn::Expr {
     parse_quote!(#caller.#fn_ident())
 }
 
+pub fn u8_serialized_len() -> syn::Expr {
+    parse_quote!(odra::casper_types::bytesrepr::U8_SERIALIZED_LENGTH)
+}
+
 pub fn failable_to_bytes<T: ToTokens>(caller: &T) -> syn::Expr {
     let fn_ident = super::ident::to_bytes();
     let ty = super::ty::to_bytes();
     parse_quote!(#ty::#fn_ident(&#caller)?)
 }
 
-pub fn to_bytes<T: ToTokens>(caller: &T) -> syn::Expr {
-    let fn_ident = super::ident::to_bytes();
-    parse_quote!(#caller.#fn_ident())
+pub fn serialize_enum() -> syn::Expr {
+    parse_quote!(Ok(odra::prelude::vec![self.clone() as u8]))
 }
 
 pub fn empty_vec() -> syn::Expr {

--- a/odra-macros/src/utils/ty.rs
+++ b/odra-macros/src/utils/ty.rs
@@ -116,8 +116,8 @@ pub fn cl_type_any() -> syn::Type {
     parse_quote!(odra::casper_types::CLType::Any)
 }
 
-pub fn cl_type_u32() -> syn::Type {
-    parse_quote!(odra::casper_types::CLType::U32)
+pub fn cl_type_u8() -> syn::Type {
+    parse_quote!(odra::casper_types::CLType::U8)
 }
 
 pub fn runtime_args() -> syn::Type {
@@ -217,8 +217,8 @@ pub fn usize() -> syn::Type {
     parse_quote!(usize)
 }
 
-pub fn u32() -> syn::Type {
-    parse_quote!(u32)
+pub fn u8() -> syn::Type {
+    parse_quote!(u8)
 }
 
 pub fn clone() -> syn::Type {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Changed data types from `u32` to `u8` across various parts of the codebase for improved efficiency.
	- Introduced a new function for calculating serialized length of u8 data.
	- Enhanced serialization logic for enums to use u8 values, ensuring more compact data representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->