### PR TITLE
Refactor contract deployment functions to return Result types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 Changelog for `odra`.
+## [1.0.0] - 2024-05-xx
+### Added
+- Add `try_deploy` function to the `Deployer` trait - allows to deploy a contract and return an error if the deployment fails.
 
 ## [0.9.1] - 2024-04-xx
 ### Changed

--- a/odra-casper/livenet-env/src/livenet_host.rs
+++ b/odra-casper/livenet-env/src/livenet_host.rs
@@ -143,10 +143,10 @@ impl HostContext for LivenetHost {
         name: &str,
         init_args: RuntimeArgs,
         entry_points_caller: EntryPointsCaller
-    ) -> Address {
+    ) -> Result<Address, OdraError> {
         let address = self.casper_client.borrow_mut().deploy_wasm(name, init_args);
         self.register_contract(address, entry_points_caller);
-        address
+        Ok(address)
     }
 
     fn contract_env(&self) -> ContractEnv {


### PR DESCRIPTION
Resolves #407 

If you expect contract deployment to fail, you can write
```rust
let result: Result<ContractHostRef, OdraError> = ContractHostRef::deploy(&env, args);

// error handling logic
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced error handling across various components to ensure more reliable and consistent responses during operations.

- **New Features**
	- Introduced a new `try_deploy` function for safer and more predictable contract deployment experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->