### PR TITLE
Allow to declare a reference as a constructor arg

### DIFF
--- a/odra-macros/src/ast/deployer_item.rs
+++ b/odra-macros/src/ast/deployer_item.rs
@@ -91,7 +91,7 @@ impl TryFrom<&'_ ModuleImplIR> for InitArgsItem {
             .named_args()
             .iter()
             .map(|arg| {
-                let ty = arg.ty().unwrap();
+                let ty = utils::ty::unreferenced_ty(&arg.ty().unwrap());
                 let ident = arg.name().unwrap();
                 let field: syn::Field = syn::parse_quote!(pub #ident: #ty);
                 field


### PR DESCRIPTION
Before if there was a reference in the constructor, the generated code was:

```rust
struct Erc20InitArgs {
  name: &String,
  ...
}
```
resulting a missing lifetime error. `InitArgs` should not have references as fields.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved handling of argument types in mapping operations for enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->