### PR TITLE
Validate args at deploy time

### DIFF
--- a/core/src/contract_container.rs
+++ b/core/src/contract_container.rs
@@ -1,5 +1,5 @@
 use crate::entry_point_callback::{Argument, EntryPointsCaller};
-use crate::{prelude::*, OdraResult};
+use crate::{prelude::*, ExecutionError, OdraResult};
 use crate::{CallDef, OdraError, VmError};
 use casper_types::bytesrepr::Bytes;
 use casper_types::RuntimeArgs;
@@ -53,7 +53,7 @@ impl ContractContainer {
                     }));
                 }
             } else {
-                return Err(OdraError::VmError(VmError::MissingArg));
+                return Err(OdraError::ExecutionError(ExecutionError::MissingArg));
             }
         }
         Ok(())
@@ -72,7 +72,7 @@ mod tests {
         casper_types::{runtime_args, RuntimeArgs},
         OdraError, VmError
     };
-    use crate::{prelude::*, CallDef, ContractEnv};
+    use crate::{prelude::*, CallDef, ContractEnv, ExecutionError};
 
     const TEST_ENTRYPOINT: &str = "ep";
 
@@ -112,7 +112,10 @@ mod tests {
         let result = instance.call(call_def);
 
         // Then MissingArg error is returned.
-        assert_eq!(result.unwrap_err(), OdraError::VmError(VmError::MissingArg));
+        assert_eq!(
+            result.unwrap_err(),
+            OdraError::ExecutionError(ExecutionError::MissingArg)
+        );
     }
 
     #[test]
@@ -144,7 +147,10 @@ mod tests {
         let result = instance.call(call_def);
 
         // Then MissingArg error is returned.
-        assert_eq!(result.unwrap_err(), OdraError::VmError(VmError::MissingArg));
+        assert_eq!(
+            result.unwrap_err(),
+            OdraError::ExecutionError(ExecutionError::MissingArg)
+        );
     }
 
     #[test]
@@ -157,7 +163,10 @@ mod tests {
         let result = instance.call(call_def);
 
         // Then MissingArg error is returned.
-        assert_eq!(result.unwrap_err(), OdraError::VmError(VmError::MissingArg));
+        assert_eq!(
+            result.unwrap_err(),
+            OdraError::ExecutionError(ExecutionError::MissingArg)
+        );
     }
 
     impl ContractContainer {

--- a/core/src/contract_context.rs
+++ b/core/src/contract_context.rs
@@ -3,7 +3,7 @@ use casper_types::CLValue;
 use crate::call_def::CallDef;
 use crate::casper_types::bytesrepr::Bytes;
 use crate::casper_types::U512;
-use crate::{Address, OdraError};
+use crate::{Address, OdraError, OdraResult};
 
 /// Trait representing the context of a smart contract.
 #[cfg_attr(test, allow(unreachable_code))]
@@ -133,7 +133,7 @@ pub trait ContractContext {
     /// # Returns
     ///
     /// The value of the named argument as a byte array.
-    fn get_named_arg_bytes(&self, name: &str) -> Bytes;
+    fn get_named_arg_bytes(&self, name: &str) -> OdraResult<Bytes>;
 
     /// Similar to `get_named_arg_bytes`, but returns `None` if the named argument is not present.
     fn get_opt_named_arg_bytes(&self, name: &str) -> Option<Bytes>;

--- a/core/src/contract_env.rs
+++ b/core/src/contract_env.rs
@@ -287,8 +287,11 @@ impl ExecutionEnv {
     /// the contract will revert.
     pub fn get_named_arg<T: FromBytes + EntrypointArgument>(&self, name: &str) -> T {
         if T::is_required() {
-            let bytes = self.env.backend.borrow().get_named_arg_bytes(name);
-            deserialize_from_slice(bytes).unwrap_or_revert(&self.env)
+            let result = self.env.backend.borrow().get_named_arg_bytes(name);
+            match result {
+                Ok(bytes) => deserialize_from_slice(bytes).unwrap_or_revert(&self.env),
+                Err(err) => self.env.revert(err)
+            }
         } else {
             let bytes = self.env.backend.borrow().get_opt_named_arg_bytes(name);
             let result =

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -150,7 +150,7 @@ impl ExecutionError {
 
 impl From<ExecutionError> for OdraError {
     fn from(error: ExecutionError) -> Self {
-        Self::ExecutionError(ExecutionError::User(error.code()))
+        Self::ExecutionError(error)
     }
 }
 

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -125,6 +125,8 @@ pub enum ExecutionError {
     CouldNotSignMessage = 120,
     /// Empty dictionary name
     EmptyDictionaryName = 121,
+    /// Calling a contract with missing entrypoint arguments.
+    MissingArg = 122,
     /// Maximum code for user errors
     MaxUserError = 32767,
     /// User error too high. The code should be in range 0..32767.
@@ -167,8 +169,6 @@ pub enum VmError {
     InvalidContractAddress,
     /// Error calling a host function in a wrong context.
     InvalidContext,
-    /// Calling a contract with missing entrypoint arguments.
-    MissingArg,
     /// Calling a contract with a wrong argument type.
     TypeMismatch {
         /// Expected type.

--- a/odra-casper/livenet-env/src/livenet_contract_env.rs
+++ b/odra-casper/livenet-env/src/livenet_contract_env.rs
@@ -5,7 +5,7 @@ use odra_casper_rpc_client::casper_client::CasperClient;
 use odra_core::callstack::{Callstack, CallstackElement};
 use odra_core::casper_types::bytesrepr::Bytes;
 use odra_core::casper_types::{CLValue, U512};
-use odra_core::prelude::*;
+use odra_core::{prelude::*, ExecutionError, OdraResult};
 use odra_core::{Address, OdraError};
 use odra_core::{CallDef, ContractContext, ContractRegister};
 use std::io::Write;
@@ -112,8 +112,9 @@ impl ContractContext for LivenetContractEnv {
         panic!("Revert: {:?} - {}", error, revert_msg);
     }
 
-    fn get_named_arg_bytes(&self, name: &str) -> Bytes {
-        self.get_opt_named_arg_bytes(name).unwrap()
+    fn get_named_arg_bytes(&self, name: &str) -> OdraResult<Bytes> {
+        self.get_opt_named_arg_bytes(name)
+            .ok_or(OdraError::ExecutionError(ExecutionError::MissingArg))
     }
 
     fn get_opt_named_arg_bytes(&self, name: &str) -> Option<Bytes> {

--- a/odra-casper/wasm-env/src/wasm_contract_env.rs
+++ b/odra-casper/wasm-env/src/wasm_contract_env.rs
@@ -7,7 +7,7 @@ use odra_core::casper_types::{CLType, CLValue, BLAKE2B_DIGEST_LENGTH};
 use odra_core::prelude::*;
 use odra_core::{casper_types, UnwrapOrRevert};
 use odra_core::{Address, OdraError};
-use odra_core::{ContractContext, ContractEnv};
+use odra_core::{ContractContext, ContractEnv, ExecutionError, OdraResult};
 
 /// ContractContext implementation for Wasm environment.
 #[derive(Clone)]
@@ -74,12 +74,10 @@ impl ContractContext for WasmContractEnv {
         host_functions::revert(error.code())
     }
 
-    fn get_named_arg_bytes(&self, name: &str) -> Bytes {
-        let result = host_functions::get_named_arg(name);
-        match result {
-            Ok(bytes) => Bytes::from(bytes),
-            Err(err) => runtime::revert(err)
-        }
+    fn get_named_arg_bytes(&self, name: &str) -> OdraResult<Bytes> {
+        host_functions::get_named_arg(name)
+            .map(Bytes::from)
+            .map_err(|_| OdraError::ExecutionError(ExecutionError::MissingArg))
     }
 
     fn get_opt_named_arg_bytes(&self, name: &str) -> Option<Bytes> {

--- a/odra-vm/src/odra_vm_contract_env.rs
+++ b/odra-vm/src/odra_vm_contract_env.rs
@@ -3,11 +3,10 @@ use blake2::digest::VariableOutput;
 use blake2::{Blake2b, Blake2b512, Blake2bVar, Blake2s256, Digest};
 use odra_core::casper_types::{
     bytesrepr::{Bytes, ToBytes},
-    U512
+    CLValue, U512
 };
-use odra_core::casper_types::{BlockTime, CLType, CLValue};
-use odra_core::prelude::*;
 use odra_core::{casper_types, Address, OdraError};
+use odra_core::{prelude::*, OdraResult};
 use odra_core::{CallDef, ContractContext};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::Hasher;
@@ -78,12 +77,12 @@ impl ContractContext for OdraVmContractEnv {
         self.vm.borrow().revert(error)
     }
 
-    fn get_named_arg_bytes(&self, name: &str) -> Bytes {
-        self.vm.borrow().get_named_arg(name).unwrap().into()
+    fn get_named_arg_bytes(&self, name: &str) -> OdraResult<Bytes> {
+        self.vm.borrow().get_named_arg(name).map(Into::into)
     }
 
     fn get_opt_named_arg_bytes(&self, name: &str) -> Option<Bytes> {
-        self.vm.borrow().get_named_arg(name).map(Into::into)
+        self.vm.borrow().get_named_arg(name).ok().map(Into::into)
     }
 
     fn handle_attached_value(&self) {

--- a/odra-vm/src/vm/odra_vm.rs
+++ b/odra-vm/src/vm/odra_vm.rs
@@ -122,13 +122,14 @@ impl OdraVm {
     /// Gets the value of the named argument.
     ///
     /// The argument must be present in the call definition.
-    pub fn get_named_arg(&self, name: &str) -> Option<Vec<u8>> {
+    pub fn get_named_arg(&self, name: &str) -> OdraResult<Vec<u8>> {
         match self.state.read().unwrap().callstack_tip() {
             CallstackElement::Account(_) => todo!(),
             CallstackElement::ContractCall { call_def, .. } => call_def
                 .args()
                 .get(name)
                 .map(|arg| arg.inner_bytes().to_vec())
+                .ok_or_else(|| OdraError::ExecutionError(ExecutionError::MissingArg))
         }
     }
 


### PR DESCRIPTION
Resolves #409 Now on both backends: `odra-vm` and `casper` a missing argument error should almost the same

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved error handling across components with the introduction of `ExecutionError` for specific scenarios.
  - Updated functions like `get_named_arg` to return `OdraResult`, enhancing argument retrieval reliability.

- **Bug Fixes**
  - Addressed potential crashes by implementing structured error handling in contract environments.

- **Refactor**
  - Streamlined error management by transitioning from `VmError` to `ExecutionError` in multiple files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->