### PR TITLE
Add block_time() to HostEnv

### DIFF
--- a/core/src/host.rs
+++ b/core/src/host.rs
@@ -151,6 +151,9 @@ pub trait HostContext {
     /// Advances the block time by the specified time difference.
     fn advance_block_time(&self, time_diff: u64);
 
+    /// Returns the current block time.
+    fn block_time(&self) -> u64;
+
     /// Returns the event bytes for the specified contract address and index.
     fn get_event(&self, contract_address: &Address, index: u32) -> Result<Bytes, EventError>;
 
@@ -234,6 +237,12 @@ impl HostEnv {
     pub fn advance_block_time(&self, time_diff: u64) {
         let backend = self.backend.borrow();
         backend.advance_block_time(time_diff)
+    }
+
+    /// Returns the current block time.
+    pub fn block_time(&self) -> u64 {
+        let backend = self.backend.borrow();
+        backend.block_time()
     }
 
     /// Registers a new contract with the specified name, initialization arguments, and entry points caller.

--- a/core/src/host_env.rs
+++ b/core/src/host_env.rs
@@ -54,6 +54,12 @@ impl HostEnv {
         backend.advance_block_time(time_diff)
     }
 
+    /// Returns the current block time.
+    pub fn block_time(&self) -> u64 {
+        let backend = self.backend.borrow();
+        backend.block_time()
+    }
+
     /// Registers a new contract with the specified name, initialization arguments, and entry points caller.
     pub fn new_contract(
         &self,

--- a/odra-casper/livenet-env/src/livenet_host.rs
+++ b/odra-casper/livenet-env/src/livenet_host.rs
@@ -81,6 +81,10 @@ impl HostContext for LivenetHost {
         sleep(std::time::Duration::from_millis(time_diff));
     }
 
+    fn block_time(&self) -> u64 {
+        self.casper_client.borrow().get_block_time()
+    }
+
     fn get_event(&self, contract_address: &Address, index: u32) -> Result<Bytes, EventError> {
         self.casper_client
             .borrow()

--- a/odra-casper/test-vm/src/casper_host.rs
+++ b/odra-casper/test-vm/src/casper_host.rs
@@ -59,6 +59,10 @@ impl HostContext for CasperHost {
         self.vm.borrow_mut().advance_block_time(time_diff)
     }
 
+    fn block_time(&self) -> u64 {
+        self.vm.borrow().block_time()
+    }
+
     fn get_event(&self, contract_address: &Address, index: u32) -> Result<Bytes, EventError> {
         self.vm.borrow().get_event(contract_address, index)
     }

--- a/odra-casper/test-vm/src/vm/casper_vm.rs
+++ b/odra-casper/test-vm/src/vm/casper_vm.rs
@@ -82,6 +82,11 @@ impl CasperVm {
         self.block_time += time_diff
     }
 
+    /// Gets the current block time.
+    pub fn block_time(&self) -> u64 {
+        self.block_time
+    }
+
     /// Gets the event at the specified index for the given contract address.
     ///
     /// The index may be negative, in which case it is interpreted as an offset from the end of the event list.

--- a/odra-vm/src/odra_vm_host.rs
+++ b/odra-vm/src/odra_vm_host.rs
@@ -41,6 +41,10 @@ impl HostContext for OdraVmHost {
         self.vm.borrow().advance_block_time_by(time_diff)
     }
 
+    fn block_time(&self) -> u64 {
+        self.vm.borrow().get_block_time()
+    }
+
     fn get_event(&self, contract_address: &Address, index: u32) -> Result<Bytes, EventError> {
         self.vm.borrow().get_event(contract_address, index)
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new method to access the current block time within various host contexts, enhancing the functionality and providing more precise time-related data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->