### PR TITLE
Value parsing improvement

### DIFF
--- a/odra-cli/src/cmd/args.rs
+++ b/odra-cli/src/cmd/args.rs
@@ -1,11 +1,8 @@
 use std::any::Any;
 
-use crate::parser::{CLTypedParser, GenericCLValueParser};
+use crate::parser::{CLTypedParser, CsprTokenAmountParser, GasParser};
 use clap::{builder::PathBufValueParser, ArgAction, ArgMatches};
-use odra::{
-    casper_types::{bytesrepr::FromBytes, CLTyped, CLValue, U512},
-    schema::casper_contract_schema::NamedCLType
-};
+use odra::schema::casper_contract_schema::NamedCLType;
 
 pub const ARG_ATTACHED_VALUE: &str = "attached_value";
 pub const ARG_GAS: &str = "gas";
@@ -121,8 +118,8 @@ fn arg_attached_value() -> clap::Arg {
         .help("The amount of CSPRs attached to the call")
         .long(ARG_ATTACHED_VALUE)
         .required(false)
-        .value_name(format!("{:?}", NamedCLType::U512))
-        .value_parser(GenericCLValueParser::<U512>::new())
+        .value_name("CSPR")
+        .value_parser(CsprTokenAmountParser)
         .action(ArgAction::Set)
 }
 
@@ -131,8 +128,8 @@ fn arg_gas() -> clap::Arg {
         .help("The amount of gas to attach to the call")
         .long(ARG_GAS)
         .required(true)
-        .value_name(format!("{:?}", NamedCLType::U64))
-        .value_parser(clap::value_parser!(u64).range(2_500_000_000..))
+        .value_name("CSPR")
+        .value_parser(GasParser)
         .action(ArgAction::Set)
 }
 
@@ -170,16 +167,4 @@ pub fn read_arg<T: ToOwned<Owned = T> + Any + Clone + Send + Sync + 'static>(
     arg: Arg
 ) -> Option<T> {
     matches.get_one::<T>(arg.name()).map(ToOwned::to_owned)
-}
-
-pub fn read_cl_value_arg<
-    T: CLTyped + FromBytes + ToOwned<Owned = T> + Any + Clone + Send + Sync + 'static
->(
-    matches: &ArgMatches,
-    arg: Arg
-) -> Option<T> {
-    matches
-        .get_one::<CLValue>(arg.name())
-        .map(ToOwned::to_owned)
-        .and_then(|cl_value| cl_value.into_t::<T>().ok())
 }

--- a/odra-cli/src/entry_point.rs
+++ b/odra-cli/src/entry_point.rs
@@ -5,7 +5,7 @@ use odra::schema::casper_contract_schema::{Entrypoint, NamedCLType};
 use odra::VmError;
 use odra::{casper_types::U512, host::HostEnv, CallDef};
 
-use crate::cmd::args::{read_arg, read_cl_value_arg, Arg, ArgsError, ARG_PRINT_EVENTS};
+use crate::cmd::args::{read_arg, Arg, ArgsError, ARG_PRINT_EVENTS};
 use crate::container::ContractProvider;
 use crate::custom_types::CustomTypeSet;
 use crate::{container, types};
@@ -49,7 +49,7 @@ pub fn call<T: ContractProvider>(
     types: &CustomTypeSet,
     contract_provider: &T
 ) -> Result<String, CallError> {
-    let amount = read_cl_value_arg::<U512>(args, Arg::AttachedValue).unwrap_or_default();
+    let amount = read_arg::<U512>(args, Arg::AttachedValue).unwrap_or_default();
 
     let runtime_args = runtime_args::compose(entry_point, args, types)?;
     let contract_address = contract_provider

--- a/odra-cli/src/parser.rs
+++ b/odra-cli/src/parser.rs
@@ -1,6 +1,6 @@
 use clap::{builder::TypedValueParser, error::ErrorKind, Arg, Command, Error};
 use odra::{
-    casper_types::CLValue,
+    casper_types::{CLValue, U512},
     schema::{casper_contract_schema::NamedCLType, NamedCLTyped}
 };
 
@@ -92,5 +92,133 @@ impl TypedValueParser for CLTypedParser {
         })?;
         let cl_type = types::named_cl_type_to_cl_type(&self.ty);
         Ok(CLValue::from_components(cl_type, bytes))
+    }
+}
+
+#[derive(Clone)]
+#[non_exhaustive]
+pub struct CsprTokenAmountParser;
+
+impl TypedValueParser for CsprTokenAmountParser {
+    type Value = U512;
+
+    fn parse_ref(
+        &self,
+        cmd: &Command,
+        _arg: Option<&Arg>,
+        value: &std::ffi::OsStr
+    ) -> Result<Self::Value, Error> {
+        let value = value
+            .to_str()
+            .ok_or_else(|| Error::new(ErrorKind::InvalidUtf8).with_cmd(cmd))?;
+
+        parse_cspr_token_amount(value).map_err(|e| Error::raw(ErrorKind::InvalidValue, e))
+    }
+}
+
+#[derive(Clone)]
+#[non_exhaustive]
+pub struct GasParser;
+
+impl TypedValueParser for GasParser {
+    type Value = u64;
+
+    fn parse_ref(
+        &self,
+        cmd: &Command,
+        arg: Option<&Arg>,
+        value: &std::ffi::OsStr
+    ) -> Result<Self::Value, Error> {
+        let parsed_value = CsprTokenAmountParser.parse_ref(cmd, arg, value)?;
+        if parsed_value < U512::from(2_500_000_000u64) {
+            Err(Error::raw(
+                ErrorKind::ValueValidation,
+                "Gas must be at least 2.5 CSPR (2,500,000,000 motes).\n"
+            ))
+        } else {
+            Ok(parsed_value.as_u64())
+        }
+    }
+}
+
+fn parse_cspr_token_amount(value: &str) -> Result<U512, &'static str> {
+    if let Ok(motes) = value.parse::<u64>() {
+        return Ok(U512::from(motes));
+    }
+
+    let value = value.trim().to_lowercase();
+    let value = value.strip_suffix("cspr").unwrap_or(&value).trim();
+
+    let parts: Vec<_> = value.split('.').collect();
+    if parts.len() > 2 {
+        return Err("Invalid CSPR amount.");
+    }
+
+    let integer_part = parts[0]
+        .parse::<u64>()
+        .map(U512::from)
+        .map(|v| v * 1_000_000_000)
+        .map_err(|_| "Invalid CSPR amount.")?;
+
+    if parts.len() == 1 {
+        return Ok(integer_part);
+    }
+
+    let fractional_part_str = parts[1];
+    if fractional_part_str.len() > 9 {
+        return Err("Invalid CSPR amount: too many fractional digits.");
+    }
+    let fractional_part = fractional_part_str
+        .parse::<u64>()
+        .map(U512::from)
+        .map_err(|_| "Invalid CSPR amount.")?;
+
+    let fractional_part =
+        fractional_part * U512::from(10).pow(U512::from(9 - fractional_part_str.len()));
+
+    Ok(integer_part + fractional_part)
+}
+
+#[cfg(test)]
+mod tests {
+    use odra::casper_types::U512;
+
+    use super::parse_cspr_token_amount;
+
+    #[test]
+    fn test_parse_cspr_token_amount() {
+        assert_eq!(parse_cspr_token_amount("1000").unwrap(), U512::from(1000));
+        assert_eq!(
+            parse_cspr_token_amount("1000cspr").unwrap(),
+            U512::from(1_000_000_000_000u64)
+        );
+        assert_eq!(
+            parse_cspr_token_amount("1000 cspr").unwrap(),
+            U512::from(1_000_000_000_000u64)
+        );
+        assert_eq!(
+            parse_cspr_token_amount("2.6 cspr").unwrap(),
+            U512::from(2_600_000_000u64)
+        );
+        assert_eq!(
+            parse_cspr_token_amount("0.123456789 cspr").unwrap(),
+            U512::from(123_456_789)
+        );
+        assert_eq!(
+            parse_cspr_token_amount("0.123 cspr").unwrap(),
+            U512::from(123_000_000)
+        );
+        assert!(
+            parse_cspr_token_amount("0.1234567890 cspr").is_err(),
+            "Too many fractional digits should be an error."
+        );
+        assert!(
+            parse_cspr_token_amount("1.2.3 cspr").is_err(),
+            "Multiple dots should be an error."
+        );
+        assert!(
+            parse_cspr_token_amount("cspr").is_err(),
+            "Empty amount should be an error."
+        );
     }
 }

--- a/odra-cli/src/types/error.rs
+++ b/odra-cli/src/types/error.rs
@@ -41,6 +41,7 @@ pub enum Format {
     Map,
     ByteArray,
     InvalidLength { actual: usize, expected: usize },
+    PatternLength { actual: usize, expected: usize },
     U8
 }
 
@@ -81,7 +82,11 @@ impl Format {
                 String::from("'0b00000001'"),
                 String::from("'1'"),
                 String::from("'255'"),
-            ]
+            ],
+            Format::PatternLength { actual, expected } => vec![format!(
+                "pattern length {} does not divide expected length {}",
+                actual, expected
+            )],
         }
     }
 }

--- a/odra-cli/src/types/error.rs
+++ b/odra-cli/src/types/error.rs
@@ -86,7 +86,7 @@ impl Format {
             Format::PatternLength { actual, expected } => vec![format!(
                 "pattern length {} does not divide expected length {}",
                 actual, expected
-            )],
+            )]
         }
     }
 }

--- a/odra-cli/src/types/into_bytes.rs
+++ b/odra-cli/src/types/into_bytes.rs
@@ -1,0 +1,277 @@
+use odra::schema::casper_contract_schema::NamedCLType;
+
+use crate::types::{into_bytes, Error, Format};
+
+#[test]
+fn test_bool() {
+    let ty = NamedCLType::Bool;
+    assert_eq!(into_bytes(&ty, "true").unwrap(), vec![1]);
+    assert_eq!(into_bytes(&ty, "false").unwrap(), vec![0]);
+    assert!(into_bytes(&ty, "a").is_err());
+}
+
+#[test]
+fn test_i32() {
+    let ty = NamedCLType::I32;
+    assert_eq!(into_bytes(&ty, "0").unwrap(), vec![0, 0, 0, 0]);
+    assert_eq!(into_bytes(&ty, "1").unwrap(), vec![1, 0, 0, 0]);
+    assert_eq!(into_bytes(&ty, "-1").unwrap(), vec![255, 255, 255, 255]);
+    assert!(into_bytes(&ty, "a").is_err());
+}
+
+#[test]
+fn test_i64() {
+    let ty = NamedCLType::I64;
+    assert_eq!(into_bytes(&ty, "0").unwrap(), vec![0, 0, 0, 0, 0, 0, 0, 0]);
+    assert_eq!(into_bytes(&ty, "1").unwrap(), vec![1, 0, 0, 0, 0, 0, 0, 0]);
+    assert_eq!(
+        into_bytes(&ty, "-1").unwrap(),
+        vec![255, 255, 255, 255, 255, 255, 255, 255]
+    );
+    assert!(into_bytes(&ty, "a").is_err());
+}
+
+#[test]
+fn test_u8() {
+    let ty = NamedCLType::U8;
+    assert_eq!(into_bytes(&ty, "0").unwrap(), vec![0]);
+    assert_eq!(into_bytes(&ty, "1").unwrap(), vec![1]);
+    assert_eq!(into_bytes(&ty, "255").unwrap(), vec![255]);
+    assert_eq!(into_bytes(&ty, "0x0f").unwrap(), vec![15]);
+    assert_eq!(into_bytes(&ty, "0b1111").unwrap(), vec![15]);
+    assert_eq!(
+        into_bytes(&ty, "a"),
+        Err(Error::Formatting(Format::U8))
+    );
+}
+
+#[test]
+fn test_u32() {
+    let ty = NamedCLType::U32;
+    assert_eq!(into_bytes(&ty, "0").unwrap(), vec![0, 0, 0, 0]);
+    assert_eq!(into_bytes(&ty, "1").unwrap(), vec![1, 0, 0, 0]);
+    assert_eq!(
+        into_bytes(&ty, "4294967295").unwrap(),
+        vec![255, 255, 255, 255]
+    );
+    assert!(into_bytes(&ty, "a").is_err());
+}
+
+#[test]
+fn test_u64() {
+    let ty = NamedCLType::U64;
+    assert_eq!(into_bytes(&ty, "0").unwrap(), vec![0, 0, 0, 0, 0, 0, 0, 0]);
+    assert_eq!(into_bytes(&ty, "1").unwrap(), vec![1, 0, 0, 0, 0, 0, 0, 0]);
+    assert_eq!(
+        into_bytes(&ty, "18446744073709551615").unwrap(),
+        vec![255, 255, 255, 255, 255, 255, 255, 255]
+    );
+    assert!(into_bytes(&ty, "a").is_err());
+}
+
+#[test]
+fn test_u128() {
+    let ty = NamedCLType::U128;
+    assert_eq!(into_bytes(&ty, "0").unwrap(), vec![0]);
+    assert_eq!(into_bytes(&ty, "1").unwrap(), vec![1, 1]);
+    assert_eq!(
+        into_bytes(&ty, "340282366920938463463374607431768211455").unwrap(),
+        vec![16, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255]
+    );
+    assert!(into_bytes(&ty, "a").is_err());
+}
+
+#[test]
+fn test_u256() {
+    let ty = NamedCLType::U256;
+    assert_eq!(into_bytes(&ty, "0").unwrap(), vec![0]);
+    assert_eq!(into_bytes(&ty, "1").unwrap(), vec![1, 1]);
+    assert!(into_bytes(&ty, "a").is_err());
+}
+
+#[test]
+fn test_u512() {
+    let ty = NamedCLType::U512;
+    assert_eq!(into_bytes(&ty, "0").unwrap(), vec![0]);
+    assert_eq!(into_bytes(&ty, "1").unwrap(), vec![1, 1]);
+    assert!(into_bytes(&ty, "a").is_err());
+}
+
+#[test]
+fn test_string() {
+    let ty = NamedCLType::String;
+    assert_eq!(
+        into_bytes(&ty, "a").unwrap(),
+        vec![1, 0, 0, 0, 97]
+    );
+    assert_eq!(
+        into_bytes(&ty, "abc").unwrap(),
+        vec![3, 0, 0, 0, 97, 98, 99]
+    );
+}
+
+#[test]
+fn test_key() {
+    let ty = NamedCLType::Key;
+    let value = "hash-000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f";
+    let expected = vec![
+        1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+        11, 12, 13, 14, 15,
+    ];
+    assert_eq!(into_bytes(&ty, value).unwrap(), expected);
+
+    let value = "account-hash-000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f";
+    let expected = vec![
+        0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+        11, 12, 13, 14, 15,
+    ];
+    assert_eq!(into_bytes(&ty, value).unwrap(), expected);
+}
+
+#[test]
+fn test_uref() {
+    let ty = NamedCLType::URef;
+    let value = "uref-000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f-007";
+    let expected = vec![
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+        11, 12, 13, 14, 15, 7,
+    ];
+    assert_eq!(into_bytes(&ty, value).unwrap(), expected);
+}
+
+#[test]
+fn test_public_key() {
+    let ty = NamedCLType::PublicKey;
+    // Use a valid Ed25519 public key hex string (01 tag + 32 zero bytes)
+    let value = "010000000000000000000000000000000000000000000000000000000000000000";
+    // Expected bytes: 0x01 tag followed by 32 zero bytes
+    let expected = vec![
+        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    ];
+    assert_eq!(into_bytes(&ty, value).unwrap(), expected);
+}
+
+#[test]
+fn test_option() {
+    let ty = NamedCLType::Option(Box::new(NamedCLType::U8));
+    assert_eq!(into_bytes(&ty, "none").unwrap(), vec![0]);
+    assert_eq!(into_bytes(&ty, "some:1").unwrap(), vec![1, 1]);
+    assert_eq!(
+        into_bytes(&ty, "a"),
+        Err(Error::Formatting(Format::Option))
+    );
+}
+
+#[test]
+fn test_result() {
+    let ty = NamedCLType::Result {
+        ok: Box::new(NamedCLType::U8),
+        err: Box::new(NamedCLType::String),
+    };
+    assert_eq!(into_bytes(&ty, "ok:1").unwrap(), vec![1, 1]);
+    assert_eq!(
+        into_bytes(&ty, r#"err:a"#).unwrap(),
+        vec![0, 1, 0, 0, 0, 97]
+    );
+    assert_eq!(
+        into_bytes(&ty, "a"),
+        Err(Error::Formatting(Format::Result))
+    );
+}
+
+#[test]
+fn test_tuple1() {
+    let ty = NamedCLType::Tuple1([Box::new(NamedCLType::U8)]);
+    assert_eq!(into_bytes(&ty, "1").unwrap(), vec![1]);
+}
+
+#[test]
+fn test_tuple2() {
+    let ty = NamedCLType::Tuple2([
+        Box::new(NamedCLType::U8),
+        Box::new(NamedCLType::String),
+    ]);
+    assert_eq!(
+        into_bytes(&ty, r#"1:a"#).unwrap(),
+        vec![1, 1, 0, 0, 0, 97]
+    );
+}
+
+#[test]
+fn test_tuple3() {
+    let ty = NamedCLType::Tuple3([
+        Box::new(NamedCLType::U8),
+        Box::new(NamedCLType::String),
+        Box::new(NamedCLType::Bool),
+    ]);
+    assert_eq!(
+        into_bytes(&ty, r#"1:a:true"#).unwrap(),
+        vec![1, 1, 0, 0, 0, 97, 1]
+    );
+}
+
+#[test]
+fn test_unit() {
+    let ty = NamedCLType::Unit;
+    assert_eq!(into_bytes(&ty, "").unwrap(), Vec::<u8>::new());
+}
+
+#[test]
+fn test_map() {
+    let ty = NamedCLType::Map {
+        key: Box::new(NamedCLType::U8),
+        value: Box::new(NamedCLType::String),
+    };
+    assert_eq!(
+        into_bytes(&ty, r#"1:a,2:b"#).unwrap(),
+        vec![2, 0, 0, 0, 1, 1, 0, 0, 0, 97, 2, 1, 0, 0, 0, 98]
+    );
+}
+
+#[test]
+fn test_list() {
+    let ty = NamedCLType::List(Box::new(NamedCLType::U8));
+    assert_eq!(
+        into_bytes(&ty, "1").unwrap(),
+        vec![1, 0, 0, 0, 1]
+    );
+
+    let ty = NamedCLType::List(Box::new(NamedCLType::U8));
+    assert_eq!(
+        into_bytes(&ty, "1,2,3").unwrap(),
+        vec![3, 0, 0, 0, 1, 2, 3]
+    );
+}
+
+#[test]
+fn test_byte_array() {
+    let ty = NamedCLType::ByteArray(4);
+    assert_eq!(into_bytes(&ty, "0x01020304").unwrap(), vec![1, 2, 3, 4]);
+    assert_eq!(into_bytes(&ty, "0x01").unwrap(), vec![1, 1, 1, 1]);
+    assert_eq!(into_bytes(&ty, "0x0").unwrap(), vec![0, 0, 0, 0]);
+    assert_eq!(
+        into_bytes(&ty, "1,2,3,4").unwrap(),
+        vec![1, 2, 3, 4]
+    );
+    assert_eq!(
+        into_bytes(&ty, "0x01,0x02,0x03,0x04").unwrap(),
+        vec![1, 2, 3, 4]
+    );
+    let ty = NamedCLType::ByteArray(16);
+    assert_eq!(
+        into_bytes(&ty, "0x010203"),
+        Err(Error::Formatting(Format::PatternLength {
+            actual: 3,
+            expected: 16
+        }))
+    );
+}
+
+#[test]
+fn test_parse_hex_isolated() {
+    assert_eq!(super::parse_hex("0x01").unwrap(), vec![1]);
+    assert_eq!(super::parse_hex("0xdeadbeef").unwrap(), vec![0xde, 0xad, 0xbe, 0xef]);
+    assert!(super::parse_hex("0x").is_err()); // Empty hex string after prefix
+    assert!(super::parse_hex("0xG").is_err()); // Invalid hex char
+    assert!(super::parse_hex("01").is_err()); // No 0x prefix
+}

--- a/odra-cli/src/types/into_bytes.rs
+++ b/odra-cli/src/types/into_bytes.rs
@@ -39,10 +39,7 @@ fn test_u8() {
     assert_eq!(into_bytes(&ty, "255").unwrap(), vec![255]);
     assert_eq!(into_bytes(&ty, "0x0f").unwrap(), vec![15]);
     assert_eq!(into_bytes(&ty, "0b1111").unwrap(), vec![15]);
-    assert_eq!(
-        into_bytes(&ty, "a"),
-        Err(Error::Formatting(Format::U8))
-    );
+    assert_eq!(into_bytes(&ty, "a"), Err(Error::Formatting(Format::U8)));
 }
 
 #[test]
@@ -100,10 +97,7 @@ fn test_u512() {
 #[test]
 fn test_string() {
     let ty = NamedCLType::String;
-    assert_eq!(
-        into_bytes(&ty, "a").unwrap(),
-        vec![1, 0, 0, 0, 97]
-    );
+    assert_eq!(into_bytes(&ty, "a").unwrap(), vec![1, 0, 0, 0, 97]);
     assert_eq!(
         into_bytes(&ty, "abc").unwrap(),
         vec![3, 0, 0, 0, 97, 98, 99]
@@ -133,8 +127,8 @@ fn test_uref() {
     let ty = NamedCLType::URef;
     let value = "uref-000102030405060708090a0b0c0d0e0f000102030405060708090a0b0c0d0e0f-007";
     let expected = vec![
-        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
-        11, 12, 13, 14, 15, 7,
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+        12, 13, 14, 15, 7,
     ];
     assert_eq!(into_bytes(&ty, value).unwrap(), expected);
 }
@@ -146,7 +140,8 @@ fn test_public_key() {
     let value = "010000000000000000000000000000000000000000000000000000000000000000";
     // Expected bytes: 0x01 tag followed by 32 zero bytes
     let expected = vec![
-        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0,
     ];
     assert_eq!(into_bytes(&ty, value).unwrap(), expected);
 }
@@ -156,27 +151,21 @@ fn test_option() {
     let ty = NamedCLType::Option(Box::new(NamedCLType::U8));
     assert_eq!(into_bytes(&ty, "none").unwrap(), vec![0]);
     assert_eq!(into_bytes(&ty, "some:1").unwrap(), vec![1, 1]);
-    assert_eq!(
-        into_bytes(&ty, "a"),
-        Err(Error::Formatting(Format::Option))
-    );
+    assert_eq!(into_bytes(&ty, "a"), Err(Error::Formatting(Format::Option)));
 }
 
 #[test]
 fn test_result() {
     let ty = NamedCLType::Result {
         ok: Box::new(NamedCLType::U8),
-        err: Box::new(NamedCLType::String),
+        err: Box::new(NamedCLType::String)
     };
     assert_eq!(into_bytes(&ty, "ok:1").unwrap(), vec![1, 1]);
     assert_eq!(
         into_bytes(&ty, r#"err:a"#).unwrap(),
         vec![0, 1, 0, 0, 0, 97]
     );
-    assert_eq!(
-        into_bytes(&ty, "a"),
-        Err(Error::Formatting(Format::Result))
-    );
+    assert_eq!(into_bytes(&ty, "a"), Err(Error::Formatting(Format::Result)));
 }
 
 #[test]
@@ -187,14 +176,8 @@ fn test_tuple1() {
 
 #[test]
 fn test_tuple2() {
-    let ty = NamedCLType::Tuple2([
-        Box::new(NamedCLType::U8),
-        Box::new(NamedCLType::String),
-    ]);
-    assert_eq!(
-        into_bytes(&ty, r#"1:a"#).unwrap(),
-        vec![1, 1, 0, 0, 0, 97]
-    );
+    let ty = NamedCLType::Tuple2([Box::new(NamedCLType::U8), Box::new(NamedCLType::String)]);
+    assert_eq!(into_bytes(&ty, r#"1:a"#).unwrap(), vec![1, 1, 0, 0, 0, 97]);
 }
 
 #[test]
@@ -202,7 +185,7 @@ fn test_tuple3() {
     let ty = NamedCLType::Tuple3([
         Box::new(NamedCLType::U8),
         Box::new(NamedCLType::String),
-        Box::new(NamedCLType::Bool),
+        Box::new(NamedCLType::Bool)
     ]);
     assert_eq!(
         into_bytes(&ty, r#"1:a:true"#).unwrap(),
@@ -220,7 +203,7 @@ fn test_unit() {
 fn test_map() {
     let ty = NamedCLType::Map {
         key: Box::new(NamedCLType::U8),
-        value: Box::new(NamedCLType::String),
+        value: Box::new(NamedCLType::String)
     };
     assert_eq!(
         into_bytes(&ty, r#"1:a,2:b"#).unwrap(),
@@ -231,16 +214,10 @@ fn test_map() {
 #[test]
 fn test_list() {
     let ty = NamedCLType::List(Box::new(NamedCLType::U8));
-    assert_eq!(
-        into_bytes(&ty, "1").unwrap(),
-        vec![1, 0, 0, 0, 1]
-    );
+    assert_eq!(into_bytes(&ty, "1").unwrap(), vec![1, 0, 0, 0, 1]);
 
     let ty = NamedCLType::List(Box::new(NamedCLType::U8));
-    assert_eq!(
-        into_bytes(&ty, "1,2,3").unwrap(),
-        vec![3, 0, 0, 0, 1, 2, 3]
-    );
+    assert_eq!(into_bytes(&ty, "1,2,3").unwrap(), vec![3, 0, 0, 0, 1, 2, 3]);
 }
 
 #[test]
@@ -249,10 +226,7 @@ fn test_byte_array() {
     assert_eq!(into_bytes(&ty, "0x01020304").unwrap(), vec![1, 2, 3, 4]);
     assert_eq!(into_bytes(&ty, "0x01").unwrap(), vec![1, 1, 1, 1]);
     assert_eq!(into_bytes(&ty, "0x0").unwrap(), vec![0, 0, 0, 0]);
-    assert_eq!(
-        into_bytes(&ty, "1,2,3,4").unwrap(),
-        vec![1, 2, 3, 4]
-    );
+    assert_eq!(into_bytes(&ty, "1,2,3,4").unwrap(), vec![1, 2, 3, 4]);
     assert_eq!(
         into_bytes(&ty, "0x01,0x02,0x03,0x04").unwrap(),
         vec![1, 2, 3, 4]
@@ -270,7 +244,10 @@ fn test_byte_array() {
 #[test]
 fn test_parse_hex_isolated() {
     assert_eq!(super::parse_hex("0x01").unwrap(), vec![1]);
-    assert_eq!(super::parse_hex("0xdeadbeef").unwrap(), vec![0xde, 0xad, 0xbe, 0xef]);
+    assert_eq!(
+        super::parse_hex("0xdeadbeef").unwrap(),
+        vec![0xde, 0xad, 0xbe, 0xef]
+    );
     assert!(super::parse_hex("0x").is_err()); // Empty hex string after prefix
     assert!(super::parse_hex("0xG").is_err()); // Invalid hex char
     assert!(super::parse_hex("01").is_err()); // No 0x prefix

--- a/odra-cli/src/types/mod.rs
+++ b/odra-cli/src/types/mod.rs
@@ -14,6 +14,9 @@ use odra::{
 mod decoder;
 mod error;
 
+#[cfg(test)]
+mod into_bytes;
+
 pub(crate) use decoder::decode;
 pub(crate) use error::{Error, Format};
 
@@ -21,6 +24,10 @@ use crate::custom_types::CustomTypeSet;
 
 const PREFIX_ERROR: &str = "err:";
 const PREFIX_OK: &str = "ok:";
+const PREFIX_HEX: &str = "0x";
+const PREFIX_BINARY: &str = "0b";
+const PREFIX_SOME: &str = "some:";
+const PREFIX_NONE: &str = "none";
 
 type TypeResult<T> = Result<T, Error>;
 
@@ -110,11 +117,11 @@ pub(crate) fn into_bytes(ty: &NamedCLType, input: &str) -> TypeResult<Vec<u8>> {
         NamedCLType::I32 => call_to_bytes!(i32, input),
         NamedCLType::I64 => call_to_bytes!(i64, input),
         NamedCLType::U8 => {
-            if let Some(hex) = input.strip_prefix("0x") {
+            if let Some(hex) = input.strip_prefix(PREFIX_HEX) {
                 u8::from_str_radix(hex, 16)
                     .map_err(|_| Error::InvalidHexString)
                     .map(|byte| vec![byte])
-            } else if let Some(bits) = input.strip_prefix("0b") {
+            } else if let Some(bits) = input.strip_prefix(PREFIX_BINARY) {
                 let byte = u8::from_str_radix(bits, 2).map_err(|_| Error::Serialization)?;
                 Ok(vec![byte])
             } else {
@@ -122,7 +129,7 @@ pub(crate) fn into_bytes(ty: &NamedCLType, input: &str) -> TypeResult<Vec<u8>> {
                 if let Ok(byte) = input.parse::<u8>() {
                     Ok(vec![byte])
                 } else {
-                    Err(Error::Formatting(Format::Option))
+                    Err(Error::Formatting(Format::U8))
                 }
             }
         }
@@ -142,10 +149,10 @@ pub(crate) fn into_bytes(ty: &NamedCLType, input: &str) -> TypeResult<Vec<u8>> {
             .to_bytes()
             .map_err(|_| Error::Serialization),
         NamedCLType::Option(ty) => {
-            if input == "none" {
+            if input == PREFIX_NONE {
                 Ok(vec![OPTION_NONE_TAG])
-            } else if input.starts_with("some:") {
-                let value = input.strip_prefix("some:").unwrap();
+            } else if input.starts_with(PREFIX_SOME) {
+                let value = strip_prefix_or_err(input, PREFIX_SOME)?;
                 let mut result = vec![OPTION_SOME_TAG];
                 result.extend(into_bytes(ty, value)?);
                 Ok(result)
@@ -156,12 +163,12 @@ pub(crate) fn into_bytes(ty: &NamedCLType, input: &str) -> TypeResult<Vec<u8>> {
         NamedCLType::Result { ok, err } => {
             let mut result = vec![];
             if input.starts_with(PREFIX_ERROR) {
-                let value = input.strip_prefix(PREFIX_ERROR).unwrap();
+                let value = strip_prefix_or_err(input, PREFIX_ERROR)?;
                 result.push(RESULT_ERR_TAG);
                 result.extend(into_bytes(err, value)?);
                 Ok(result)
             } else if input.starts_with(PREFIX_OK) {
-                let value = input.strip_prefix(PREFIX_OK).unwrap();
+                let value = strip_prefix_or_err(input, PREFIX_OK)?;
                 result.push(RESULT_OK_TAG);
                 result.extend(into_bytes(ok, value)?);
                 Ok(result)
@@ -233,14 +240,30 @@ pub(crate) fn into_bytes(ty: &NamedCLType, input: &str) -> TypeResult<Vec<u8>> {
 
             match parse_hex(input) {
                 Ok(data) => {
-                    validate_byte_array_size(n, data.len())?;
-                    Ok(data)
+                    let pattern_len = data.len();
+                    if pattern_len == 0 {
+                        return if n == 0 {
+                            Ok(vec![])
+                        } else {
+                            Err(Error::Formatting(Format::ByteArray))
+                        };
+                    }
+
+                    if n % pattern_len != 0 {
+                        return Err(Error::Formatting(Format::PatternLength {
+                            actual: pattern_len,
+                            expected: n
+                        }));
+                    }
+
+                    let count = n / pattern_len;
+                    Ok(data.repeat(count))
                 }
                 Err(Error::InvalidHexString) => {
                     let parts = input.split(',').collect::<Vec<_>>();
                     validate_byte_array_size(n, parts.len())?;
 
-                    if parts.iter().all(|s| s.starts_with("0x")) {
+                    if parts.iter().all(|s| s.starts_with(PREFIX_HEX)) {
                         let bytes = parts
                             .iter()
                             .map(|part| parse_hex(part))
@@ -357,7 +380,7 @@ pub(crate) fn from_bytes<'a>(ty: &NamedCLType, input: &'a [u8]) -> TypeResult<(S
         NamedCLType::ByteArray(n) => {
             let size = *n as usize;
 
-            let mut hex = "0x".to_string();
+            let mut hex = PREFIX_HEX.to_string();
             let mut dec = "".to_string();
             for val in input.iter().take(size) {
                 dec.push_str(&format!("{}, ", val));
@@ -393,8 +416,24 @@ pub(crate) fn from_bytes<'a>(ty: &NamedCLType, input: &'a [u8]) -> TypeResult<(S
 }
 
 fn parse_hex(input: &str) -> TypeResult<Vec<u8>> {
-    match input.strip_prefix("0x") {
-        Some(data) => hex::decode(data).map_err(|_| Error::HexDecode),
+    if input.is_empty() || input.contains(',') {
+        return Err(Error::InvalidHexString);
+    }
+    if !input.starts_with(PREFIX_HEX) {
+        return Err(Error::InvalidHexString);
+    }
+    match input.strip_prefix(PREFIX_HEX) {
+        Some(data) => {
+            if data.is_empty() {
+                return Err(Error::InvalidHexString);
+            }
+            if data.len() % 2 != 0 {
+                hex::decode(format!("{}{}", data, data))
+                    .map_err(|_| Error::HexDecode)
+            } else {
+                hex::decode(data).map_err(|_| Error::HexDecode)
+            }
+        }
         None => Err(Error::InvalidHexString)
     }
 }
@@ -407,6 +446,10 @@ pub(crate) fn from_bytes_or_err<T: FromBytes>(input: &[u8]) -> TypeResult<(T, &[
 #[inline]
 pub(crate) fn to_bytes_or_err<T: ToBytes>(input: T) -> TypeResult<Vec<u8>> {
     input.to_bytes().map_err(|_| Error::Serialization)
+}
+#[inline]
+fn strip_prefix_or_err<'a>(input: &'a str, prefix: &str) -> TypeResult<&'a str> {
+    input.strip_prefix(prefix).ok_or(Error::Serialization)
 }
 
 fn validate_byte_array_size(expected: usize, actual: usize) -> TypeResult<()> {

--- a/odra-cli/src/types/mod.rs
+++ b/odra-cli/src/types/mod.rs
@@ -428,8 +428,7 @@ fn parse_hex(input: &str) -> TypeResult<Vec<u8>> {
                 return Err(Error::InvalidHexString);
             }
             if data.len() % 2 != 0 {
-                hex::decode(format!("{}{}", data, data))
-                    .map_err(|_| Error::HexDecode)
+                hex::decode(format!("{}{}", data, data)).map_err(|_| Error::HexDecode)
             } else {
                 hex::decode(data).map_err(|_| Error::HexDecode)
             }


### PR DESCRIPTION
Add parsers to accept the `gas` and `attached value` args in the format of `123cspr` or `100000000` (motes)
No need to pass the full value of `ByteArray` - e.g., ' ByteArray(32) ' may be passed as `0x0` (`0x01`), as the missing value are inferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced support for parsing CSPR token amounts and gas values with enhanced validation and error messages.
  * Improved byte array parsing to support repeating hex patterns for fixed-size arrays.

* **Bug Fixes**
  * Enhanced error handling and messaging for invalid prefixes and formatting in option, result, and byte array types.
  * Improved error reporting for invalid U8 value parsing.

* **Tests**
  * Added comprehensive unit tests for byte serialization of various data types, ensuring correct handling and error reporting.

* **Chores**
  * Refactored internal string prefix handling for consistency and maintainability.
  * Updated argument parsing for attached value and gas to use dedicated parsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->