### PR TITLE
Update changelog for  v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Changelog for `odra`.
 a `&T` reference.
 - `odra-cli` requires the `gas` parameter to call a mutable entrypoint.
 - `__attached_value` is now `attached_value` in `odra-cli`.
+- `HostEnv::address() -> &Address` now is `HostEnv::contract_address(&self) -> Address`.
+- `Addressable::address()` returns `Address` instead of `&Address`.
 
 ## [2.0.1] - 2025-06-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Changelog for `odra`.
 - `init_dictionary` function in `ContractEnv`.
 - `init` functions to all named keys related modules.
 - Enforce all named keys in `CEP-18` and `CEP-95` to be initialized in the `init` function.
+- New commands in `odra-cli`:
+  - `whoami` - prints the address of the current account.
+  - `print-events` - prints all events emitted by the contract.
+- A base cli implementation in templates.
+
+### Changed
+- Signature of functions in `HostEnv`, to accept `&Addressable` instead of `Address`.
+- Signature of `emitted_*` functions in `HostEnv`, to accept `T: ToBytes + EventInstance` instead of
+a `&T` reference.
+- `odra-cli` requires the `gas` parameter to call a mutable entrypoint.
+- `__attached_value` is now `attached_value` in `odra-cli`.
 
 ## [2.0.1] - 2025-06-06
 ### Added


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new CLI commands: `whoami` to display the current account address and `print-events` to show all contract-emitted events.

* **Improvements**
  * CLI now requires a `gas` parameter when calling mutable entrypoints.
  * Renamed the parameter `__attached_value` to `attached_value` in CLI commands.
  * Updated contract address and event handling interfaces for enhanced consistency and usability.

* **Documentation**
  * Updated changelog to reflect new features and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->