### PR TITLE
Improve UnwrapOrRevert interface

### DIFF
--- a/core/src/mapping.rs
+++ b/core/src/mapping.rs
@@ -7,7 +7,7 @@ use crate::module::{ModuleComponent, ModulePrimitive, Revertible};
 use crate::{
     module::{Module, SubModule},
     var::Var,
-    ContractEnv, UnwrapOrRevert
+    ContractEnv
 };
 use crate::{prelude::*, OdraError};
 use core::fmt::Debug;
@@ -91,9 +91,8 @@ impl<K: ToBytes, V: ToBytes + FromBytes + CLTyped + OverflowingAdd + Default> Ma
     /// If the operation fails due to overflow, the currently executing contract reverts.
     pub fn add(&mut self, key: &K, value: V) {
         let env = self.env_for_key(key);
-        let current_value = Var::<V>::instance(Rc::new(env.clone()), self.index).get_or_default();
-        let new_value = current_value.overflowing_add(value).unwrap_or_revert(self);
-        Var::<V>::instance(Rc::new(env), self.index).set(new_value);
+        let mut var = Var::<V>::instance(Rc::new(env), self.index);
+        var.add(value);
     }
 }
 
@@ -108,8 +107,7 @@ impl<
     /// If the operation fails due to overflow, the currently executing contract reverts.
     pub fn subtract(&mut self, key: &K, value: V) {
         let env = self.env_for_key(key);
-        let current_value = Var::<V>::instance(Rc::new(env.clone()), self.index).get_or_default();
-        let new_value = current_value.overflowing_sub(value).unwrap_or_revert(self);
-        Var::<V>::instance(Rc::new(env), self.index).set(new_value);
+        let mut var = Var::<V>::instance(Rc::new(env), self.index);
+        var.subtract(value);
     }
 }

--- a/core/src/sequence.rs
+++ b/core/src/sequence.rs
@@ -1,4 +1,4 @@
-use crate::prelude::*;
+use crate::module::Revertible;
 use crate::{
     casper_types::{
         bytesrepr::{FromBytes, ToBytes},
@@ -7,6 +7,7 @@ use crate::{
     module::{ModuleComponent, ModulePrimitive},
     ContractEnv
 };
+use crate::{prelude::*, OdraError};
 use num_traits::{Num, One, Zero};
 
 use crate::Var;
@@ -19,6 +20,15 @@ where
     env: Rc<ContractEnv>,
     index: u8,
     value: Var<T>
+}
+
+impl<T> Revertible for Sequence<T>
+where
+    T: Num + One + Zero + Default + Copy + ToBytes + FromBytes + CLTyped
+{
+    fn revert<E: Into<OdraError>>(&self, e: E) -> ! {
+        self.env.revert(e)
+    }
 }
 
 impl<T> Sequence<T>

--- a/core/src/unwrap_or_revert.rs
+++ b/core/src/unwrap_or_revert.rs
@@ -1,4 +1,4 @@
-use crate::{ContractEnv, ExecutionError, OdraError};
+use crate::{module::Revertible, ExecutionError, OdraError};
 
 /// A trait that allows safe unwrapping in the context of a smart contract.
 /// On failure the contract does not panic, but reverts calling [`ContractEnv::revert`](crate::ContractEnv::revert()).
@@ -6,28 +6,28 @@ use crate::{ContractEnv, ExecutionError, OdraError};
 pub trait UnwrapOrRevert<T> {
     /// On success, unwraps the value into its inner type,
     /// on failure, calls [`ContractEnv::revert`](crate::ContractEnv::revert()) with the passed error.
-    fn unwrap_or_revert_with<E: Into<OdraError>>(self, env: &ContractEnv, err: E) -> T;
+    fn unwrap_or_revert_with<E: Into<OdraError>, M: Revertible>(self, rev: &M, err: E) -> T;
     /// On success, unwraps the value into its inner type,
     /// on failure, calls [`ContractEnv::revert`](crate::ContractEnv::revert()) with the default error.
-    fn unwrap_or_revert(self, env: &ContractEnv) -> T;
+    fn unwrap_or_revert<M: Revertible>(self, rev: &M) -> T;
 }
 
 impl<T, E: Into<OdraError>> UnwrapOrRevert<T> for Result<T, E> {
-    fn unwrap_or_revert_with<F: Into<OdraError>>(self, env: &ContractEnv, err: F) -> T {
-        self.unwrap_or_else(|_| env.revert(err))
+    fn unwrap_or_revert_with<F: Into<OdraError>, M: Revertible>(self, rev: &M, err: F) -> T {
+        self.unwrap_or_else(|_| rev.revert(err))
     }
 
-    fn unwrap_or_revert(self, env: &ContractEnv) -> T {
-        self.unwrap_or_else(|err| env.revert(err))
+    fn unwrap_or_revert<M: Revertible>(self, rev: &M) -> T {
+        self.unwrap_or_else(|err| rev.revert(err))
     }
 }
 
 impl<T> UnwrapOrRevert<T> for Option<T> {
-    fn unwrap_or_revert_with<E: Into<OdraError>>(self, env: &ContractEnv, err: E) -> T {
-        self.unwrap_or_else(|| env.revert(err))
+    fn unwrap_or_revert_with<E: Into<OdraError>, M: Revertible>(self, rev: &M, err: E) -> T {
+        self.unwrap_or_else(|| rev.revert(err))
     }
 
-    fn unwrap_or_revert(self, env: &ContractEnv) -> T {
-        self.unwrap_or_else(|| env.revert(ExecutionError::UnwrapError))
+    fn unwrap_or_revert<M: Revertible>(self, rev: &M) -> T {
+        self.unwrap_or_else(|| rev.revert(ExecutionError::UnwrapError))
     }
 }

--- a/core/src/var.rs
+++ b/core/src/var.rs
@@ -83,9 +83,11 @@ impl<V: ToBytes + FromBytes + CLTyped + OverflowingAdd + Default> Var<V> {
     /// If the operation fails due to overflow, the currently executing contract reverts.
     #[inline(always)]
     pub fn add(&mut self, value: V) {
-        let current_value = self.get_or_default();
+        let env = self.env();
+        let key = env.current_key();
+        let current_value = env.get_value::<V>(&key).unwrap_or_default();
         let new_value = current_value.overflowing_add(value).unwrap_or_revert(self);
-        self.set(new_value);
+        env.set_value(&key, new_value);
     }
 }
 
@@ -96,8 +98,10 @@ impl<V: ToBytes + FromBytes + CLTyped + OverflowingSub + Default> Var<V> {
     /// If the operation fails due to overflow, the currently executing contract reverts.
     #[inline(always)]
     pub fn subtract(&mut self, value: V) {
-        let current_value = self.get().unwrap_or_default();
+        let env = self.env();
+        let key = env.current_key();
+        let current_value = env.get_value::<V>(&key).unwrap_or_default();
         let new_value = current_value.overflowing_sub(value).unwrap_or_revert(self);
-        self.set(new_value);
+        env.set_value(&key, new_value);
     }
 }

--- a/examples/src/features/cross_calls.rs
+++ b/examples/src/features/cross_calls.rs
@@ -18,7 +18,7 @@ impl CrossContract {
 
     /// Adds 3 and 5 using the math engine contract.
     pub fn add_using_another(&self) -> u32 {
-        let math_engine_address = self.math_engine.get().unwrap_or_revert(&self.env());
+        let math_engine_address = self.math_engine.get().unwrap_or_revert(self);
         MathEngineContractRef::new(self.env(), math_engine_address).add(3, 5)
     }
 }

--- a/examples/src/features/livenet.rs
+++ b/examples/src/features/livenet.rs
@@ -40,7 +40,7 @@ impl LivenetContract {
 
     /// Pops a value from the stack.
     pub fn pop_from_stack(&mut self) -> u64 {
-        self.stack.pop().unwrap_or_revert(&self.env())
+        self.stack.pop().unwrap_or_revert(self)
     }
 
     /// Returns the length of the stack.

--- a/examples/src/features/module_nesting.rs
+++ b/examples/src/features/module_nesting.rs
@@ -61,7 +61,7 @@ impl NestedOdraTypesContract {
                 self.current_generation_storage
                     .results
                     .get(&key)
-                    .unwrap_or_revert(&self.env())
+                    .unwrap_or_revert(self)
             })
             .collect()
     }

--- a/modules/src/cep18/storage.rs
+++ b/modules/src/cep18/storage.rs
@@ -52,7 +52,7 @@ impl Cep18BalancesStorage {
     /// Adds the given amount to the balance of the given account.
     pub fn add(&self, account: &Address, amount: U256) {
         let balance = self.get(account).unwrap_or_default();
-        let new_balance = balance.checked_add(amount).unwrap_or_revert(&self.env());
+        let new_balance = balance.checked_add(amount).unwrap_or_revert(self);
         self.set(account, new_balance);
     }
 
@@ -61,7 +61,7 @@ impl Cep18BalancesStorage {
         let balance = self.get(account).unwrap_or_default();
         let new_balance = balance
             .checked_sub(amount)
-            .unwrap_or_revert_with(&self.env(), Overflow);
+            .unwrap_or_revert_with(self, Overflow);
         self.set(account, new_balance);
     }
 }

--- a/modules/src/cep18_token.rs
+++ b/modules/src/cep18_token.rs
@@ -96,7 +96,7 @@ impl Cep18 {
         let caller_badge = self
             .security_badges
             .get(&caller)
-            .unwrap_or_revert_with(&self.env(), Error::InsufficientRights);
+            .unwrap_or_revert_with(self, Error::InsufficientRights);
 
         if !caller_badge.can_admin() {
             self.env().revert(Error::InsufficientRights);
@@ -234,7 +234,7 @@ impl Cep18 {
             recipient,
             allowance
                 .checked_sub(*amount)
-                .unwrap_or_revert_with(&self.env(), Error::InsufficientAllowance)
+                .unwrap_or_revert_with(self, Error::InsufficientAllowance)
         );
         self.env().emit_event(TransferFrom {
             spender,
@@ -254,7 +254,7 @@ impl Cep18 {
         let security_badge = self
             .security_badges
             .get(&self.env().caller())
-            .unwrap_or_revert_with(&self.env(), Error::InsufficientRights);
+            .unwrap_or_revert_with(self, Error::InsufficientRights);
         if !security_badge.can_mint() {
             self.env().revert(Error::InsufficientRights);
         }

--- a/modules/src/cep78/metadata.rs
+++ b/modules/src/cep78/metadata.rs
@@ -100,7 +100,7 @@ impl Metadata {
             if req == &Requirement::Required || req == &Requirement::Optional {
                 serde_json_wasm::from_str::<CustomMetadataSchema>(&json_schema)
                     .map_err(|_| CEP78Error::InvalidJsonSchema)
-                    .unwrap_or_revert(&self.env());
+                    .unwrap_or_revert(self);
             }
         }
         self.nft_metadata_kind.set(base_metadata_kind);
@@ -301,7 +301,7 @@ impl Metadata {
             NFTMetadataKind::CustomValidated => {
                 serde_json_wasm::from_str::<CustomMetadataSchema>(&self.json_schema.get())
                     .map_err(|_| CEP78Error::InvalidJsonSchema)
-                    .unwrap_or_revert(&self.env())
+                    .unwrap_or_revert(self)
             }
         }
     }

--- a/modules/src/cep78/reverse_lookup.rs
+++ b/modules/src/cep78/reverse_lookup.rs
@@ -87,7 +87,7 @@ impl ReverseLookup {
 
         self.hash_by_index.set(
             &current_number_of_minted_tokens,
-            token_identifier.get_hash().unwrap_or_revert(&self.env())
+            token_identifier.get_hash().unwrap_or_revert(self)
         );
         self.index_by_hash.set(
             &token_identifier.to_string(),
@@ -236,7 +236,7 @@ impl ReverseLookup {
             vec![false; PAGE_SIZE as usize]
         } else {
             env.get_dictionary_value(&page_dict, new_item_key.as_bytes())
-                .unwrap_or_revert(&env)
+                .unwrap_or_revert(self)
         };
 
         let _ = core::mem::replace(&mut target_page[page_address as usize], true);

--- a/modules/src/cep78/token.rs
+++ b/modules/src/cep78/token.rs
@@ -586,8 +586,7 @@ impl Cep78 {
         let number_of_minted_tokens = self.data.number_of_minted_tokens();
         if let NFTIdentifierMode::Ordinal = identifier_mode {
             // Revert if token_id is out of bounds
-            if token_identifier.get_index().unwrap_or_revert(&self.__env) >= number_of_minted_tokens
-            {
+            if token_identifier.get_index().unwrap_or_revert(self) >= number_of_minted_tokens {
                 self.revert(CEP78Error::InvalidTokenIdentifier);
             }
         }

--- a/modules/src/wrapped_native.rs
+++ b/modules/src/wrapped_native.rs
@@ -28,7 +28,7 @@ impl WrappedNativeToken {
 
         let amount = self.env().attached_value();
 
-        let amount = amount.to_u256().unwrap_or_revert(&self.env());
+        let amount = amount.to_u256().unwrap_or_revert(self);
         self.erc20.mint(&caller, &amount);
 
         self.env().emit_event(Deposit {


### PR DESCRIPTION
* Add Revertible trait
* unwrap_or_revert accepts revertible - reduces ContractEnv cloning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new `Revertible` trait with a `revert` method to handle contract execution reversals.
  
- **Bug Fixes**
  - Enhanced error handling across multiple modules by refactoring the use of `unwrap_or_revert` methods to improve reliability.

- **Refactor**
  - Updated method calls to remove references to `&self.env()` and instead use `self` for better consistency and cleaner code.
  - Consolidated import statements for improved code maintainability.

- **Documentation**
  - Adjusted public entity declarations to reflect the new `Revertible` trait and associated method changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->