### PR TITLE
Correct name of metadata named key in cep95

### DIFF
--- a/modules/src/cep95.rs
+++ b/modules/src/cep95.rs
@@ -164,7 +164,7 @@ const KEY_NAME: &str = "name";
 const KEY_SYMBOL: &str = "symbol";
 const KEY_APPROVED: &str = "approvals";
 const KEY_OPERATORS: &str = "operators";
-const KEY_METADATA: &str = "metadata";
+const KEY_METADATA: &str = "token_metadata";
 const KEY_OWNERS: &str = "owners";
 
 single_value_storage!(Cep95Name, String, KEY_NAME, Error::ValueNotSet);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the internal key used for storing and retrieving token metadata. No changes to app functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->