### PR TITLE
Complex enums as Odra Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Changelog for `odra`.
 
+## [0.9.1] - 2024-04-xx
+### Changed
+- `#[odra::odra_type]` attribute can be applied to all flavors of enums (before applicable to unit-only enums).
+
 ## [0.9.0] - 2024-04-02
 ### Added
 - `Maybe<T>` - a type that represents an entrypoint arg that may or may not be present.

--- a/examples/Odra.toml
+++ b/examples/Odra.toml
@@ -63,3 +63,6 @@ fqn = "features::livenet::LivenetContract"
 
 [[contracts]]
 fqn = "features::optional_args::Token"
+
+[[contracts]]
+fqn = "features::custom_types::MyContract"

--- a/examples/src/features/custom_types.rs
+++ b/examples/src/features/custom_types.rs
@@ -1,0 +1,115 @@
+#![allow(missing_docs)]
+use odra::{prelude::*, Var};
+
+type IPv4 = [u8; 4];
+type IPv6 = [u8; 16];
+
+/// An enum representing an IP address.
+#[odra::odra_type]
+#[derive(Default)]
+pub enum IP {
+    /// No data.
+    #[default]
+    Unknown,
+    /// Single unnamed element.
+    IPv4(IPv4),
+    /// multiple unnamed elements.
+    IPv4WithDescription(IPv4, String),
+    /// single named element.
+    IPv6 { ip: IPv6 },
+    /// multiple named elements.
+    IPv6WithDescription { ip: IPv6, description: String }
+}
+
+#[odra::odra_type]
+pub enum Fieldless {
+    /// Tuple variant.
+    Tuple(),
+    /// Struct variant.
+    Struct {},
+    /// Unit variant.
+    Unit
+}
+
+/// Unit-only enum.
+#[odra::odra_type]
+#[derive(Default)]
+pub enum Unit {
+    #[default]
+    A = 10,
+    B = 20,
+    C
+}
+
+/// A struct with named elements.
+#[odra::odra_type]
+pub struct MyStruct {
+    a: u32,
+    b: u32
+}
+
+// A struct with unnamed elements cannot be an Odra type.
+// #[odra::odra_type]
+// pub struct TupleStruct(u32, u32);
+
+#[odra::module]
+pub struct MyContract {
+    ip: Var<IP>,
+    fieldless: Var<Fieldless>,
+    unit: Var<Unit>,
+    my_struct: Var<MyStruct>
+}
+
+#[odra::odra_error]
+pub enum Errors {
+    NotFound = 1
+}
+
+#[odra::module]
+impl MyContract {
+    pub fn init(&mut self, ip: IP, fieldless: Fieldless, unit: Unit, my_struct: MyStruct) {
+        self.ip.set(ip);
+        self.fieldless.set(fieldless);
+        self.unit.set(unit);
+        self.my_struct.set(my_struct);
+    }
+
+    pub fn get_ip(&self) -> IP {
+        self.ip.get_or_default()
+    }
+
+    pub fn get_fieldless(&self) -> Fieldless {
+        self.fieldless.get_or_revert_with(Errors::NotFound)
+    }
+
+    pub fn get_unit(&self) -> Unit {
+        self.unit.get_or_default()
+    }
+
+    pub fn get_struct(&self) -> MyStruct {
+        self.my_struct.get_or_revert_with(Errors::NotFound)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use odra::host::Deployer;
+
+    #[test]
+    fn test_contract() {
+        let test_env = odra_test::env();
+        let init_args = MyContractInitArgs {
+            ip: IP::IPv4([192, 168, 0, 1]),
+            fieldless: Fieldless::Tuple(),
+            unit: Unit::C,
+            my_struct: MyStruct { a: 10, b: 20 }
+        };
+        let contract = MyContractHostRef::deploy(&test_env, init_args);
+
+        assert_eq!(contract.get_ip(), IP::IPv4([192, 168, 0, 1]));
+        assert_eq!(contract.get_fieldless(), Fieldless::Tuple());
+        assert_eq!(contract.get_unit(), Unit::C);
+        assert_eq!(contract.get_struct(), MyStruct { a: 10, b: 20 });
+    }
+}

--- a/examples/src/features/mod.rs
+++ b/examples/src/features/mod.rs
@@ -2,6 +2,7 @@
 pub mod access_control;
 pub mod collecting_events;
 pub mod cross_calls;
+pub mod custom_types;
 pub mod events;
 pub mod handling_errors;
 pub mod host_functions;

--- a/odra-macros/src/ast/odra_type_item.rs
+++ b/odra-macros/src/ast/odra_type_item.rs
@@ -566,7 +566,9 @@ mod tests {
                 /// Description of B
                 B(u32, String),
                 /// Description of C
-                C()
+                C(),
+                /// Description of D
+                D {},
             }
 
             impl odra::casper_types::bytesrepr::FromBytes for MyType {
@@ -584,6 +586,7 @@ mod tests {
                             Ok((Self::B(f0, f1), bytes))
                         },
                         2u8 => Ok((Self::C(), bytes)),
+                        3u8 => Ok((Self::D {}, bytes)),
                         _ => Err(odra::casper_types::bytesrepr::Error::Formatting),
                     }
                 }
@@ -607,6 +610,10 @@ mod tests {
                         Self::C() => {
                             let mut result = odra::prelude::vec![2u8];
                             Ok(result)
+                        },
+                        Self::D {} => {
+                            let mut result = odra::prelude::vec![3u8];
+                            Ok(result)
                         }
                     }
                 }
@@ -616,6 +623,7 @@ mod tests {
                         Self::A { a, b } => odra::casper_types::bytesrepr::U8_SERIALIZED_LENGTH + a.serialized_length() + b.serialized_length(),
                         Self::B(f0, f1) => odra::casper_types::bytesrepr::U8_SERIALIZED_LENGTH + f0.serialized_length() + f1.serialized_length(),
                         Self::C() => odra::casper_types::bytesrepr::U8_SERIALIZED_LENGTH,
+                        Self::D {} => odra::casper_types::bytesrepr::U8_SERIALIZED_LENGTH,
                     }
                 }
             }
@@ -639,5 +647,12 @@ mod tests {
         );
 
         test_utils::assert_eq(item, expected);
+    }
+
+    #[test]
+    fn test_union() {
+        let ir = test_utils::mock::custom_union();
+        let item = OdraTypeItem::try_from(&ir);
+        assert!(item.is_err());
     }
 }

--- a/odra-macros/src/ast/odra_type_item.rs
+++ b/odra-macros/src/ast/odra_type_item.rs
@@ -1,11 +1,13 @@
 use crate::ast::events_item::HasEventsImplItem;
 use crate::ast::fn_utils::{FnItem, SingleArgFnItem};
-use crate::ast::utils::{ImplItem, Named};
-use crate::ir::TypeIR;
+use crate::ast::utils::ImplItem;
+use crate::ir::{TypeIR, TypeKind};
 use crate::utils;
 use crate::utils::misc::AsBlock;
 use derive_try_from_ref::TryFromRef;
-use syn::parse_quote;
+use quote::{format_ident, ToTokens};
+use syn::{parse_quote, Token};
+use syn::punctuated::Punctuated;
 use crate::ast::schema::SchemaCustomTypeItem;
 
 macro_rules! impl_from_ir {
@@ -14,13 +16,10 @@ macro_rules! impl_from_ir {
             type Error = syn::Error;
 
             fn try_from(ir: &TypeIR) -> Result<Self, Self::Error> {
-                match ir {
-                    x if x.is_enum() => Self::from_enum(ir),
-                    x if x.is_struct() => Self::from_struct(ir),
-                    _ => Err(syn::Error::new_spanned(
-                        ir.self_code(),
-                        "Only support enum or struct"
-                    ))
+                match ir.kind()? {
+                    TypeKind::UnitEnum { names } => Self::from_unit_enum(names),
+                    TypeKind::Enum { variants } => Self::from_enum(variants),
+                    TypeKind::Struct { fields } => Self::from_struct(fields),
                 }
             }
         }
@@ -117,9 +116,10 @@ impl TryFrom<&'_ TypeIR> for CLTypedItem {
     type Error = syn::Error;
 
     fn try_from(ir: &TypeIR) -> Result<Self, Self::Error> {
-        let ret_ty_cl_type_any = match ir.is_enum() {
-            true => utils::ty::cl_type_u8(),
-            false => utils::ty::cl_type_any()
+        let ret_ty_cl_type_any = match ir.kind()? {
+            TypeKind::UnitEnum { names: _ } => utils::ty::cl_type_u8(),
+            TypeKind::Enum { variants: _ } => utils::ty::cl_type_any(),
+            TypeKind::Struct { fields: _ } => utils::ty::cl_type_any(),
         }
         .as_block();
         let ty_cl_type = utils::ty::cl_type();
@@ -144,8 +144,7 @@ struct FromBytesFnItem {
 impl_from_ir!(FromBytesFnItem);
 
 impl FromBytesFnItem {
-    fn from_enum(ir: &TypeIR) -> syn::Result<Self> {
-        let ident = ir.name()?;
+    fn from_enum(variants: Vec<syn::Variant>)  -> syn::Result<Self> {
         let ident_bytes = utils::ident::bytes();
         let ident_from_bytes = utils::ident::from_bytes();
         let ident_result = utils::ident::result();
@@ -154,9 +153,63 @@ impl FromBytesFnItem {
 
         let read_stmt: syn::Stmt =
             parse_quote!(let (#ident_result, #ident_bytes): (#ty_u8, _) = #from_bytes_expr;);
-        let deser = ir.map_fields(
-            |i| quote::quote!(x if x == #ident::#i as #ty_u8 => Ok((#ident::#i, #ident_bytes)))
-        )?;
+        let arms = variants
+            .iter()
+            .enumerate()
+            .map(|(v_idx, v)| {
+                let v_idx: u8 = v_idx as u8;
+                let ident = &v.ident;
+                let fields = variant_ident_vec(v);
+                let deser = fields.iter()
+                    .map(|f| quote::quote!(let (#f, bytes) = odra::casper_types::bytesrepr::FromBytes::from_bytes(bytes)?;))
+                    .collect::<Vec<_>>();
+                let code = match &v.fields {
+                    syn::Fields::Unit => {
+                        quote::quote!(Ok((Self::#ident, bytes)))
+                    },
+                    syn::Fields::Named(_) => {
+                        quote::quote!(
+                            #(#deser)*
+                            Ok((Self::#ident { #(#fields,)* }, bytes))
+                        )
+                    },
+                    syn::Fields::Unnamed(_) => {
+                        quote::quote!(
+                            #(#deser)*
+                            Ok((Self::#ident(#(#fields,)*), bytes))
+                        )
+                    }
+                };
+                quote::quote!(#v_idx => { #code })
+            })
+            .collect::<Punctuated<_, Token![,]>>();
+
+        let arg = Self::arg();
+        let ret_ty = Self::ret_ty();
+        let block = parse_quote!({
+            #read_stmt
+            match #ident_result {
+                #arms 
+                _ => Err(odra::casper_types::bytesrepr::Error::Formatting),
+            }
+        });
+        Ok(Self {
+            fn_item: SingleArgFnItem::new(&ident_from_bytes, arg, ret_ty, block)
+        })
+    }
+
+    fn from_unit_enum(names: Vec<syn::Ident>) -> syn::Result<Self> {
+        let ident_bytes = utils::ident::bytes();
+        let ident_from_bytes = utils::ident::from_bytes();
+        let ident_result = utils::ident::result();
+        let ty_u8 = utils::ty::u8();
+        let from_bytes_expr = utils::expr::failable_from_bytes(&ident_bytes);
+
+        let read_stmt: syn::Stmt =
+            parse_quote!(let (#ident_result, #ident_bytes): (#ty_u8, _) = #from_bytes_expr;);
+        let deser = names.iter()
+            .map(|i| quote::quote!(x if x == Self::#i as #ty_u8 => Ok((Self::#i, #ident_bytes))))
+            .collect::<Vec<_>>();
         let arg = Self::arg();
         let ret_ty = Self::ret_ty();
         let block = parse_quote!({
@@ -171,16 +224,18 @@ impl FromBytesFnItem {
         })
     }
 
-    fn from_struct(ir: &TypeIR) -> syn::Result<Self> {
+    fn from_struct(fields: Vec<(syn::Ident, syn::Type)>) -> syn::Result<Self> {
         let ident_bytes = utils::ident::bytes();
         let ident_from_bytes = utils::ident::from_bytes();
 
         let from_bytes_expr = utils::expr::failable_from_bytes(&ident_bytes);
-        let fields = ir
-            .fields()?
+        let fields = fields
             .into_iter()
+            .map(|(i, _)| i)
             .collect::<syn::punctuated::Punctuated<syn::Ident, syn::Token![,]>>();
-        let deser = ir.map_fields(|i| quote::quote!(let (#i, #ident_bytes) = #from_bytes_expr;))?;
+        let deser = fields.iter()
+            .map(|i| quote::quote!(let (#i, #ident_bytes) = #from_bytes_expr;))
+            .collect::<Vec<_>>();
         let arg = Self::arg();
         let ret_ty = Self::ret_ty();
         let block = parse_quote!({
@@ -216,7 +271,7 @@ struct ToBytesFnItem {
 impl_from_ir!(ToBytesFnItem);
 
 impl ToBytesFnItem {
-    fn from_struct(ir: &TypeIR) -> syn::Result<Self> {
+    fn from_struct(fields: Vec<(syn::Ident, syn::Type)>) -> syn::Result<Self> {
         let ty_bytes_vec = utils::ty::bytes_vec();
         let ty_ret = utils::ty::bytes_result(&ty_bytes_vec);
         let ty_self = utils::ty::_self();
@@ -227,11 +282,11 @@ impl ToBytesFnItem {
         let init_vec_stmt =
             utils::stmt::new_mut_vec_with_capacity(&ident_result, &serialized_length_expr);
 
-        let serialize = ir.map_fields(|i| {
+        let serialize = fields.iter().map(|(i, _)| {
             let member = utils::member::_self(i);
             let expr_to_bytes = utils::expr::failable_to_bytes(&member);
             quote::quote!(#ident_result.extend(#expr_to_bytes);)
-        })?;
+        }).collect::<Vec<_>>();
 
         let name = utils::ident::to_bytes();
         let ret_ty = utils::misc::ret_ty(&ty_ret);
@@ -245,7 +300,37 @@ impl ToBytesFnItem {
         })
     }
 
-    fn from_enum(_ir: &TypeIR) -> syn::Result<Self> {
+    fn from_enum(variants: Vec<syn::Variant>) -> syn::Result<Self> {
+        let ty_bytes_vec = utils::ty::bytes_vec();
+        let ty_ret = utils::ty::bytes_result(&ty_bytes_vec);
+        let name = utils::ident::to_bytes();
+        let ret_ty = utils::misc::ret_ty(&ty_ret);
+        let ident_result = utils::ident::result();
+
+        let arms = variants.iter()
+            .enumerate()
+            .map(|(idx, v)| {
+                let idx = idx as u8;
+                let ident = &v.ident;
+                let fields = variant_ident_vec(v);
+                let left = match &v.fields {
+                    syn::Fields::Unit => quote::quote!(Self::#ident),
+                    syn::Fields::Named(_) => quote::quote!(Self::#ident { #(#fields),* }),
+                    syn::Fields::Unnamed(_) => quote::quote!(Self::#ident( #(#fields),* ))
+                };
+                quote::quote!(#left => {
+                    let mut #ident_result = odra::prelude::vec![#idx];
+                    #(#ident_result.extend_from_slice(&#fields.to_bytes()?);)*
+                    Ok(#ident_result)
+                })
+            })
+            .collect::<Punctuated<_, Token![,]>>();
+        Ok(Self {
+            fn_item: FnItem::new(&name, vec![], ret_ty, match_self_expr(arms).as_block()).instanced()
+        })
+    }
+
+    fn from_unit_enum(_names: Vec<syn::Ident>) -> syn::Result<Self> {
         let ty_bytes_vec = utils::ty::bytes_vec();
         let ty_ret = utils::ty::bytes_result(&ty_bytes_vec);
         let name = utils::ident::to_bytes();
@@ -267,16 +352,16 @@ struct SerializedLengthFnItem {
 impl_from_ir!(SerializedLengthFnItem);
 
 impl SerializedLengthFnItem {
-    fn from_struct(ir: &TypeIR) -> syn::Result<Self> {
+    fn from_struct(fields: Vec<(syn::Ident, syn::Type)>) -> syn::Result<Self> {
         let ty_usize = utils::ty::usize();
         let ident_result = utils::ident::result();
 
-        let stmts = ir.map_fields(|i| {
+        let stmts = fields.iter().map(|(i, _)| {
             let member = utils::member::_self(i);
             let expr = utils::expr::serialized_length(&member);
             let stmt: syn::Stmt = parse_quote!(#ident_result += #expr;);
             stmt
-        })?;
+        }).collect::<Vec<_>>();
 
         let name = utils::ident::serialized_length();
         let ret_ty = utils::misc::ret_ty(&ty_usize);
@@ -290,7 +375,30 @@ impl SerializedLengthFnItem {
         })
     }
 
-    fn from_enum(_ir: &TypeIR) -> syn::Result<Self> {
+    fn from_enum(variants: Vec<syn::Variant>)  -> syn::Result<Self> {
+        let ty_usize = utils::ty::usize();
+        let name = utils::ident::serialized_length();
+        let ret_ty = utils::misc::ret_ty(&ty_usize);
+        let expr_u8_serialized_len = utils::expr::u8_serialized_len();
+        
+        let arms = variants.iter()
+            .map(|v| {
+                let ident = &v.ident;
+                let fields = variant_ident_vec(v);
+                let left = match &v.fields {
+                    syn::Fields::Unit => quote::quote!(Self::#ident),
+                    syn::Fields::Named(_) => quote::quote!(Self::#ident { #(#fields),* }),
+                    syn::Fields::Unnamed(_) => quote::quote!(Self::#ident( #(#fields),* ))
+                };
+                quote::quote!(#left => #expr_u8_serialized_len #(+ #fields.serialized_length())* )
+            })
+            .collect::<Punctuated<_, Token![,]>>();
+        Ok(Self {
+            fn_item: FnItem::new(&name, vec![], ret_ty, match_self_expr(arms).as_block()).instanced()
+        })
+    }
+
+    fn from_unit_enum(_names: Vec<syn::Ident>) -> syn::Result<Self> {
         let ty_usize = utils::ty::usize();
         let name = utils::ident::serialized_length();
         let ret_ty = utils::misc::ret_ty(&ty_usize);
@@ -299,6 +407,22 @@ impl SerializedLengthFnItem {
             fn_item: FnItem::new(&name, vec![], ret_ty, block).instanced()
         })
     }
+}
+
+fn variant_ident_vec(variant: &syn::Variant) -> Vec<syn::Ident> {
+    variant.fields
+        .clone()
+        .iter()
+        .enumerate()
+        .map(|(idx, i)| match &i.ident {
+            Some(ident) => ident.clone(),
+            None => format_ident!("f{}", idx)
+        })
+        .collect::<Vec<_>>()
+}
+
+fn match_self_expr<T: ToTokens>(arms: T) -> syn::Expr {
+    parse_quote!(match self { #arms })
 }
 
 #[cfg(test)]
@@ -368,7 +492,7 @@ mod tests {
     }
 
     #[test]
-    fn test_enum() {
+    fn test_unit_enum() {
         let ir = test_utils::mock::custom_enum();
         let item = OdraTypeItem::try_from(&ir).unwrap();
         let expected = quote!(
@@ -384,8 +508,8 @@ mod tests {
                 fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), odra::casper_types::bytesrepr::Error> {
                     let (result, bytes): (u8, _) = odra::casper_types::bytesrepr::FromBytes::from_bytes(bytes)?;
                     match result {
-                        x if x == MyType::A as u8 => Ok((MyType::A, bytes)),
-                        x if x == MyType::B as u8 => Ok((MyType::B, bytes)),
+                        x if x == Self::A as u8 => Ok((Self::A, bytes)),
+                        x if x == Self::B as u8 => Ok((Self::B, bytes)),
                         _ => Err(odra::casper_types::bytesrepr::Error::Formatting),
                     }
                 }
@@ -404,6 +528,93 @@ mod tests {
             impl odra::casper_types::CLTyped for MyType {
                 fn cl_type() -> odra::casper_types::CLType {
                     odra::casper_types::CLType::U8
+                }
+            }
+
+            impl odra::contract_def::HasEvents for MyType {
+                fn events() -> odra::prelude::vec::Vec<odra::contract_def::Event> {
+                    odra::prelude::vec::Vec::new()
+                }
+
+                #[cfg(target_arch = "wasm32")]
+                fn event_schemas() -> odra::prelude::BTreeMap<odra::prelude::string::String, odra::casper_event_standard::Schema> {
+                    odra::prelude::BTreeMap::new()
+                }
+            }
+        );
+
+        test_utils::assert_eq(item, expected);
+    }
+
+    #[test]
+    fn test_complex_enum() {
+        let ir = test_utils::mock::custom_complex_enum();
+        let item = OdraTypeItem::try_from(&ir).unwrap();
+        let expected = quote!(
+            #[derive(Clone, PartialEq, Eq, Debug)]
+            enum MyType {
+                /// Description of A
+                A { a: String, b: u32 },
+                /// Description of B
+                B(u32, String),
+                /// Description of C
+                C()
+            }
+
+            impl odra::casper_types::bytesrepr::FromBytes for MyType {
+                fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), odra::casper_types::bytesrepr::Error> {
+                    let (result, bytes): (u8, _) = odra::casper_types::bytesrepr::FromBytes::from_bytes(bytes)?;
+                    match result {
+                        0u8 => {
+                            let (a, bytes) = odra::casper_types::bytesrepr::FromBytes::from_bytes(bytes)?;
+                            let (b, bytes) = odra::casper_types::bytesrepr::FromBytes::from_bytes(bytes)?;
+                            Ok((Self::A { a, b }, bytes))
+                        },
+                        1u8 => {
+                            let (f0, bytes) = odra::casper_types::bytesrepr::FromBytes::from_bytes(bytes)?;
+                            let (f1, bytes) = odra::casper_types::bytesrepr::FromBytes::from_bytes(bytes)?;
+                            Ok((Self::B(f0, f1), bytes))
+                        },
+                        2u8 => Ok((Self::C(), bytes)),
+                        _ => Err(odra::casper_types::bytesrepr::Error::Formatting),
+                    }
+                }
+            }
+
+            impl odra::casper_types::bytesrepr::ToBytes for MyType {
+                fn to_bytes(&self) -> Result<odra::prelude::vec::Vec<u8>, odra::casper_types::bytesrepr::Error> {
+                    match self {
+                        Self::A { a, b } => {
+                            let mut result = odra::prelude::vec![0u8];
+                            result.extend_from_slice(&a.to_bytes()?);
+                            result.extend_from_slice(&b.to_bytes()?);
+                            Ok(result)
+                        },
+                        Self::B(f0, f1) => {
+                            let mut result = odra::prelude::vec![1u8];
+                            result.extend_from_slice(&f0.to_bytes()?);
+                            result.extend_from_slice(&f1.to_bytes()?);
+                            Ok(result)
+                        },
+                        Self::C() => {
+                            let mut result = odra::prelude::vec![2u8];
+                            Ok(result)
+                        }
+                    }
+                }
+
+                fn serialized_length(&self) -> usize {
+                    match self {
+                        Self::A { a, b } => odra::casper_types::bytesrepr::U8_SERIALIZED_LENGTH + a.serialized_length() + b.serialized_length(),
+                        Self::B(f0, f1) => odra::casper_types::bytesrepr::U8_SERIALIZED_LENGTH + f0.serialized_length() + f1.serialized_length(),
+                        Self::C() => odra::casper_types::bytesrepr::U8_SERIALIZED_LENGTH,
+                    }
+                }
+            }
+
+            impl odra::casper_types::CLTyped for MyType {
+                fn cl_type() -> odra::casper_types::CLType {
+                    odra::casper_types::CLType::Any
                 }
             }
 

--- a/odra-macros/src/ast/schema/custom_item.rs
+++ b/odra-macros/src/ast/schema/custom_item.rs
@@ -255,6 +255,7 @@ mod tests {
                                     odra::schema::enum_custom_type_variant("A", 0u16, "MyType::A"),
                                     odra::schema::enum_typed_variant::<(u32, String,)>("B", 1u16),
                                     odra::schema::enum_variant("C", 2u16),
+                                    odra::schema::enum_variant("D", 3u16),
                                 ]
                             ))
                         ])
@@ -265,7 +266,8 @@ mod tests {
                                     odra::schema::struct_member::<String>("a"),
                                     odra::schema::struct_member::<u32>("b")
                                 ]
-                            ))
+                            )),
+                            Some(odra::schema::custom_struct("MyType::D", odra::prelude::vec![]))
                         ])
                         .collect::<Vec<_>>()
                 }
@@ -287,5 +289,12 @@ mod tests {
         );
 
         test_utils::assert_eq(item, expected);
+    }
+
+    #[test]
+    fn test_union() {
+        let ir = test_utils::mock::custom_union();
+        let item = SchemaCustomTypeItem::try_from(&ir);
+        assert!(item.is_err());
     }
 }

--- a/odra-macros/src/ast/schema/custom_item.rs
+++ b/odra-macros/src/ast/schema/custom_item.rs
@@ -1,4 +1,5 @@
 use quote::ToTokens;
+use syn::Fields;
 use crate::{ast::utils::Named, ir::{TypeIR, TypeKind}, utils};
 
 pub struct SchemaCustomTypeItem {
@@ -12,8 +13,8 @@ impl ToTokens for SchemaCustomTypeItem {
         let ident = &self.ty_ident;
 
         let custom_item = match &self.kind {
-            TypeKind::UnitEnum { names: _ } => todo!(),
-            TypeKind::Enum { variants } => custom_enum(name, variants),
+            TypeKind::UnitEnum { variants } => custom_enum(name, variants),
+            TypeKind::Enum { variants } => custom_complex_enum(name, variants),
             TypeKind::Struct { fields } => custom_struct(name, fields),
         };
 
@@ -27,6 +28,25 @@ impl ToTokens for SchemaCustomTypeItem {
             _ => Vec::new(),
         };
 
+        let enum_sub_types = match &self.kind {
+            TypeKind::Enum { variants } => variants.iter().filter_map(|v| {
+                match &v.fields {
+                    Fields::Named(f) => {
+                        let fields = f.named.iter().map(|f| {
+                            let name = f.ident.as_ref().unwrap().to_string();
+                            let ty = &f.ty;
+                            quote::quote!(odra::schema::struct_member::<#ty>(#name))
+                        }).collect::<Vec<_>>();
+                        let ty_name = format!("{}::{}", name, v.ident);
+                        Some(quote::quote!(odra::schema::custom_struct(#ty_name, odra::prelude::vec![#(#fields),*])))
+                    }
+                    Fields::Unnamed(_) => None,
+                    Fields::Unit => None
+                }
+            }).collect::<Vec<_>>(),
+            _ => Vec::new()
+        };
+
         let item = quote::quote! {
             #[automatically_derived]
             #[cfg(not(target_arch = "wasm32"))]
@@ -35,6 +55,7 @@ impl ToTokens for SchemaCustomTypeItem {
                     odra::prelude::BTreeSet::<Option<odra::schema::casper_contract_schema::CustomType>>::new()
                         .into_iter()
                         .chain(odra::prelude::vec![Some(#custom_item)])
+                        .chain(odra::prelude::vec![#(Some(#enum_sub_types)),*])
                         #(#sub_types)*
                         .collect::<Vec<_>>()
                 }
@@ -58,13 +79,48 @@ impl ToTokens for SchemaCustomTypeItem {
 }
 
 fn custom_enum(name: &str, variants: &[syn::Variant]) -> proc_macro2::TokenStream {
-    let variants = utils::syn::transform_variants(variants, |name, discriminant, _| {
+    let variants = utils::syn::transform_variants(variants, |name, _, discriminant, _| {
         quote::quote!(odra::schema::enum_variant(#name, #discriminant),)
     });
 
     quote::quote!(odra::schema::custom_enum(#name, #variants))
 }
 
+fn custom_complex_enum(enum_name: &str, variants: &[syn::Variant]) -> proc_macro2::TokenStream {
+    let variants = utils::syn::transform_variants(variants, |name, fields, discriminant, _| match fields {
+        Fields::Named(_) => {
+            match fields.len() {
+                0 => quote::quote!(odra::schema::enum_variant(#name, #discriminant),),
+                _ => {
+                    let ty_name = format!("{}::{}", enum_name, name);
+                    quote::quote!(odra::schema::enum_custom_type_variant(#name, #discriminant, #ty_name),)
+                }
+            }
+        }
+        Fields::Unnamed(_) => {
+            match fields.len() {
+                0 => quote::quote!(odra::schema::enum_variant(#name, #discriminant),),
+                1 => {
+                    let ty = fields.iter().next().unwrap().ty.clone();
+                    let ty = quote::quote!(#ty);
+                    quote::quote!(odra::schema::enum_typed_variant::<#ty>(#name, #discriminant),)
+                }
+                _ => {
+                    let mut ty = proc_macro2::TokenStream::new();
+                    syn::token::Paren::default().surround(&mut ty, |tokens| {
+                        fields.iter().for_each(|f| {
+                            let ty = &f.ty;
+                            tokens.extend(quote::quote!(#ty,))
+                        });
+                    });
+                    quote::quote!(odra::schema::enum_typed_variant::<#ty>(#name, #discriminant),)
+                }
+            }
+        }
+        Fields::Unit => quote::quote!(odra::schema::enum_variant(#name, #discriminant),),
+    });
+    quote::quote!(odra::schema::custom_enum(#enum_name, #variants))
+}
 fn custom_struct(name: &str, fields: &[(syn::Ident, syn::Type)]) -> proc_macro2::TokenStream {
     let members = fields
         .iter()
@@ -113,6 +169,7 @@ mod tests {
                                 ]
                             ))
                         ])
+                        .chain(odra::prelude::vec![])
                         .chain(<String as odra::schema::SchemaCustomTypes>::schema_types())
                         .chain(<u32 as odra::schema::SchemaCustomTypes>::schema_types())
                         .collect::<Vec<_>>()
@@ -138,7 +195,7 @@ mod tests {
     }
 
     #[test]
-    fn test_enum() {
+    fn test_unit_enum() {
         let ir = test_utils::mock::custom_enum();
         let item = SchemaCustomTypeItem::try_from(&ir).unwrap();
         let expected = quote!(
@@ -154,6 +211,59 @@ mod tests {
                                 odra::prelude::vec![
                                     odra::schema::enum_variant("A", 10u16),
                                     odra::schema::enum_variant("B", 11u16),
+                                ]
+                            ))
+                        ])
+                        .chain(odra::prelude::vec![])
+                        .collect::<Vec<_>>()
+                }
+            }
+
+            #[automatically_derived]
+            #[cfg(not(target_arch = "wasm32"))]
+            impl odra::schema::NamedCLTyped for MyType {
+                fn ty() -> odra::schema::casper_contract_schema::NamedCLType {
+                    odra::schema::casper_contract_schema::NamedCLType::Custom(String::from(
+                        "MyType"
+                    ))
+                }
+            }
+
+            #[automatically_derived]
+            #[cfg(not(target_arch = "wasm32"))]
+            impl odra::schema::SchemaCustomElement for MyType {}
+        );
+
+        test_utils::assert_eq(item, expected);
+    }
+
+    #[test]
+    fn test_complex_enum() {
+        let ir = test_utils::mock::custom_complex_enum();
+        let item = SchemaCustomTypeItem::try_from(&ir).unwrap();
+        let expected = quote!(
+            #[automatically_derived]
+            #[cfg(not(target_arch = "wasm32"))]
+            impl odra::schema::SchemaCustomTypes for MyType {
+                fn schema_types() -> odra::prelude::vec::Vec<Option<odra::schema::casper_contract_schema::CustomType>> {
+                    odra::prelude::BTreeSet::<Option<odra::schema::casper_contract_schema::CustomType>>::new()
+                        .into_iter()
+                        .chain(odra::prelude::vec![
+                            Some(odra::schema::custom_enum(
+                                "MyType",
+                                odra::prelude::vec![
+                                    odra::schema::enum_custom_type_variant("A", 0u16, "MyType::A"),
+                                    odra::schema::enum_typed_variant::<(u32, String,)>("B", 1u16),
+                                    odra::schema::enum_variant("C", 2u16),
+                                ]
+                            ))
+                        ])
+                        .chain(odra::prelude::vec![
+                            Some(odra::schema::custom_struct(
+                                "MyType::A", 
+                                odra::prelude::vec![
+                                    odra::schema::struct_member::<String>("a"),
+                                    odra::schema::struct_member::<u32>("b")
                                 ]
                             ))
                         ])

--- a/odra-macros/src/ast/schema/errors.rs
+++ b/odra-macros/src/ast/schema/errors.rs
@@ -93,7 +93,7 @@ impl TryFrom<&TypeIR> for SchemaErrorItem {
 }
 
 fn enum_variants(variants: &[syn::Variant]) -> proc_macro2::TokenStream {
-    utils::syn::transform_variants(variants, |name, discriminant, docs| {
+    utils::syn::transform_variants(variants, |name, _, discriminant, docs| {
         let description = docs.first().cloned().unwrap_or_default().trim().to_string();
         quote::quote!(odra::schema::error(#name, #description, #discriminant),)
     })

--- a/odra-macros/src/ir/mod.rs
+++ b/odra-macros/src/ir/mod.rs
@@ -657,14 +657,11 @@ impl TypeIR {
         match &self.code {
             syn::Item::Enum(e) => {
                 let is_unit = e.variants.iter().all(|v| v.fields.is_empty());
+                let variants = e.variants.iter().cloned().collect();
                 if is_unit {
-                    Ok(TypeKind::UnitEnum {
-                        names: e.variants.iter().map(|v| v.ident.clone()).collect()
-                    })
+                    Ok(TypeKind::UnitEnum { variants })
                 } else {
-                    Ok(TypeKind::Enum {
-                        variants: e.variants.iter().cloned().collect()
-                    })
+                    Ok(TypeKind::Enum { variants })
                 }
             }
             syn::Item::Struct(syn::ItemStruct { fields, .. }) => {
@@ -689,7 +686,7 @@ impl TypeIR {
 
 pub enum TypeKind {
     UnitEnum {
-        names: Vec<syn::Ident>
+        variants: Vec<syn::Variant>
     },
     Enum {
         variants: Vec<syn::Variant>

--- a/odra-macros/src/ir/mod.rs
+++ b/odra-macros/src/ir/mod.rs
@@ -5,7 +5,7 @@ use crate::utils;
 use config::ConfigItem;
 use proc_macro2::Ident;
 use quote::{format_ident, ToTokens};
-use syn::{parse_quote, ImplItem};
+use syn::{parse_quote, spanned::Spanned, ImplItem};
 
 use self::attr::OdraAttribute;
 
@@ -653,22 +653,48 @@ impl TypeIR {
         &self.code
     }
 
-    pub fn fields(&self) -> syn::Result<Vec<syn::Ident>> {
-        utils::syn::derive_item_variants(&self.code)
+    pub fn kind(&self) -> syn::Result<TypeKind> {
+        match &self.code {
+            syn::Item::Enum(e) => {
+                let is_unit = e.variants.iter().all(|v| v.fields.is_empty());
+                if is_unit {
+                    Ok(TypeKind::UnitEnum {
+                        names: e.variants.iter().map(|v| v.ident.clone()).collect()
+                    })
+                } else {
+                    Ok(TypeKind::Enum {
+                        variants: e.variants.iter().cloned().collect()
+                    })
+                }
+            }
+            syn::Item::Struct(syn::ItemStruct { fields, .. }) => {
+                let fields = fields
+                    .iter()
+                    .map(|f| {
+                        f.ident
+                            .clone()
+                            .map(|i| (i, f.ty.clone()))
+                            .ok_or(syn::Error::new(f.span(), "Unnamed field"))
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(TypeKind::Struct { fields })
+            }
+            _ => Err(syn::Error::new_spanned(
+                &self.code,
+                "Invalid type. Only enums and structs are supported"
+            ))
+        }
     }
+}
 
-    pub fn map_fields<F, R>(&self, func: F) -> syn::Result<Vec<R>>
-    where
-        F: FnMut(&syn::Ident) -> R
-    {
-        Ok(self.fields()?.iter().map(func).collect::<Vec<_>>())
-    }
-
-    pub fn is_enum(&self) -> bool {
-        matches!(self.code, syn::Item::Enum(_))
-    }
-
-    pub fn is_struct(&self) -> bool {
-        matches!(self.code, syn::Item::Struct(_))
+pub enum TypeKind {
+    UnitEnum {
+        names: Vec<syn::Ident>
+    },
+    Enum {
+        variants: Vec<syn::Variant>
+    },
+    Struct {
+        fields: Vec<(syn::Ident, syn::Type)>
     }
 }

--- a/odra-macros/src/test_utils.rs
+++ b/odra-macros/src/test_utils.rs
@@ -158,7 +158,19 @@ pub mod mock {
                 /// Description of B
                 B(u32, String),
                 /// Description of C
-                C()
+                C(),
+                /// Description of D
+                D {}
+            }
+        );
+        TypeIR::try_from(&ty).unwrap()
+    }
+
+    pub fn custom_union() -> TypeIR {
+        let ty = quote!(
+            union MyUnion {
+                f1: u32,
+                f2: f32,
             }
         );
         TypeIR::try_from(&ty).unwrap()

--- a/odra-macros/src/test_utils.rs
+++ b/odra-macros/src/test_utils.rs
@@ -150,6 +150,20 @@ pub mod mock {
         TypeIR::try_from(&ty).unwrap()
     }
 
+    pub fn custom_complex_enum() -> TypeIR {
+        let ty = quote!(
+            enum MyType {
+                /// Description of A
+                A { a: String, b: u32 },
+                /// Description of B
+                B(u32, String),
+                /// Description of C
+                C()
+            }
+        );
+        TypeIR::try_from(&ty).unwrap()
+    }
+
     pub fn ext_contract() -> ModuleImplIR {
         let ext = quote!(
             pub trait Token {

--- a/odra-macros/src/utils/syn.rs
+++ b/odra-macros/src/utils/syn.rs
@@ -100,36 +100,6 @@ fn map_fields<T, F: FnMut(&syn::Field) -> syn::Result<T>>(
     }
 }
 
-pub fn derive_item_variants(item: &syn::Item) -> syn::Result<Vec<syn::Ident>> {
-    match &item {
-        syn::Item::Struct(syn::ItemStruct { fields, .. }) => fields
-            .iter()
-            .map(|f| {
-                f.ident
-                    .clone()
-                    .ok_or(syn::Error::new(f.span(), "Unnamed field"))
-            })
-            .collect::<Result<Vec<_>, _>>(),
-        syn::Item::Enum(syn::ItemEnum { variants, .. }) => {
-            let is_valid = variants
-                .iter()
-                .all(|v| matches!(v.fields, syn::Fields::Unit));
-            if is_valid {
-                Ok(variants.iter().map(|v| v.ident.clone()).collect::<Vec<_>>())
-            } else {
-                Err(syn::Error::new_spanned(
-                    variants,
-                    "Expected a unit enum variant."
-                ))
-            }
-        }
-        _ => Err(syn::Error::new_spanned(
-            item,
-            "Struct with named fields expected"
-        ))
-    }
-}
-
 pub fn visibility_pub() -> syn::Visibility {
     parse_quote!(pub)
 }
@@ -209,20 +179,6 @@ pub fn as_casted_ty_stream(ty: &syn::Type, as_ty: syn::Type) -> TokenStream {
 
 pub fn is_ref(ty: &syn::Type) -> bool {
     matches!(ty, syn::Type::Reference(_))
-}
-
-pub fn extract_named_field(input: &syn::ItemStruct) -> syn::Result<Vec<syn::Field>> {
-    let fields = &input.fields;
-    fields
-        .iter()
-        .map(|f| {
-            if f.ident.is_none() {
-                Err(syn::Error::new(f.span(), "Unnamed field"))
-            } else {
-                Ok(f.clone())
-            }
-        })
-        .collect()
 }
 
 pub fn extract_unit_variants(input: &syn::ItemEnum) -> syn::Result<Vec<syn::Variant>> {

--- a/odra-schema/src/lib.rs
+++ b/odra-schema/src/lib.rs
@@ -112,12 +112,7 @@ pub fn enum_typed_variant<T: NamedCLTyped>(name: &str, discriminant: u16) -> Enu
 
 /// Creates a new enum variant of type [NamedCLType::Unit].
 pub fn enum_variant(name: &str, discriminant: u16) -> EnumVariant {
-    EnumVariant {
-        name: name.to_string(),
-        description: None,
-        discriminant,
-        ty: NamedCLType::Unit.into()
-    }
+    enum_typed_variant::<()>(name, discriminant)
 }
 
 /// Creates a new [CustomType] of type struct.

--- a/odra-schema/src/lib.rs
+++ b/odra-schema/src/lib.rs
@@ -115,6 +115,16 @@ pub fn enum_variant(name: &str, discriminant: u16) -> EnumVariant {
     enum_typed_variant::<()>(name, discriminant)
 }
 
+/// Creates a new enum variant of type [NamedCLType::Custom].
+pub fn enum_custom_type_variant(name: &str, discriminant: u16, custom_type: &str) -> EnumVariant {
+    EnumVariant {
+        name: name.to_string(),
+        description: None,
+        discriminant,
+        ty: NamedCLType::Custom(custom_type.into()).into()
+    }
+}
+
 /// Creates a new [CustomType] of type struct.
 pub fn custom_struct(name: &str, members: Vec<StructMember>) -> CustomType {
     CustomType::Struct {
@@ -318,12 +328,17 @@ mod test {
 
     #[test]
     fn test_custom_enum() {
-        let variant = super::enum_variant("variant1", 1);
-        let custom_enum = super::custom_enum("enum1", vec![variant]);
+        let variant1 = super::enum_variant("variant1", 1);
+        let variant2 = super::enum_typed_variant::<String>("v2", 2);
+        let variant3 = super::enum_custom_type_variant("v3", 3, "Type1");
+        let custom_enum = super::custom_enum("enum1", vec![variant1, variant2, variant3]);
         match custom_enum {
             casper_contract_schema::CustomType::Enum { name, variants, .. } => {
                 assert_eq!(name, "enum1".into());
-                assert_eq!(variants.len(), 1);
+                assert_eq!(variants.len(), 3);
+                assert_eq!(variants[0].ty, NamedCLType::Unit.into());
+                assert_eq!(variants[1].ty, NamedCLType::String.into());
+                assert_eq!(variants[2].ty, NamedCLType::Custom("Type1".into()).into());
             }
             _ => panic!("Expected CustomType::Enum")
         }


### PR DESCRIPTION
Makes this code working:

```rust
#[odra::odra_type]
enum IP {
    Unknown,                                               // no data,
    IPv4(IPv4),                                            // single unnamed element,
    IPv4WithDescription(IPv4, String),                     // multiple unnamed elements,
    IPv6 { ip: IPv6 },                                     // single named element,
    IPv6WithDescription { ip: IPv6, description: String }, // multiple named elements,
}

#[odra::odra_type]
pub enum Fieldless {
    Tuple(),
    Struct {},
    Unit
}
```

Resolves #172 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced custom types and structures for enhanced data representation, including IP addresses and enums.
	- Added a new contract `MyContract` with initialization and retrieval capabilities for custom types.
- **Refactor**
	- Improved handling of enums and structs across the codebase, enhancing the processing and differentiation of various types.
	- Streamlined type handling through the introduction of `TypeKind` enum, optimizing the construction of custom types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->