### PR TITLE
Bump versions to 0.9.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Changelog for `odra`.
 
-## [0.9.0] - 2024-03-xx
+## [0.9.0] - 2024-04-02
 ### Added
 - `Maybe<T>` - a type that represents an entrypoint arg that may or may not be present.
 - `EntrypointArgument` - a trait for types that can be used as entrypoint arguments.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,19 +16,19 @@ exclude = [ "examples", "modules", "benchmark", "odra-casper/proxy-caller", "tem
 resolver = "2"
 
 [workspace.package]
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Jakub Płaskonka <kuba@odra.dev>", "Krzysztof Pobiarżyn <krzysztof@odra.dev>", "Maciej Zieliński <maciej@odra.dev>"]
 license = "MIT"
 homepage = "https://odra.dev/docs"
 repository = "https://github.com/odradev/odra"
 
 [workspace.dependencies]
-odra-core = { path = "core", version = "0.8.1" }
-odra-macros = { path = "odra-macros", version = "0.8.1" }
-odra-casper-test-vm = { path = "odra-casper/test-vm", version = "0.8.1" }
-odra-casper-rpc-client = { path = "odra-casper/rpc-client", version = "0.8.1" }
-odra-vm = { path = "odra-vm", version = "0.8.1" }
-odra-casper-wasm-env = { path = "odra-casper/wasm-env", version = "0.8.1"}
+odra-core = { path = "core", version = "0.9.0" }
+odra-macros = { path = "odra-macros", version = "0.9.0" }
+odra-casper-test-vm = { path = "odra-casper/test-vm", version = "0.9.0" }
+odra-casper-rpc-client = { path = "odra-casper/rpc-client", version = "0.9.0" }
+odra-vm = { path = "odra-vm", version = "0.9.0" }
+odra-casper-wasm-env = { path = "odra-casper/wasm-env", version = "0.9.0"}
 casper-contract = { version = "3.0.0", default-features = false }
 casper-types = { version = "3.0.0", default-features = false }
 casper-execution-engine = "5.0.0"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odra-examples"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2021"
 
 [dependencies]

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "odra-modules"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2021"
 authors = ["Jakub Płaskonka <kuba@odra.dev>", "Krzysztof Pobiarżyn <krzysztof@odra.dev>", "Maciej Zieliński <maciej@odra.dev>"]
 license = "MIT"
@@ -10,14 +10,14 @@ keywords = ["wasm", "webassembly", "blockchain"]
 categories = ["wasm"]
 
 [dependencies]
-odra = { path = "../odra", version = "0.8.1", default-features = false }
+odra = { path = "../odra", version = "0.9.0", default-features = false }
 hex = { version = "0.4.3", default-features = false }
 
 [dev-dependencies]
-odra-test = { path = "../odra-test", version = "0.8.1" }
+odra-test = { path = "../odra-test", version = "0.9.0" }
 
 [build-dependencies]
-odra-build = { path = "../odra-build", version = "0.8.1" }
+odra-build = { path = "../odra-build", version = "0.9.0" }
 
 [features]
 default = []

--- a/odra-casper/proxy-caller/Cargo.toml
+++ b/odra-casper/proxy-caller/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "odra-casper-proxy-caller"
 edition = "2021"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Jakub Płaskonka <kuba@odra.dev>", "Krzysztof Pobiarżyn <krzysztof@odra.dev>", "Maciej Zieliński <maciej@odra.dev>"]
 license = "MIT"
 homepage = "https://odra.dev/docs"

--- a/release-odra.sh
+++ b/release-odra.sh
@@ -8,6 +8,7 @@ cargo publish -p odra-core
 cargo publish -p odra-macros
 cargo publish -p odra-vm
 cargo publish -p odra-casper-wasm-env 
+cargo publish -p odra-schema
 cargo publish -p odra
 cargo publish -p odra-casper-test-vm
 cargo publish -p odra-test


### PR DESCRIPTION
Bump versions to 0.9.0.
Update changelog dates.
Added odra-schema to release script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Chores**
	- Updated `odra` and related dependencies to version 0.9.0.
	- Updated package versions in examples and `odra-casper` proxy-caller to 0.9.0.
	- Modified authors' list for `odra-casper` proxy-caller.
	- Added publishing command for `odra-schema`.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->