### PR TITLE
Rewards system is the same in casper_vm and odra_vm

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-07-31
+          toolchain: nightly-2025-01-01
           target: wasm32-unknown-unknown
       - name: Cache target
         uses: actions/cache@v3

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,8 +24,12 @@ jobs:
       - name: Cache target
         uses: actions/cache@v4
         with:
-          path: target
-          key: odra-target-folder
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/debug/.fingerprint
+            target/debug/build
+          key: odra-cache
       - name: Prepare test environment
         run: just prepare-test-env
       - name: Run benchmark

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,11 +21,6 @@ jobs:
         with:
           toolchain: nightly-2025-01-01
           target: wasm32-unknown-unknown
-      - name: Cache target
-        uses: actions/cache@v3
-        with:
-          path: target
-          key: odra-target-folder
       - name: Prepare test environment
         run: just prepare-test-env
       - name: Run benchmark

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,6 +21,11 @@ jobs:
         with:
           toolchain: nightly-2025-01-01
           target: wasm32-unknown-unknown
+      - name: Cache target
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: odra-target-folder
       - name: Prepare test environment
         run: just prepare-test-env
       - name: Run benchmark

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,8 +19,12 @@ jobs:
       - name: Cache target
         uses: actions/cache@v4
         with:
-          path: target
-          key: odra-target-folder
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/debug/.fingerprint
+            target/debug/build
+          key: odra-cache
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup toolchain

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-07-31
+          toolchain: nightly-2025-01-01
           target: wasm32-unknown-unknown
           components: rustfmt, clippy, llvm-tools-preview
       - name: Prepare test environment

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup just
         uses: extractions/setup-just@v1
       - name: Cache target
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: target
           key: odra-target-folder

--- a/.github/workflows/evaluate-benchmark.yml
+++ b/.github/workflows/evaluate-benchmark.yml
@@ -27,8 +27,12 @@ jobs:
       - name: Cache target
         uses: actions/cache@v4
         with:
-          path: target
-          key: odra-target-folder
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/debug/.fingerprint
+            target/debug/build
+          key: odra-cache
       - name: Prepare test environment
         run: just prepare-test-env
       - name: Set base benchmark filename

--- a/.github/workflows/evaluate-benchmark.yml
+++ b/.github/workflows/evaluate-benchmark.yml
@@ -25,7 +25,7 @@ jobs:
           toolchain: nightly-2025-01-01
           target: wasm32-unknown-unknown
       - name: Cache target
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: target
           key: odra-target-folder

--- a/.github/workflows/evaluate-benchmark.yml
+++ b/.github/workflows/evaluate-benchmark.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-07-31
+          toolchain: nightly-2025-01-01
           target: wasm32-unknown-unknown
       - name: Cache target
         uses: actions/cache@v3

--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -26,7 +26,11 @@ jobs:
       - name: Cache target
         uses: actions/cache@v4
         with:
-          path: target
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/debug/.fingerprint
+            target/debug/build
           key: odra-target-folder
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Cache target
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: target
           key: odra-target-folder

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,8 +37,12 @@ jobs:
       - name: Cache target
         uses: actions/cache@v4
         with:
-          path: target
-          key: odra-target-folder
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/debug/.fingerprint
+            target/debug/build
+          key: odra-cache
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Cache target
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: target
           key: odra-target-folder

--- a/core/src/consts.rs
+++ b/core/src/consts.rs
@@ -67,5 +67,9 @@ pub const DEFAULT_BALANCE: u64 = 10_000_000_000_000_000_000;
 
 pub const DEFAULT_MINIMUM_DELEGATION_AMOUNT: u64 = 500_000_000_000u64;
 
+pub const DEFAULT_BID_AMOUNT: u64 = 5_000_000_000_000_000_000u64;
+
+pub const DEFAULT_REWARD_AMOUNT: u64 = 2_500_000_000_000u64;
+
 /// Amount of random bytes returned by pseudorandom_bytes
 pub const RANDOM_BYTES_COUNT: usize = 32;

--- a/examples/src/features/storage/variable.rs
+++ b/examples/src/features/storage/variable.rs
@@ -3,7 +3,7 @@ use odra::prelude::*;
 
 /// Emits when the dog's name is changed.
 #[odra::event]
-pub struct NamedChanged {
+pub struct NameChanged {
     /// The old name of the dog.
     pub old_name: String,
     /// The new name of the dog.
@@ -11,7 +11,7 @@ pub struct NamedChanged {
 }
 
 /// A simple contract that represents a dog.
-#[odra::module(events = [NamedChanged])]
+#[odra::module(events = [NameChanged])]
 pub struct DogContract {
     barks: Var<bool>,
     weight: Var<u32>,
@@ -60,7 +60,7 @@ impl DogContract {
     pub fn rename(&mut self, new_name: String) {
         let old_name = self.name.get_or_default();
         self.name.set(new_name.clone());
-        self.env().emit_event(NamedChanged { old_name, new_name });
+        self.env().emit_event(NameChanged { old_name, new_name });
     }
 }
 

--- a/examples/src/features/validators.rs
+++ b/examples/src/features/validators.rs
@@ -279,19 +279,26 @@ mod tests {
         );
 
         let minimum_delegation_amount = staking.get_minimum_delegation_amount().into();
+        assert_eq!(staking.currently_delegated_amount(), U512::zero());
 
         staking.with_tokens(minimum_delegation_amount).stake();
 
-        assert_eq!(staking.currently_delegated_amount(), minimum_delegation_amount);
+        assert_eq!(
+            staking.currently_delegated_amount(),
+            minimum_delegation_amount
+        );
 
-        test_env.advance_with_auctions(test_env.auction_delay() * 2);
+        test_env.advance_with_auctions(test_env.auction_delay());
 
-        assert_eq!(staking.currently_delegated_amount(), U512::from(500_000_099_998u64));
+        assert_eq!(
+            staking.currently_delegated_amount(),
+            U512::from(500_000_049_999u64)
+        );
 
         staking.unstake(U512::from(500_000_000_000u64));
 
         test_env.advance_with_auctions(test_env.auction_delay());
-        test_env.advance_with_auctions(test_env.unbonding_delay());
+        test_env.advance_with_auctions(test_env.unbonding_delay() * 5);
 
         assert_eq!(staking.currently_delegated_amount(), U512::zero());
     }

--- a/examples/src/features/validators.rs
+++ b/examples/src/features/validators.rs
@@ -69,6 +69,7 @@ pub enum ValError {
 mod tests {
     use alloc::vec::Vec;
     use odra::casper_types::U512;
+    use odra::host::HostRef;
 
     #[test]
     fn test_advance_with_auctions() {
@@ -260,5 +261,38 @@ mod tests {
         let minimum_delegation_amount = staking.get_minimum_delegation_amount();
 
         assert_eq!(minimum_delegation_amount, 500_000_000_000u64);
+    }
+
+    #[test]
+    fn test_delegation() {
+        use crate::features::validators::{ValidatorsContract, ValidatorsContractInitArgs};
+        use odra::host::Deployer;
+        let test_env = odra_test::env();
+        let validator = test_env.get_validator(0);
+
+        test_env.set_caller(test_env.get_account(0));
+        let mut staking = ValidatorsContract::deploy(
+            &test_env,
+            ValidatorsContractInitArgs {
+                validator: validator.clone()
+            }
+        );
+
+        let minimum_delegation_amount = staking.get_minimum_delegation_amount().into();
+
+        staking.with_tokens(minimum_delegation_amount).stake();
+
+        assert_eq!(staking.currently_delegated_amount(), minimum_delegation_amount);
+
+        test_env.advance_with_auctions(test_env.auction_delay() * 2);
+
+        assert_eq!(staking.currently_delegated_amount(), U512::from(500_000_099_998u64));
+
+        staking.unstake(U512::from(500_000_000_000u64));
+
+        test_env.advance_with_auctions(test_env.auction_delay());
+        test_env.advance_with_auctions(test_env.unbonding_delay());
+
+        assert_eq!(staking.currently_delegated_amount(), U512::zero());
     }
 }

--- a/odra-casper/test-vm/src/vm/casper_vm.rs
+++ b/odra-casper/test-vm/src/vm/casper_vm.rs
@@ -690,7 +690,7 @@ impl CasperVm {
         );
 
         builder.run_genesis(chainspec.unwrap()).commit();
-
+        let unbonding_delay = builder.get_unbonding_delay();
         builder.advance_eras_by(20);
 
         for account in validators.iter() {
@@ -702,7 +702,7 @@ impl CasperVm {
                     ARG_PUBLIC_KEY => account.public_key(),
                     ARG_AMOUNT => U512::from(1_000_000_000_000u64),
                     ARG_DELEGATION_RATE=> 0u8,
-                    ARG_MINIMUM_DELEGATION_AMOUNT => 500_000_000_000u64,
+                    ARG_MINIMUM_DELEGATION_AMOUNT => DEFAULT_MINIMUM_DELEGATION_AMOUNT,
                 }
             )
             .build();

--- a/odra-casper/test-vm/src/vm/casper_vm.rs
+++ b/odra-casper/test-vm/src/vm/casper_vm.rs
@@ -652,7 +652,7 @@ impl CasperVm {
             let validator_account = GenesisAccount::account(
                 public_key.clone(),
                 Motes::new(DEFAULT_BALANCE),
-                Some(GenesisValidator::new(Motes::new(DEFAULT_BALANCE), 0))
+                Some(GenesisValidator::new(Motes::new(DEFAULT_BID_AMOUNT), 0))
             );
             accounts.push(validator_account.clone());
             validators.push(validator_account);
@@ -691,7 +691,8 @@ impl CasperVm {
 
         builder.run_genesis(chainspec.unwrap()).commit();
         let unbonding_delay = builder.get_unbonding_delay();
-        builder.advance_eras_by(20);
+        let auction_delay = builder.get_auction_delay();
+        builder.advance_eras_by(unbonding_delay + auction_delay);
 
         for account in validators.iter() {
             let bid_request = ExecuteRequestBuilder::contract_call_by_hash(
@@ -700,7 +701,7 @@ impl CasperVm {
                 METHOD_ADD_BID,
                 runtime_args! {
                     ARG_PUBLIC_KEY => account.public_key(),
-                    ARG_AMOUNT => U512::from(1_000_000_000_000u64),
+                    ARG_AMOUNT => U512::from(DEFAULT_BID_AMOUNT),
                     ARG_DELEGATION_RATE=> 0u8,
                     ARG_MINIMUM_DELEGATION_AMOUNT => DEFAULT_MINIMUM_DELEGATION_AMOUNT,
                 }

--- a/odra-vm/src/vm/odra_vm_state.rs
+++ b/odra-vm/src/vm/odra_vm_state.rs
@@ -243,7 +243,8 @@ impl OdraVmState {
             .get(&delegator)
             .cloned()
             .unwrap_or_default();
-        validators_delegations.insert(delegator, delegation.checked_sub(amount).unwrap());
+        let new_delegation = delegation.checked_sub(amount).unwrap();
+        validators_delegations.insert(delegator, new_delegation);
 
         let mut validator_info = match self.validators.get(&validator) {
             None => ValidatorInfo::new(U512::zero(), DEFAULT_MINIMUM_DELEGATION_AMOUNT),
@@ -256,27 +257,23 @@ impl OdraVmState {
             from: self.validator_account[&validator],
             to: delegator,
             amount,
-            transfer_unlock,
+            transfer_unlock
         };
         self.awaiting_transfers.push(transfer);
 
-        if validator_info.staked_amount < validator_info.minimum_delegation_amount.into() {
-            // Undelegate everything
-            validator_info.set_staked_amount(U512::zero());
+        if new_delegation < validator_info.minimum_delegation_amount.into() {
+            // Undelegate everything, as we are below the minimum delegation amount
+            validators_delegations.remove(&delegator);
 
-            validators_delegations.iter().for_each(|(delegator, amount)|  {
-
-                let transfer = AwaitingTransfer {
-                    from: self.validator_account[&validator],
-                    to: *delegator,
-                    amount: *amount,
-                    transfer_unlock,
-                };
-                self.awaiting_transfers.push(transfer);
-            });
-
-            self.delegations.remove(&validator);
+            let transfer = AwaitingTransfer {
+                from: self.validator_account[&validator],
+                to: delegator,
+                amount: new_delegation,
+                transfer_unlock
+            };
+            self.awaiting_transfers.push(transfer);
         }
+
         self.validators.insert(validator.clone(), validator_info);
     }
 
@@ -363,7 +360,7 @@ impl OdraVmState {
         // Calculate how many auctions we can run based on time_diff
         let num_auctions = milliseconds / time_between_auctions;
 
-        let auction_total_reward = 5_000_000_000_000u64;
+        let auction_total_reward = 299_999u64;
 
         // Run auctions and distribute rewards one at a time
         // to each validator which has a delegation
@@ -381,18 +378,21 @@ impl OdraVmState {
                         return;
                     }
 
-                    let validator_reward = (validator_info.staked_amount * auction_total_reward) / total_staked;
+                    let validator_reward =
+                        (validator_info.staked_amount * auction_total_reward) / total_staked;
 
                     let mut delegations = match self.delegations.get(validator) {
                         None => BTreeMap::new(),
                         Some(delegation) => delegation.clone()
                     };
 
-                    delegations.iter_mut().for_each(|(delegator_address, delegator_amount)| {
-                        let delegator_reward = (*delegator_amount * validator_reward) / validator_info.staked_amount;
-                        *delegator_amount += delegator_reward;
-                    });
-
+                    delegations
+                        .iter_mut()
+                        .for_each(|(delegator_address, delegator_amount)| {
+                            let delegator_reward = (*delegator_amount * validator_reward)
+                                / validator_info.staked_amount;
+                            *delegator_amount += delegator_reward;
+                        });
 
                     self.delegations.insert(validator.clone(), delegations);
 
@@ -471,7 +471,7 @@ impl Default for OdraVmState {
         let accounts: Vec<Address> = key_pairs.keys().copied().collect();
         let mut balances = BTreeMap::<Address, AccountBalance>::new();
         for address in accounts.clone() {
-            balances.insert(address, 10_000_000_000_000_000_000u64.into());
+            balances.insert(address, DEFAULT_BALANCE.into());
         }
 
         // last 5 key pairs are validators
@@ -483,7 +483,10 @@ impl Default for OdraVmState {
             .map(|(_, pk)| {
                 (
                     pk.1.clone(),
-                    ValidatorInfo::new(DEFAULT_BALANCE.into(), DEFAULT_MINIMUM_DELEGATION_AMOUNT)
+                    ValidatorInfo::new(
+                        U512::from(DEFAULT_MINIMUM_DELEGATION_AMOUNT * 2),
+                        DEFAULT_MINIMUM_DELEGATION_AMOUNT
+                    )
                 )
             })
             .collect::<BTreeMap<PublicKey, ValidatorInfo>>();

--- a/odra-vm/src/vm/odra_vm_state.rs
+++ b/odra-vm/src/vm/odra_vm_state.rs
@@ -10,7 +10,9 @@ use odra_core::casper_types::{
     bytesrepr::{Bytes, FromBytes, ToBytes},
     PublicKey, SecretKey, U512
 };
-use odra_core::consts::{DEFAULT_BALANCE, DEFAULT_MINIMUM_DELEGATION_AMOUNT};
+use odra_core::consts::{
+    DEFAULT_BALANCE, DEFAULT_BID_AMOUNT, DEFAULT_MINIMUM_DELEGATION_AMOUNT, DEFAULT_REWARD_AMOUNT
+};
 use odra_core::crypto::generate_key_pairs;
 use odra_core::prelude::*;
 use odra_core::validator::ValidatorInfo;
@@ -360,7 +362,7 @@ impl OdraVmState {
         // Calculate how many auctions we can run based on time_diff
         let num_auctions = milliseconds / time_between_auctions;
 
-        let auction_total_reward = 299_999u64;
+        let auction_total_reward = DEFAULT_REWARD_AMOUNT;
 
         // Run auctions and distribute rewards one at a time
         // to each validator which has a delegation
@@ -484,7 +486,7 @@ impl Default for OdraVmState {
                 (
                     pk.1.clone(),
                     ValidatorInfo::new(
-                        U512::from(DEFAULT_MINIMUM_DELEGATION_AMOUNT * 2),
+                        U512::from(DEFAULT_BID_AMOUNT),
                         DEFAULT_MINIMUM_DELEGATION_AMOUNT
                     )
                 )

--- a/odra-vm/src/vm/odra_vm_state.rs
+++ b/odra-vm/src/vm/odra_vm_state.rs
@@ -10,7 +10,7 @@ use odra_core::casper_types::{
     bytesrepr::{Bytes, FromBytes, ToBytes},
     PublicKey, SecretKey, U512
 };
-use odra_core::consts::DEFAULT_MINIMUM_DELEGATION_AMOUNT;
+use odra_core::consts::{DEFAULT_BALANCE, DEFAULT_MINIMUM_DELEGATION_AMOUNT};
 use odra_core::crypto::generate_key_pairs;
 use odra_core::prelude::*;
 use odra_core::validator::ValidatorInfo;
@@ -28,7 +28,7 @@ pub struct AwaitingTransfer {
     pub from: Address,
     pub to: Address,
     pub amount: U512,
-    pub block_time: u64
+    pub transfer_unlock: u64
 }
 
 /// Struct representing the state of the Odra VM.
@@ -236,6 +236,8 @@ impl OdraVmState {
         if self.removed_validators.contains(&validator) {
             panic!("Validator is disabled");
         }
+
+        let transfer_unlock = self.block_time + self.unbonding_period();
         let validators_delegations = self.delegations.entry(validator.clone()).or_default();
         let delegation = validators_delegations
             .get(&delegator)
@@ -249,16 +251,33 @@ impl OdraVmState {
         };
 
         validator_info.set_staked_amount(validator_info.staked_amount.checked_sub(amount).unwrap());
-        self.validators.insert(validator.clone(), validator_info);
 
         let transfer = AwaitingTransfer {
             from: self.validator_account[&validator],
             to: delegator,
             amount,
-            block_time: self.block_time + self.unbonding_period()
+            transfer_unlock,
         };
-
         self.awaiting_transfers.push(transfer);
+
+        if validator_info.staked_amount < validator_info.minimum_delegation_amount.into() {
+            // Undelegate everything
+            validator_info.set_staked_amount(U512::zero());
+
+            validators_delegations.iter().for_each(|(delegator, amount)|  {
+
+                let transfer = AwaitingTransfer {
+                    from: self.validator_account[&validator],
+                    to: *delegator,
+                    amount: *amount,
+                    transfer_unlock,
+                };
+                self.awaiting_transfers.push(transfer);
+            });
+
+            self.delegations.remove(&validator);
+        }
+        self.validators.insert(validator.clone(), validator_info);
     }
 
     pub fn attach_value(&mut self, amount: U512) {
@@ -344,7 +363,7 @@ impl OdraVmState {
         // Calculate how many auctions we can run based on time_diff
         let num_auctions = milliseconds / time_between_auctions;
 
-        let auction_reward = 99999u64;
+        let auction_total_reward = 5_000_000_000_000u64;
 
         // Run auctions and distribute rewards one at a time
         // to each validator which has a delegation
@@ -362,16 +381,22 @@ impl OdraVmState {
                         return;
                     }
 
-                    let mut new_total_amount = validator_info.staked_amount;
+                    let validator_reward = (validator_info.staked_amount * auction_total_reward) / total_staked;
 
-                    let delegations = self.delegations.get_mut(validator).unwrap();
-                    delegations.iter_mut().for_each(|(address, amount)| {
-                        let reward = (validator_info.staked_amount * auction_reward) / total_staked;
-                        *amount += reward;
-                        new_total_amount += reward;
+                    let mut delegations = match self.delegations.get(validator) {
+                        None => BTreeMap::new(),
+                        Some(delegation) => delegation.clone()
+                    };
+
+                    delegations.iter_mut().for_each(|(delegator_address, delegator_amount)| {
+                        let delegator_reward = (*delegator_amount * validator_reward) / validator_info.staked_amount;
+                        *delegator_amount += delegator_reward;
                     });
 
-                    validator_info.staked_amount = new_total_amount;
+
+                    self.delegations.insert(validator.clone(), delegations);
+
+                    validator_info.staked_amount += validator_reward;
                 });
         }
 
@@ -383,7 +408,7 @@ impl OdraVmState {
             .clone()
             .into_iter()
             .for_each(|transfer| {
-                if self.block_time >= transfer.block_time {
+                if self.block_time >= transfer.transfer_unlock {
                     self.transfer(&transfer.from, &transfer.to, &transfer.amount)
                         .unwrap();
                 }
@@ -391,7 +416,7 @@ impl OdraVmState {
 
         // Remove the processed transfers from the list
         self.awaiting_transfers
-            .retain(|transfer| self.block_time < transfer.block_time);
+            .retain(|transfer| self.block_time < transfer.transfer_unlock);
     }
 
     pub fn auction_delay(&self) -> u64 {
@@ -458,7 +483,7 @@ impl Default for OdraVmState {
             .map(|(_, pk)| {
                 (
                     pk.1.clone(),
-                    ValidatorInfo::new(U512::zero(), DEFAULT_MINIMUM_DELEGATION_AMOUNT)
+                    ValidatorInfo::new(DEFAULT_BALANCE.into(), DEFAULT_MINIMUM_DELEGATION_AMOUNT)
                 )
             })
             .collect::<BTreeMap<PublicKey, ValidatorInfo>>();


### PR DESCRIPTION
This PR makes the rewards given when using the delegation the same between odra_vm and casper_vm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced default bid and reward amounts for improved configuration.
  * Added a new test for delegation logic in validators.

* **Bug Fixes**
  * Improved delegation and undelegation logic to handle minimum delegation thresholds and proportional reward distribution.

* **Refactor**
  * Replaced hardcoded numeric values with named constants for better clarity and maintainability.
  * Renamed event struct from `NamedChanged` to `NameChanged` for consistency.
  * Renamed a field in transfer tracking for clearer intent.

* **Tests**
  * Expanded test coverage for delegation scenarios.

* **Chores**
  * Updated GitHub workflows to use a newer Rust nightly toolchain version and upgraded caching actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->