### PR TITLE
Move the code that generates contract schema to `odra-build`

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,6 +9,9 @@ odra-modules = { path = "../modules", default-features = false }
 sha3 = { version = "0.10.6", default-features = false }
 odra-casper-livenet-env = { path = "../odra-casper/livenet-env", optional = true }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+odra-build = { path = "../odra-build" }
+
 [dev-dependencies]
 odra-test = { path = "../odra-test" }
 hex = "0.4.3"

--- a/examples/bin/build_schema.rs
+++ b/examples/bin/build_schema.rs
@@ -10,60 +10,7 @@ extern "Rust" {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
-    let module = std::env::var("ODRA_MODULE").expect("ODRA_MODULE environment variable is not set");
-    let module = to_snake_case(&module);
-
-    let contract_schema = unsafe { crate::casper_contract_schema() };
-    let module_schema = unsafe { crate::module_schema() };
-
-    write_schema_file(
-        "resources/casper_contract_schemas",
-        &module,
-        contract_schema
-            .as_json()
-            .expect("Failed to convert schema to JSON")
-    );
-
-    write_schema_file(
-        "resources/legacy",
-        &module,
-        module_schema
-            .as_json()
-            .expect("Failed to convert schema to JSON")
-    );
-}
-
-fn write_schema_file(path: &str, module: &str, json: String) {
-    if !std::path::Path::new(path).exists() {
-        std::fs::create_dir_all(path).expect("Failed to create resources directory");
-    }
-    let filename = format!("{}/{}_schema.json", path, module);
-    let mut schema_file = std::fs::File::create(filename).expect("Failed to create schema file");
-
-    std::io::Write::write_all(&mut schema_file, &json.into_bytes())
-        .expect("Failed to write to schema file");
-}
-
-fn to_snake_case(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    let mut chars = s.chars().peekable();
-    let mut is_first = true;
-
-    while let Some(c) = chars.next() {
-        if c.is_uppercase() {
-            if !is_first {
-                if let Some(next) = chars.peek() {
-                    if next.is_lowercase() {
-                        result.push('_');
-                    }
-                }
-            }
-            result.push(c.to_lowercase().next().unwrap());
-        } else {
-            result.push(c);
-        }
-        is_first = false;
-    }
-
-    result
+    odra_build::schema(unsafe { crate::module_schema() }, unsafe {
+        crate::casper_contract_schema()
+    });
 }

--- a/modules/Cargo.toml
+++ b/modules/Cargo.toml
@@ -16,6 +16,9 @@ serde-json-wasm = { version = "1.0.1", default-features = false }
 base16 = { version = "0.2.1", default-features = false }
 base64 = { version = "0.22.0", default-features = false, features = ["alloc"] }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+odra-build = { path = "../odra-build" }
+
 [dev-dependencies]
 odra-test = { path = "../odra-test", version = "1.0.0" }
 once_cell = "1"

--- a/modules/bin/build_schema.rs
+++ b/modules/bin/build_schema.rs
@@ -10,60 +10,7 @@ extern "Rust" {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
-    let module = std::env::var("ODRA_MODULE").expect("ODRA_MODULE environment variable is not set");
-    let module = to_snake_case(&module);
-
-    let contract_schema = unsafe { crate::casper_contract_schema() };
-    let module_schema = unsafe { crate::module_schema() };
-
-    write_schema_file(
-        "resources/casper_contract_schemas",
-        &module,
-        contract_schema
-            .as_json()
-            .expect("Failed to convert schema to JSON")
-    );
-
-    write_schema_file(
-        "resources/legacy",
-        &module,
-        module_schema
-            .as_json()
-            .expect("Failed to convert schema to JSON")
-    );
-}
-
-fn write_schema_file(path: &str, module: &str, json: String) {
-    if !std::path::Path::new(path).exists() {
-        std::fs::create_dir_all(path).expect("Failed to create resources directory");
-    }
-    let filename = format!("{}/{}_schema.json", path, module);
-    let mut schema_file = std::fs::File::create(filename).expect("Failed to create schema file");
-
-    std::io::Write::write_all(&mut schema_file, &json.into_bytes())
-        .expect("Failed to write to schema file");
-}
-
-fn to_snake_case(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    let mut chars = s.chars().peekable();
-    let mut is_first = true;
-
-    while let Some(c) = chars.next() {
-        if c.is_uppercase() {
-            if !is_first {
-                if let Some(next) = chars.peek() {
-                    if next.is_lowercase() {
-                        result.push('_');
-                    }
-                }
-            }
-            result.push(c.to_lowercase().next().unwrap());
-        } else {
-            result.push(c);
-        }
-        is_first = false;
-    }
-
-    result
+    odra_build::schema(unsafe { crate::module_schema() }, unsafe {
+        crate::casper_contract_schema()
+    });
 }

--- a/modules/resources/casper_contract_schemas/test_cep78_schema.json
+++ b/modules/resources/casper_contract_schemas/test_cep78_schema.json
@@ -8,8 +8,8 @@
   ],
   "repository": "https://github.com/odradev/odra",
   "homepage": null,
-  "contract_name": "Cep78",
-  "contract_version": "1.5.1",
+  "contract_name": "TestCep78",
+  "contract_version": "1.0.0",
   "types": [
     {
       "struct": {
@@ -1306,8 +1306,242 @@
   ],
   "entry_points": [
     {
+      "name": "is_whitelisted",
+      "description": "",
+      "is_mutable": false,
+      "arguments": [
+        {
+          "name": "address",
+          "description": null,
+          "ty": "Key",
+          "optional": false
+        }
+      ],
+      "return_ty": "Bool",
+      "is_contract_context": true,
+      "access": "public"
+    },
+    {
+      "name": "get_whitelist_mode",
+      "description": "",
+      "is_mutable": false,
+      "arguments": [],
+      "return_ty": "WhitelistMode",
+      "is_contract_context": true,
+      "access": "public"
+    },
+    {
+      "name": "get_collection_name",
+      "description": "",
+      "is_mutable": false,
+      "arguments": [],
+      "return_ty": "String",
+      "is_contract_context": true,
+      "access": "public"
+    },
+    {
+      "name": "get_collection_symbol",
+      "description": "",
+      "is_mutable": false,
+      "arguments": [],
+      "return_ty": "String",
+      "is_contract_context": true,
+      "access": "public"
+    },
+    {
+      "name": "is_minting_allowed",
+      "description": "",
+      "is_mutable": false,
+      "arguments": [],
+      "return_ty": "Bool",
+      "is_contract_context": true,
+      "access": "public"
+    },
+    {
+      "name": "is_operator_burn_mode",
+      "description": "",
+      "is_mutable": false,
+      "arguments": [],
+      "return_ty": "Bool",
+      "is_contract_context": true,
+      "access": "public"
+    },
+    {
+      "name": "get_total_supply",
+      "description": "",
+      "is_mutable": false,
+      "arguments": [],
+      "return_ty": "U64",
+      "is_contract_context": true,
+      "access": "public"
+    },
+    {
+      "name": "get_minting_mode",
+      "description": "",
+      "is_mutable": false,
+      "arguments": [],
+      "return_ty": "MintingMode",
+      "is_contract_context": true,
+      "access": "public"
+    },
+    {
+      "name": "get_holder_mode",
+      "description": "",
+      "is_mutable": false,
+      "arguments": [],
+      "return_ty": "NFTHolderMode",
+      "is_contract_context": true,
+      "access": "public"
+    },
+    {
+      "name": "get_number_of_minted_tokens",
+      "description": "",
+      "is_mutable": false,
+      "arguments": [],
+      "return_ty": "U64",
+      "is_contract_context": true,
+      "access": "public"
+    },
+    {
+      "name": "get_page",
+      "description": "",
+      "is_mutable": false,
+      "arguments": [
+        {
+          "name": "page_number",
+          "description": null,
+          "ty": "U64",
+          "optional": false
+        }
+      ],
+      "return_ty": {
+        "List": "Bool"
+      },
+      "is_contract_context": true,
+      "access": "public"
+    },
+    {
+      "name": "get_page_by_token_id",
+      "description": "",
+      "is_mutable": false,
+      "arguments": [
+        {
+          "name": "token_id",
+          "description": null,
+          "ty": "U64",
+          "optional": false
+        }
+      ],
+      "return_ty": {
+        "List": "Bool"
+      },
+      "is_contract_context": true,
+      "access": "public"
+    },
+    {
+      "name": "get_page_by_token_hash",
+      "description": "",
+      "is_mutable": false,
+      "arguments": [
+        {
+          "name": "token_hash",
+          "description": null,
+          "ty": "String",
+          "optional": false
+        }
+      ],
+      "return_ty": {
+        "List": "Bool"
+      },
+      "is_contract_context": true,
+      "access": "public"
+    },
+    {
+      "name": "get_page_table",
+      "description": "",
+      "is_mutable": false,
+      "arguments": [],
+      "return_ty": {
+        "List": "Bool"
+      },
+      "is_contract_context": true,
+      "access": "public"
+    },
+    {
+      "name": "get_metadata_by_kind",
+      "description": "",
+      "is_mutable": false,
+      "arguments": [
+        {
+          "name": "kind",
+          "description": null,
+          "ty": "NFTMetadataKind",
+          "optional": false
+        },
+        {
+          "name": "token_id",
+          "description": null,
+          "ty": "U64",
+          "optional": true
+        },
+        {
+          "name": "token_hash",
+          "description": null,
+          "ty": "String",
+          "optional": true
+        }
+      ],
+      "return_ty": "String",
+      "is_contract_context": true,
+      "access": "public"
+    },
+    {
+      "name": "get_token_issuer",
+      "description": "",
+      "is_mutable": false,
+      "arguments": [
+        {
+          "name": "token_id",
+          "description": null,
+          "ty": "U64",
+          "optional": true
+        },
+        {
+          "name": "token_hash",
+          "description": null,
+          "ty": "String",
+          "optional": true
+        }
+      ],
+      "return_ty": "Key",
+      "is_contract_context": true,
+      "access": "public"
+    },
+    {
+      "name": "token_burned",
+      "description": "",
+      "is_mutable": false,
+      "arguments": [
+        {
+          "name": "token_id",
+          "description": null,
+          "ty": "U64",
+          "optional": true
+        },
+        {
+          "name": "token_hash",
+          "description": null,
+          "ty": "String",
+          "optional": true
+        }
+      ],
+      "return_ty": "Bool",
+      "is_contract_context": true,
+      "access": "public"
+    },
+    {
       "name": "set_variables",
-      "description": "Exposes all variables that can be changed by managing account post",
+      "description": "Delegated. See `self.token.set_variables()` for details.",
       "is_mutable": true,
       "arguments": [
         {
@@ -1337,7 +1571,7 @@
     },
     {
       "name": "mint",
-      "description": "Mints a new token with provided metadata.",
+      "description": "Delegated. See `self.token.mint()` for details.",
       "is_mutable": true,
       "arguments": [
         {
@@ -1365,7 +1599,7 @@
     },
     {
       "name": "burn",
-      "description": "Burns the token with provided `token_id` argument, after which it is no",
+      "description": "Delegated. See `self.token.burn()` for details.",
       "is_mutable": true,
       "arguments": [
         {
@@ -1387,7 +1621,7 @@
     },
     {
       "name": "transfer",
-      "description": "Transfers ownership of the token from one account to another.",
+      "description": "Delegated. See `self.token.transfer()` for details.",
       "is_mutable": true,
       "arguments": [
         {
@@ -1421,7 +1655,7 @@
     },
     {
       "name": "approve",
-      "description": "Approves another token holder (an approved account) to transfer tokens. It",
+      "description": "Delegated. See `self.token.approve()` for details.",
       "is_mutable": true,
       "arguments": [
         {
@@ -1449,7 +1683,7 @@
     },
     {
       "name": "revoke",
-      "description": "Revokes an approved account to transfer tokens. It reverts",
+      "description": "Delegated. See `self.token.revoke()` for details.",
       "is_mutable": true,
       "arguments": [
         {
@@ -1471,7 +1705,7 @@
     },
     {
       "name": "set_approval_for_all",
-      "description": "Approves all tokens owned by the caller and future to another token holder",
+      "description": "Delegated. See `self.token.set_approval_for_all()` for details.",
       "is_mutable": true,
       "arguments": [
         {
@@ -1493,7 +1727,7 @@
     },
     {
       "name": "is_approved_for_all",
-      "description": "Returns if an account is operator for a token owner",
+      "description": "Delegated. See `self.token.is_approved_for_all()` for details.",
       "is_mutable": true,
       "arguments": [
         {
@@ -1515,7 +1749,7 @@
     },
     {
       "name": "owner_of",
-      "description": "Returns the token owner given a token_id. It reverts if token_id",
+      "description": "Delegated. See `self.token.owner_of()` for details.",
       "is_mutable": false,
       "arguments": [
         {
@@ -1537,7 +1771,7 @@
     },
     {
       "name": "get_approved",
-      "description": "Returns the approved account (if any) associated with the provided token_id",
+      "description": "Delegated. See `self.token.get_approved()` for details.",
       "is_mutable": true,
       "arguments": [
         {
@@ -1561,7 +1795,7 @@
     },
     {
       "name": "metadata",
-      "description": "Returns the metadata associated with the provided token_id",
+      "description": "Delegated. See `self.token.metadata()` for details.",
       "is_mutable": false,
       "arguments": [
         {
@@ -1583,7 +1817,7 @@
     },
     {
       "name": "set_token_metadata",
-      "description": "Updates the metadata if valid.",
+      "description": "Delegated. See `self.token.set_token_metadata()` for details.",
       "is_mutable": true,
       "arguments": [
         {
@@ -1611,7 +1845,7 @@
     },
     {
       "name": "balance_of",
-      "description": "Returns number of owned tokens associated with the provided token holder",
+      "description": "Delegated. See `self.token.balance_of()` for details.",
       "is_mutable": true,
       "arguments": [
         {
@@ -1627,7 +1861,7 @@
     },
     {
       "name": "register_owner",
-      "description": "This entrypoint allows users to register with a give CEP-78 instance,",
+      "description": "Delegated. See `self.token.register_owner()` for details.",
       "is_mutable": true,
       "arguments": [
         {
@@ -1681,8 +1915,8 @@
     }
   ],
   "call": {
-    "wasm_file_name": "Cep78.wasm",
-    "description": "Initializes the module.",
+    "wasm_file_name": "TestCep78.wasm",
+    "description": "Delegated. See `self.token.init()` for details.",
     "arguments": [
       {
         "name": "odra_cfg_package_hash_key_name",

--- a/modules/resources/legacy/test_cep78_schema.json
+++ b/modules/resources/legacy/test_cep78_schema.json
@@ -1,5 +1,5 @@
 {
-  "name": "Cep78",
+  "name": "TestCep78",
   "events": [
     {
       "name": "Approval",
@@ -196,6 +196,234 @@
     }
   ],
   "entrypoints": [
+    {
+      "name": "is_whitelisted",
+      "args": [
+        {
+          "name": "address",
+          "ty": "Key",
+          "is_ref": false,
+          "is_slice": false,
+          "is_required": true
+        }
+      ],
+      "is_mutable": false,
+      "return_ty": "Bool",
+      "ty": "Public",
+      "attributes": []
+    },
+    {
+      "name": "get_whitelist_mode",
+      "args": [],
+      "is_mutable": false,
+      "return_ty": "U8",
+      "ty": "Public",
+      "attributes": []
+    },
+    {
+      "name": "get_collection_name",
+      "args": [],
+      "is_mutable": false,
+      "return_ty": "String",
+      "ty": "Public",
+      "attributes": []
+    },
+    {
+      "name": "get_collection_symbol",
+      "args": [],
+      "is_mutable": false,
+      "return_ty": "String",
+      "ty": "Public",
+      "attributes": []
+    },
+    {
+      "name": "is_minting_allowed",
+      "args": [],
+      "is_mutable": false,
+      "return_ty": "Bool",
+      "ty": "Public",
+      "attributes": []
+    },
+    {
+      "name": "is_operator_burn_mode",
+      "args": [],
+      "is_mutable": false,
+      "return_ty": "Bool",
+      "ty": "Public",
+      "attributes": []
+    },
+    {
+      "name": "get_total_supply",
+      "args": [],
+      "is_mutable": false,
+      "return_ty": "U64",
+      "ty": "Public",
+      "attributes": []
+    },
+    {
+      "name": "get_minting_mode",
+      "args": [],
+      "is_mutable": false,
+      "return_ty": "U8",
+      "ty": "Public",
+      "attributes": []
+    },
+    {
+      "name": "get_holder_mode",
+      "args": [],
+      "is_mutable": false,
+      "return_ty": "U8",
+      "ty": "Public",
+      "attributes": []
+    },
+    {
+      "name": "get_number_of_minted_tokens",
+      "args": [],
+      "is_mutable": false,
+      "return_ty": "U64",
+      "ty": "Public",
+      "attributes": []
+    },
+    {
+      "name": "get_page",
+      "args": [
+        {
+          "name": "page_number",
+          "ty": "U64",
+          "is_ref": false,
+          "is_slice": false,
+          "is_required": true
+        }
+      ],
+      "is_mutable": false,
+      "return_ty": {
+        "List": "Bool"
+      },
+      "ty": "Public",
+      "attributes": []
+    },
+    {
+      "name": "get_page_by_token_id",
+      "args": [
+        {
+          "name": "token_id",
+          "ty": "U64",
+          "is_ref": false,
+          "is_slice": false,
+          "is_required": true
+        }
+      ],
+      "is_mutable": false,
+      "return_ty": {
+        "List": "Bool"
+      },
+      "ty": "Public",
+      "attributes": []
+    },
+    {
+      "name": "get_page_by_token_hash",
+      "args": [
+        {
+          "name": "token_hash",
+          "ty": "String",
+          "is_ref": false,
+          "is_slice": false,
+          "is_required": true
+        }
+      ],
+      "is_mutable": false,
+      "return_ty": {
+        "List": "Bool"
+      },
+      "ty": "Public",
+      "attributes": []
+    },
+    {
+      "name": "get_page_table",
+      "args": [],
+      "is_mutable": false,
+      "return_ty": {
+        "List": "Bool"
+      },
+      "ty": "Public",
+      "attributes": []
+    },
+    {
+      "name": "get_metadata_by_kind",
+      "args": [
+        {
+          "name": "kind",
+          "ty": "U8",
+          "is_ref": false,
+          "is_slice": false,
+          "is_required": true
+        },
+        {
+          "name": "token_id",
+          "ty": "U64",
+          "is_ref": false,
+          "is_slice": false,
+          "is_required": false
+        },
+        {
+          "name": "token_hash",
+          "ty": "String",
+          "is_ref": false,
+          "is_slice": false,
+          "is_required": false
+        }
+      ],
+      "is_mutable": false,
+      "return_ty": "String",
+      "ty": "Public",
+      "attributes": []
+    },
+    {
+      "name": "get_token_issuer",
+      "args": [
+        {
+          "name": "token_id",
+          "ty": "U64",
+          "is_ref": false,
+          "is_slice": false,
+          "is_required": false
+        },
+        {
+          "name": "token_hash",
+          "ty": "String",
+          "is_ref": false,
+          "is_slice": false,
+          "is_required": false
+        }
+      ],
+      "is_mutable": false,
+      "return_ty": "Key",
+      "ty": "Public",
+      "attributes": []
+    },
+    {
+      "name": "token_burned",
+      "args": [
+        {
+          "name": "token_id",
+          "ty": "U64",
+          "is_ref": false,
+          "is_slice": false,
+          "is_required": false
+        },
+        {
+          "name": "token_hash",
+          "ty": "String",
+          "is_ref": false,
+          "is_slice": false,
+          "is_required": false
+        }
+      ],
+      "is_mutable": false,
+      "return_ty": "Bool",
+      "ty": "Public",
+      "attributes": []
+    },
     {
       "name": "init",
       "args": [

--- a/modules/src/cep18_token.rs
+++ b/modules/src/cep18_token.rs
@@ -15,8 +15,12 @@ use crate::cep18::storage::{
 use crate::cep18::utils::{Cep18Modality, SecurityBadge};
 
 /// CEP-18 token module
-#[odra::module(events = [Mint, Burn, SetAllowance, IncreaseAllowance, DecreaseAllowance, Transfer,
-    TransferFrom, ChangeSecurity])]
+#[odra::module(
+    events = [
+        Mint, Burn, SetAllowance, IncreaseAllowance, DecreaseAllowance, Transfer,TransferFrom, ChangeSecurity
+    ],
+    errors = Error
+)]
 pub struct Cep18 {
     decimals: SubModule<Cep18DecimalsStorage>,
     symbol: SubModule<Cep18SymbolStorage>,

--- a/modules/src/cep78/token.rs
+++ b/modules/src/cep78/token.rs
@@ -50,7 +50,8 @@ single_value_storage!(
 /// - `metadata_mutability`: The mutability of the metadata associated with the NFTs in the collection. See [MetadataMutability] for more details.
 #[odra::module(
     version = "1.5.1",
-    events = [Approval, ApprovalForAll, ApprovalRevoked, Burn, MetadataUpdated, Mint, RevokedForAll, Transfer, VariablesSet]
+    events = [Approval, ApprovalForAll, ApprovalRevoked, Burn, MetadataUpdated, Mint, RevokedForAll, Transfer, VariablesSet],
+    errors = CEP78Error
 )]
 pub struct Cep78 {
     data: SubModule<CollectionData>,

--- a/odra-build/Cargo.toml
+++ b/odra-build/Cargo.toml
@@ -7,3 +7,7 @@ authors.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true, default-features = false, features = ["alloc"] }

--- a/templates/blank/_Cargo.toml
+++ b/templates/blank/_Cargo.toml
@@ -12,6 +12,9 @@ edition = "2021"
 [build-dependencies]
 #odra_build_dependency
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+#odra_build_dependency
+
 [[bin]]
 name = "{{project-name}}_build_contract"
 path = "bin/build_contract.rs"

--- a/templates/blank/bin/build_schema.rs
+++ b/templates/blank/bin/build_schema.rs
@@ -10,60 +10,7 @@ extern "Rust" {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
-    let module = std::env::var("ODRA_MODULE").expect("ODRA_MODULE environment variable is not set");
-    let module = to_snake_case(&module);
-
-    let contract_schema = unsafe { crate::casper_contract_schema() };
-    let module_schema = unsafe { crate::module_schema() };
-
-    write_schema_file(
-        "resources/casper_contract_schemas",
-        &module,
-        contract_schema
-            .as_json()
-            .expect("Failed to convert schema to JSON")
-    );
-
-    write_schema_file(
-        "resources/legacy",
-        &module,
-        module_schema
-            .as_json()
-            .expect("Failed to convert schema to JSON")
-    );
-}
-
-fn write_schema_file(path: &str, module: &str, json: String) {
-    if !std::path::Path::new(path).exists() {
-        std::fs::create_dir_all(path).expect("Failed to create resources directory");
-    }
-    let filename = format!("{}/{}_schema.json", path, module);
-    let mut schema_file = std::fs::File::create(filename).expect("Failed to create schema file");
-
-    std::io::Write::write_all(&mut schema_file, &json.into_bytes())
-        .expect("Failed to write to schema file");
-}
-
-fn to_snake_case(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    let mut chars = s.chars().peekable();
-    let mut is_first = true;
-
-    while let Some(c) = chars.next() {
-        if c.is_uppercase() {
-            if !is_first {
-                if let Some(next) = chars.peek() {
-                    if next.is_lowercase() {
-                        result.push('_');
-                    }
-                }
-            }
-            result.push(c.to_lowercase().next().unwrap());
-        } else {
-            result.push(c);
-        }
-        is_first = false;
-    }
-
-    result
+    odra_build::schema(unsafe { crate::module_schema() }, unsafe {
+        crate::casper_contract_schema()
+    });
 }

--- a/templates/cep18/_Cargo.toml
+++ b/templates/cep18/_Cargo.toml
@@ -13,6 +13,9 @@ edition = "2021"
 [build-dependencies]
 #odra_build_dependency
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+#odra_build_dependency
+
 [[bin]]
 name = "{{project-name}}_build_contract"
 path = "bin/build_contract.rs"

--- a/templates/cep18/bin/build_schema.rs
+++ b/templates/cep18/bin/build_schema.rs
@@ -10,60 +10,7 @@ extern "Rust" {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
-    let module = std::env::var("ODRA_MODULE").expect("ODRA_MODULE environment variable is not set");
-    let module = to_snake_case(&module);
-
-    let contract_schema = unsafe { crate::casper_contract_schema() };
-    let module_schema = unsafe { crate::module_schema() };
-
-    write_schema_file(
-        "resources/casper_contract_schemas",
-        &module,
-        contract_schema
-            .as_json()
-            .expect("Failed to convert schema to JSON")
-    );
-
-    write_schema_file(
-        "resources/legacy",
-        &module,
-        module_schema
-            .as_json()
-            .expect("Failed to convert schema to JSON")
-    );
-}
-
-fn write_schema_file(path: &str, module: &str, json: String) {
-    if !std::path::Path::new(path).exists() {
-        std::fs::create_dir_all(path).expect("Failed to create resources directory");
-    }
-    let filename = format!("{}/{}_schema.json", path, module);
-    let mut schema_file = std::fs::File::create(filename).expect("Failed to create schema file");
-
-    std::io::Write::write_all(&mut schema_file, &json.into_bytes())
-        .expect("Failed to write to schema file");
-}
-
-fn to_snake_case(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    let mut chars = s.chars().peekable();
-    let mut is_first = true;
-
-    while let Some(c) = chars.next() {
-        if c.is_uppercase() {
-            if !is_first {
-                if let Some(next) = chars.peek() {
-                    if next.is_lowercase() {
-                        result.push('_');
-                    }
-                }
-            }
-            result.push(c.to_lowercase().next().unwrap());
-        } else {
-            result.push(c);
-        }
-        is_first = false;
-    }
-
-    result
+    odra_build::schema(unsafe { crate::module_schema() }, unsafe {
+        crate::casper_contract_schema()
+    });
 }

--- a/templates/cep78/_Cargo.toml
+++ b/templates/cep78/_Cargo.toml
@@ -13,6 +13,9 @@ edition = "2021"
 [build-dependencies]
 #odra_build_dependency
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+#odra_build_dependency
+
 [[bin]]
 name = "{{project-name}}_build_contract"
 path = "bin/build_contract.rs"

--- a/templates/cep78/bin/build_schema.rs
+++ b/templates/cep78/bin/build_schema.rs
@@ -10,60 +10,7 @@ extern "Rust" {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
-    let module = std::env::var("ODRA_MODULE").expect("ODRA_MODULE environment variable is not set");
-    let module = to_snake_case(&module);
-
-    let contract_schema = unsafe { crate::casper_contract_schema() };
-    let module_schema = unsafe { crate::module_schema() };
-
-    write_schema_file(
-        "resources/casper_contract_schemas",
-        &module,
-        contract_schema
-            .as_json()
-            .expect("Failed to convert schema to JSON")
-    );
-
-    write_schema_file(
-        "resources/legacy",
-        &module,
-        module_schema
-            .as_json()
-            .expect("Failed to convert schema to JSON")
-    );
-}
-
-fn write_schema_file(path: &str, module: &str, json: String) {
-    if !std::path::Path::new(path).exists() {
-        std::fs::create_dir_all(path).expect("Failed to create resources directory");
-    }
-    let filename = format!("{}/{}_schema.json", path, module);
-    let mut schema_file = std::fs::File::create(filename).expect("Failed to create schema file");
-
-    std::io::Write::write_all(&mut schema_file, &json.into_bytes())
-        .expect("Failed to write to schema file");
-}
-
-fn to_snake_case(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    let mut chars = s.chars().peekable();
-    let mut is_first = true;
-
-    while let Some(c) = chars.next() {
-        if c.is_uppercase() {
-            if !is_first {
-                if let Some(next) = chars.peek() {
-                    if next.is_lowercase() {
-                        result.push('_');
-                    }
-                }
-            }
-            result.push(c.to_lowercase().next().unwrap());
-        } else {
-            result.push(c);
-        }
-        is_first = false;
-    }
-
-    result
+    odra_build::schema(unsafe { crate::module_schema() }, unsafe {
+        crate::casper_contract_schema()
+    });
 }

--- a/templates/cep78/src/token.rs
+++ b/templates/cep78/src/token.rs
@@ -1,7 +1,7 @@
 use odra::{args::Maybe, prelude::*, Address, SubModule};
 use odra_modules::cep78::{
     modalities::{MetadataMutability, NFTIdentifierMode, NFTKind, NFTMetadataKind, OwnershipMode},
-    token::{Cep78, MintReceipt, TransferReceipt},
+    token::Cep78,
 };
 
 /// A module definition. Each module struct consists Vars and Mappings
@@ -76,7 +76,7 @@ impl MyToken {
                 token_owner: Address,
                 token_meta_data: String,
                 token_hash: Maybe<String>
-            ) -> MintReceipt;
+            );
 
             /// Burns the token with provided `token_id` argument, after which it is no
             /// longer possible to transfer it.
@@ -96,7 +96,7 @@ impl MyToken {
                 token_hash: Maybe<String>,
                 source_key: Address,
                 target_key: Address
-            ) -> TransferReceipt;
+            );
 
             /// Approves another token holder (an approved account) to transfer tokens. It
             /// reverts if token_id is invalid, if caller is not the owner nor operator, if token has already

--- a/templates/full/_Cargo.toml
+++ b/templates/full/_Cargo.toml
@@ -12,6 +12,9 @@ edition = "2021"
 [build-dependencies]
 #odra_build_dependency
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+#odra_build_dependency
+
 [[bin]]
 name = "{{project-name}}_build_contract"
 path = "bin/build_contract.rs"

--- a/templates/full/bin/build_schema.rs
+++ b/templates/full/bin/build_schema.rs
@@ -10,60 +10,7 @@ extern "Rust" {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
-    let module = std::env::var("ODRA_MODULE").expect("ODRA_MODULE environment variable is not set");
-    let module = to_snake_case(&module);
-
-    let contract_schema = unsafe { crate::casper_contract_schema() };
-    let module_schema = unsafe { crate::module_schema() };
-
-    write_schema_file(
-        "resources/casper_contract_schemas",
-        &module,
-        contract_schema
-            .as_json()
-            .expect("Failed to convert schema to JSON")
-    );
-
-    write_schema_file(
-        "resources/legacy",
-        &module,
-        module_schema
-            .as_json()
-            .expect("Failed to convert schema to JSON")
-    );
-}
-
-fn write_schema_file(path: &str, module: &str, json: String) {
-    if !std::path::Path::new(path).exists() {
-        std::fs::create_dir_all(path).expect("Failed to create resources directory");
-    }
-    let filename = format!("{}/{}_schema.json", path, module);
-    let mut schema_file = std::fs::File::create(filename).expect("Failed to create schema file");
-
-    std::io::Write::write_all(&mut schema_file, &json.into_bytes())
-        .expect("Failed to write to schema file");
-}
-
-fn to_snake_case(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    let mut chars = s.chars().peekable();
-    let mut is_first = true;
-
-    while let Some(c) = chars.next() {
-        if c.is_uppercase() {
-            if !is_first {
-                if let Some(next) = chars.peek() {
-                    if next.is_lowercase() {
-                        result.push('_');
-                    }
-                }
-            }
-            result.push(c.to_lowercase().next().unwrap());
-        } else {
-            result.push(c);
-        }
-        is_first = false;
-    }
-
-    result
+    odra_build::schema(unsafe { crate::module_schema() }, unsafe {
+        crate::casper_contract_schema()
+    });
 }

--- a/templates/workspace/flapper/Cargo.toml
+++ b/templates/workspace/flapper/Cargo.toml
@@ -12,6 +12,9 @@ odra-test = { workspace = true }
 [build-dependencies]
 odra-build = { workspace = true }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+#odra_build_dependency
+
 [[bin]]
 name = "flapper_build_contract"
 path = "bin/build_contract.rs"

--- a/templates/workspace/flapper/Cargo.toml
+++ b/templates/workspace/flapper/Cargo.toml
@@ -13,7 +13,7 @@ odra-test = { workspace = true }
 odra-build = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-#odra_build_dependency
+odra-build = { workspace = true }
 
 [[bin]]
 name = "flapper_build_contract"

--- a/templates/workspace/flapper/bin/build_schema.rs
+++ b/templates/workspace/flapper/bin/build_schema.rs
@@ -10,60 +10,7 @@ extern "Rust" {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
-    let module = std::env::var("ODRA_MODULE").expect("ODRA_MODULE environment variable is not set");
-    let module = to_snake_case(&module);
-
-    let contract_schema = unsafe { crate::casper_contract_schema() };
-    let module_schema = unsafe { crate::module_schema() };
-
-    write_schema_file(
-        "resources/casper_contract_schemas",
-        &module,
-        contract_schema
-            .as_json()
-            .expect("Failed to convert schema to JSON")
-    );
-
-    write_schema_file(
-        "resources/legacy",
-        &module,
-        module_schema
-            .as_json()
-            .expect("Failed to convert schema to JSON")
-    );
-}
-
-fn write_schema_file(path: &str, module: &str, json: String) {
-    if !std::path::Path::new(path).exists() {
-        std::fs::create_dir_all(path).expect("Failed to create resources directory");
-    }
-    let filename = format!("{}/{}_schema.json", path, module);
-    let mut schema_file = std::fs::File::create(filename).expect("Failed to create schema file");
-
-    std::io::Write::write_all(&mut schema_file, &json.into_bytes())
-        .expect("Failed to write to schema file");
-}
-
-fn to_snake_case(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    let mut chars = s.chars().peekable();
-    let mut is_first = true;
-
-    while let Some(c) = chars.next() {
-        if c.is_uppercase() {
-            if !is_first {
-                if let Some(next) = chars.peek() {
-                    if next.is_lowercase() {
-                        result.push('_');
-                    }
-                }
-            }
-            result.push(c.to_lowercase().next().unwrap());
-        } else {
-            result.push(c);
-        }
-        is_first = false;
-    }
-
-    result
+    odra_build::schema(unsafe { crate::module_schema() }, unsafe {
+        crate::casper_contract_schema()
+    });
 }

--- a/templates/workspace/flipper/Cargo.toml
+++ b/templates/workspace/flipper/Cargo.toml
@@ -13,7 +13,7 @@ odra-test = { workspace = true }
 odra-build = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-#odra_build_dependency
+odra-build = { workspace = true }
 
 [[bin]]
 name = "flipper_build_contract"

--- a/templates/workspace/flipper/Cargo.toml
+++ b/templates/workspace/flipper/Cargo.toml
@@ -12,6 +12,9 @@ odra-test = { workspace = true }
 [build-dependencies]
 odra-build = { workspace = true }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+#odra_build_dependency
+
 [[bin]]
 name = "flipper_build_contract"
 path = "bin/build_contract.rs"

--- a/templates/workspace/flipper/bin/build_schema.rs
+++ b/templates/workspace/flipper/bin/build_schema.rs
@@ -10,60 +10,7 @@ extern "Rust" {
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
-    let module = std::env::var("ODRA_MODULE").expect("ODRA_MODULE environment variable is not set");
-    let module = to_snake_case(&module);
-
-    let contract_schema = unsafe { crate::casper_contract_schema() };
-    let module_schema = unsafe { crate::module_schema() };
-
-    write_schema_file(
-        "resources/casper_contract_schemas",
-        &module,
-        contract_schema
-            .as_json()
-            .expect("Failed to convert schema to JSON")
-    );
-
-    write_schema_file(
-        "resources/legacy",
-        &module,
-        module_schema
-            .as_json()
-            .expect("Failed to convert schema to JSON")
-    );
-}
-
-fn write_schema_file(path: &str, module: &str, json: String) {
-    if !std::path::Path::new(path).exists() {
-        std::fs::create_dir_all(path).expect("Failed to create resources directory");
-    }
-    let filename = format!("{}/{}_schema.json", path, module);
-    let mut schema_file = std::fs::File::create(filename).expect("Failed to create schema file");
-
-    std::io::Write::write_all(&mut schema_file, &json.into_bytes())
-        .expect("Failed to write to schema file");
-}
-
-fn to_snake_case(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    let mut chars = s.chars().peekable();
-    let mut is_first = true;
-
-    while let Some(c) = chars.next() {
-        if c.is_uppercase() {
-            if !is_first {
-                if let Some(next) = chars.peek() {
-                    if next.is_lowercase() {
-                        result.push('_');
-                    }
-                }
-            }
-            result.push(c.to_lowercase().next().unwrap());
-        } else {
-            result.push(c);
-        }
-        is_first = false;
-    }
-
-    result
+    odra_build::schema(unsafe { crate::module_schema() }, unsafe {
+        crate::casper_contract_schema()
+    });
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added comprehensive error handling to the CEP-78 and CEP-18 token modules.
  - Introduced a new test contract schema for `TestCep78`.

- **Bug Fixes**
  - Updated return types for multiple functions in CEP-78 to improve consistency and error reporting.

- **Refactor**
  - Simplified schema generation across various modules by centralizing the logic in `odra_build::schema`.
  - Removed unnecessary schema functions and types to streamline the codebase.

- **Chores**
  - Added conditional dependencies for non-"wasm32" targets in multiple `Cargo.toml` files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->