### PR TITLE
CEP95 `mint` does not emit the MetadataUpdated event.

### DIFF
--- a/modules/src/cep95.rs
+++ b/modules/src/cep95.rs
@@ -455,7 +455,7 @@ impl Cep95 {
 
         self.balances.set(&to, self.balance_of(to) + 1);
         self.owners.set(&token_id, Some(to));
-        self.set_metadata(token_id, metadata);
+        self.metadata.set(&token_id, BTreeMap::from_iter(metadata));
 
         self.env().emit_event(Mint { to, token_id });
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the way NFT metadata is stored during minting, resulting in more direct and efficient metadata assignment. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->