### PR TITLE
Fix event initialization by cloning deployed contracts before iteration

### DIFF
--- a/core/src/host.rs
+++ b/core/src/host.rs
@@ -454,7 +454,8 @@ impl HostEnv {
         *self.captures_events.borrow_mut() = captures;
         if captures {
             // Initialize events for all deployed contracts if capturing is enabled
-            for (contract_address, _) in self.deployed_contracts.borrow().iter() {
+            let deployed_contracts = self.deployed_contracts.borrow().clone();
+            for (contract_address, _) in deployed_contracts.iter() {
                 self.init_events(contract_address);
             }
         }


### PR DESCRIPTION
Resolves #595 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stability when enabling event capture: existing deployed contracts are initialized immediately.
  - Clarified behavior: only contracts deployed at the time of enabling are included in the initial initialization; later deployments are handled separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->