### PR TITLE
Protect static mocks with Mutex

### DIFF
--- a/core/src/host.rs
+++ b/core/src/host.rs
@@ -508,6 +508,11 @@ mod test {
     use casper_event_standard::Event;
     use casper_types::account::AccountHash;
     use mockall::{mock, predicate};
+    use std::sync::Mutex;
+
+    pub static IDENT_MTX: Mutex<()> = Mutex::new(());
+    pub static EPC_MTX: Mutex<()> = Mutex::new(());
+    pub static VALIDATE_MTX: Mutex<()> = Mutex::new(());
 
     #[derive(Debug, Event, PartialEq)]
     struct TestEv {}
@@ -542,6 +547,9 @@ mod test {
 
     #[test]
     fn test_deploy_with_default_args() {
+        let _i = IDENT_MTX.lock();
+        let _e = EPC_MTX.lock();
+
         // stubs
         let indent_ctx = MockTestRef::ident_context();
         indent_ctx.expect().returning(|| "TestRef".to_string());
@@ -569,6 +577,9 @@ mod test {
     #[should_panic(expected = "Invalid init args for contract TestRef.")]
     fn test_deploy_with_invalid_args() {
         // stubs
+        let _i = IDENT_MTX.lock();
+        let _v = VALIDATE_MTX.lock();
+
         let args_ctx = MockEv::validate_context();
         args_ctx.expect().returning(|_| false);
         let indent_ctx = MockTestRef::ident_context();
@@ -582,6 +593,9 @@ mod test {
     #[test]
     fn test_load_ref() {
         // stubs
+        let _e = EPC_MTX.lock();
+        let _v = VALIDATE_MTX.lock();
+
         let args_ctx = MockEv::validate_context();
         args_ctx.expect().returning(|_| true);
         let epc_ctx = MockTestRef::entry_points_caller_context();

--- a/core/src/host.rs
+++ b/core/src/host.rs
@@ -510,9 +510,9 @@ mod test {
     use mockall::{mock, predicate};
     use std::sync::Mutex;
 
-    pub static IDENT_MTX: Mutex<()> = Mutex::new(());
-    pub static EPC_MTX: Mutex<()> = Mutex::new(());
-    pub static VALIDATE_MTX: Mutex<()> = Mutex::new(());
+    static IDENT_MTX: Mutex<()> = Mutex::new(());
+    static EPC_MTX: Mutex<()> = Mutex::new(());
+    static VALIDATE_MTX: Mutex<()> = Mutex::new(());
 
     #[derive(Debug, Event, PartialEq)]
     struct TestEv {}
@@ -547,6 +547,10 @@ mod test {
 
     #[test]
     fn test_deploy_with_default_args() {
+        // MockTestRef::ident() and  MockTestRef::entry_points_caller() are static and can't be safely used
+        // from multiple tests at the same time. Should be to protected with a Mutex. Each function has
+        // a separate Mutex.
+        // https://github.com/asomers/mockall/blob/master/mockall/tests/mock_struct_with_static_method.rs
         let _i = IDENT_MTX.lock();
         let _e = EPC_MTX.lock();
 
@@ -576,10 +580,14 @@ mod test {
     #[test]
     #[should_panic(expected = "Invalid init args for contract TestRef.")]
     fn test_deploy_with_invalid_args() {
-        // stubs
+        // MockTestRef::ident() and  MockEv::validate() are static and can't be safely used
+        // from multiple tests at the same time. Should be to protected with a Mutex. Each function has
+        // a separate Mutex.
+        // https://github.com/asomers/mockall/blob/master/mockall/tests/mock_struct_with_static_method.rs
         let _i = IDENT_MTX.lock();
         let _v = VALIDATE_MTX.lock();
 
+        // stubs
         let args_ctx = MockEv::validate_context();
         args_ctx.expect().returning(|_| false);
         let indent_ctx = MockTestRef::ident_context();
@@ -592,10 +600,14 @@ mod test {
 
     #[test]
     fn test_load_ref() {
-        // stubs
+        // MockTestRef::ident() and  MockEv::validate() are static and can't be safely used
+        // from multiple tests at the same time. Should be to protected with a Mutex. Each function has
+        // a separate Mutex.
+        // https://github.com/asomers/mockall/blob/master/mockall/tests/mock_struct_with_static_method.rs
         let _e = EPC_MTX.lock();
         let _v = VALIDATE_MTX.lock();
 
+        // stubs
         let args_ctx = MockEv::validate_context();
         args_ctx.expect().returning(|_| true);
         let epc_ctx = MockTestRef::entry_points_caller_context();


### PR DESCRIPTION
All the random test failures, eg:
https://github.com/odradev/odra/actions/runs/9250932555/job/25445407808
https://github.com/odradev/odra/actions/runs/9112635335/job/25052310612
https://github.com/odradev/odra/actions/runs/9224271075/job/25379202348

are related to mocking static functions, the thread https://github.com/asomers/mockall/issues/267 suggests running tests on a single thread or protected tests with a Mutext.

In should resolve #444 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved test reliability by introducing new locking mechanisms to ensure proper synchronization during test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->