### PR TITLE
Enforce named keys in cep18 and cep95

### DIFF
--- a/core/src/contract_context.rs
+++ b/core/src/contract_context.rs
@@ -67,6 +67,12 @@ pub trait ContractContext {
     /// * `dictionary_name` - The name of the dictionary.
     fn remove_dictionary(&self, dictionary_name: &str);
 
+    /// Initializes the empty dictionary with the given name.
+    ///
+    /// # Arguments
+    /// * `dictionary_name` - The name of the dictionary to initialize.
+    fn init_dictionary(&self, dictionary_name: &str);
+
     /// Retrieves the address of the caller.
     fn caller(&self) -> Address;
 

--- a/core/src/contract_env.rs
+++ b/core/src/contract_env.rs
@@ -164,6 +164,12 @@ impl ContractEnv {
         self.backend.borrow().remove_dictionary(dictionary_name);
     }
 
+    /// Initializes the empty dictionary with the given name.
+    pub fn init_dictionary<U: AsRef<str>>(&self, dictionary_name: U) {
+        let dictionary_name = dictionary_name.as_ref();
+        self.backend.borrow().init_dictionary(dictionary_name);
+    }
+
     /// Returns the address of the caller of the contract.
     pub fn caller(&self) -> Address {
         let backend = self.backend.borrow();

--- a/core/src/named_keys.rs
+++ b/core/src/named_keys.rs
@@ -37,8 +37,10 @@ macro_rules! single_value_storage {
 }
 
 /// Creates an Odra module that stores a values in a given dictionary.
-/// The module has two methods: `set` and `get`.
+///
+/// The module has three methods: `set`, `get` and `init`.
 /// The `key` argument of `set` and `get` is used as a dictionary key.
+/// The `init` method initializes the dictionary with the given name.
 #[macro_export]
 macro_rules! key_value_storage {
     ($name:ident, $dict:expr, $value_type:ty) => {
@@ -54,14 +56,19 @@ macro_rules! key_value_storage {
             pub fn get(&self, key: &str) -> Option<$value_type> {
                 self.env().get_dictionary_value($dict, key.as_bytes())
             }
+
+            pub fn init(&self) {
+                self.env().init_dictionary($dict);
+            }
         }
     };
 }
 
 /// Creates an Odra module that stores a values in a given dictionary.
 ///
-/// The module has two methods: `set` and `get`.
+/// The module has three methods: `set`, `get` and `init`.
 /// The `key` argument of `set` and `get` is base64-encoded and then used as a dictionary key.
+/// The `init` method initializes the dictionary with the given name.
 #[macro_export]
 macro_rules! base64_encoded_key_value_storage {
     ($name:ident, $dict:expr, $key:ty, $value_type:ty) => {
@@ -81,6 +88,10 @@ macro_rules! base64_encoded_key_value_storage {
                     .get_dictionary_value($dict, encoded_key.as_bytes())
             }
 
+            pub fn init(&self) {
+                self.env().init_dictionary($dict);
+            }
+
             #[inline]
             fn key<R: odra::module::Revertible>(rev: &R, key: &$key) -> String {
                 use base64::prelude::{Engine, BASE64_STANDARD};
@@ -94,9 +105,10 @@ macro_rules! base64_encoded_key_value_storage {
 
 /// Creates an Odra module that stores a values in a given dictionary.
 ///
-/// The module has two methods: `set` and `get`.
+/// The module has three methods: `set`, `get` and `init`.
 /// The `key1` and `key2` arguments of `set` and `get` are converted to bytes, combined into a single bytes vector,
 /// and finally hex-encoded and then used as a dictionary key.
+/// The `init` method initializes the dictionary with the given name.
 #[macro_export]
 macro_rules! compound_key_value_storage {
     ($name:ident, $dict:expr, $k1_type:ty, $k2_type:ty, $value_type:ty) => {
@@ -126,6 +138,10 @@ macro_rules! compound_key_value_storage {
                 let key_bytes = env.hash(&preimage);
                 odra::utils::hex_to_slice(&key_bytes, &mut key);
                 env.get_dictionary_value($dict, &key).unwrap_or_default()
+            }
+
+            pub fn init(&self) {
+                self.env().init_dictionary($dict);
             }
         }
     };

--- a/modules/src/cep18_token.rs
+++ b/modules/src/cep18_token.rs
@@ -40,26 +40,22 @@ impl Cep18 {
         self.decimals.set(decimals);
         self.total_supply.set(initial_supply);
 
-        // Set the initial balance of the caller.
-        //
-        // NOTE: This is executed also if the initial supply is zero, so the
-        // `balances` named key is initialized.
-        self.balances.set(&caller, initial_supply);
-
-        // If the initial supply is not zero, emit a Mint event.
         if !initial_supply.is_zero() {
+            // If the initial supply is not zero:
+            // - mint the initial supply to the caller,
+            // - emit the `Mint` event.
+            self.balances.set(&caller, initial_supply);
             self.env().emit_event(Mint {
                 recipient: caller,
                 amount: initial_supply
             });
+        } else {
+            // If the initial supply is zero, initialize `balances`.
+            self.balances.init();
         }
 
-        // NOTE: Allow the current contract to spend zero tokens on behalf of
-        // the caller. Zero is the default value, so it doesn't really change
-        // anything. By doing so, the `allowances` named key is initialized,
-        // which is a good practice.
-        let self_address = self.env().self_address();
-        self.allowances.set(&self_address, &caller, U256::zero());
+        // Initialize allowances.
+        self.allowances.init();
     }
 
     /// Returns the name of the token.

--- a/modules/src/cep18_token.rs
+++ b/modules/src/cep18_token.rs
@@ -33,20 +33,33 @@ impl Cep18 {
     /// Initializes the contract with the given metadata, initial supply.
     pub fn init(&mut self, symbol: String, name: String, decimals: u8, initial_supply: U256) {
         let caller = self.env().caller();
-        // set the metadata
+
+        // Set the metadata
         self.symbol.set(symbol);
         self.name.set(name);
         self.decimals.set(decimals);
         self.total_supply.set(initial_supply);
 
+        // Set the initial balance of the caller.
+        //
+        // NOTE: This is executed also if the initial supply is zero, so the
+        // `balances` named key is initialized.
+        self.balances.set(&caller, initial_supply);
+
+        // If the initial supply is not zero, emit a Mint event.
         if !initial_supply.is_zero() {
-            // mint the initial supply for the caller
-            self.balances.set(&caller, initial_supply);
             self.env().emit_event(Mint {
                 recipient: caller,
                 amount: initial_supply
             });
         }
+
+        // NOTE: Allow the current contract to spend zero tokens on behalf of
+        // the caller. Zero is the default value, so it doesn't really change
+        // anything. By doing so, the `allowances` named key is initialized,
+        // which is a good practice.
+        let self_address = self.env().self_address();
+        self.allowances.set(&self_address, &caller, U256::zero());
     }
 
     /// Returns the name of the token.

--- a/modules/src/cep95.rs
+++ b/modules/src/cep95.rs
@@ -420,8 +420,16 @@ impl CEP95Interface for Cep95 {
 impl Cep95 {
     /// Initializes the module with a name and symbol.
     pub fn init(&mut self, name: String, symbol: String) {
+        // Initialize the name and symbol.
         self.name.set(name);
         self.symbol.set(symbol);
+
+        // Initialize dictionaries.
+        self.balances.init();
+        self.owners.init();
+        self.approvals.init();
+        self.operators.init();
+        self.metadata.init();
     }
 
     #[inline]

--- a/odra-casper/livenet-env/src/livenet_contract_env.rs
+++ b/odra-casper/livenet-env/src/livenet_contract_env.rs
@@ -63,6 +63,10 @@ impl ContractContext for LivenetContractEnv {
         panic!("Cannot remove dictionary value in LivenetEnv without a deploy")
     }
 
+    fn init_dictionary(&self, _dictionary_name: &str) {
+        panic!("Cannot initialize dictionary in LivenetEnv without a deploy")
+    }
+
     fn caller(&self) -> Address {
         *self.callstack.borrow().first().address()
     }

--- a/odra-casper/wasm-env/src/host_functions.rs
+++ b/odra-casper/wasm-env/src/host_functions.rs
@@ -290,6 +290,13 @@ pub fn remove_dictionary(dictionary_name: &str) {
     runtime::remove_key(dictionary_name);
 }
 
+/// Initializes an empty dictionary with the given name if it does not exist.
+#[inline]
+pub fn init_dictionary(dictionary_name: &str) {
+    // Reuse `get_dictionary` to create a new dictionary if it does not exist.
+    let _ = get_dictionary(dictionary_name);
+}
+
 /// Gets a value under a key in a dictionary from the contract's storage.
 pub fn get_dictionary_value(dictionary_name: &str, key: &[u8]) -> Option<Bytes> {
     let dictionary_uref = get_dictionary(dictionary_name);

--- a/odra-casper/wasm-env/src/wasm_contract_env.rs
+++ b/odra-casper/wasm-env/src/wasm_contract_env.rs
@@ -42,6 +42,10 @@ impl ContractContext for WasmContractEnv {
         host_functions::remove_dictionary(dictionary_name);
     }
 
+    fn init_dictionary(&self, dictionary_name: &str) {
+        host_functions::init_dictionary(dictionary_name);
+    }
+
     fn caller(&self) -> Address {
         host_functions::caller().unwrap_or_else(|e| self.revert(e))
     }

--- a/odra-vm/src/odra_vm_contract_env.rs
+++ b/odra-vm/src/odra_vm_contract_env.rs
@@ -46,6 +46,10 @@ impl ContractContext for OdraVmContractEnv {
         self.vm.borrow().remove_dictionary(dictionary_name);
     }
 
+    fn init_dictionary(&self, dictionary_name: &str) {
+        // no-op, dictionaries are initialized automatically in Odra VM
+    }
+
     fn caller(&self) -> Address {
         self.vm.borrow().caller()
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured initial balances and allowances storage are properly initialized regardless of token supply.
  
- **New Features**
  - Added dictionary initialization support across multiple contract environments and storage modules.
  - Extended token contract initialization to include internal dictionary setups for balances, owners, approvals, operators, and metadata.

- **Documentation**
  - Clarified comments describing initialization processes for balances and allowances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->