### PR TITLE
Now out of gas error can be handled in livenet.

### DIFF
--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -133,6 +133,8 @@ pub enum ExecutionError {
     EmptyDictionaryName = 121,
     /// Calling a contract with missing entrypoint arguments.
     MissingArg = 122,
+    /// Out of gas error
+    OutOfGas = 123,
     /// Maximum code for user errors
     MaxUserError = 64535,
     /// User error too high. The code should be in range 0..32767.

--- a/examples/bin/livenet_tests.rs
+++ b/examples/bin/livenet_tests.rs
@@ -2,6 +2,7 @@
 use odra::casper_types::U256;
 use odra::host::{Deployer, HostEnv, HostRef, HostRefLoader};
 use odra::Address;
+use odra::ExecutionError;
 use odra_examples::features::livenet::{LivenetContractHostRef, LivenetContractInitArgs};
 use odra_modules::access::events::OwnershipTransferred;
 use odra_modules::erc20::{Erc20HostRef, Erc20InitArgs};
@@ -18,6 +19,11 @@ fn main() {
 
     // Contract can be loaded
     let (mut contract, erc20) = load(&env, *contract.address(), *erc20.address());
+
+    // Errors can be handled
+    env.set_gas(1_000u64);
+    let result = contract.try_push_on_stack(1).unwrap_err();
+    assert_eq!(result, ExecutionError::OutOfGas.into());
 
     // Set gas will be used for all subsequent calls
     env.set_gas(1_000_000_000u64);

--- a/justfile
+++ b/justfile
@@ -95,6 +95,9 @@ test-templates:
     just test-template workspace
     just test-template cep78
 
+run-nctl:
+    docker run --rm -it --name mynctl -d -p 11101:11101 -p 14101:14101 -p 18101:18101 makesoftware/casper-nctl:v155
+
 test-livenet:
     set shell := bash
     mkdir -p examples/.node-keys


### PR DESCRIPTION
#364 seems to be fixed by previous errors PR by @kpob 
This one adds a test to avoid regression and adds an ExecutionError to allow handling oog error in tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added error handling for "Out of Gas" scenarios to improve user feedback during execution failures.

- **Chores**
  - Introduced a new target `run-nctl` in the build configuration to streamline Docker container setup for specific network uses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->