### PR TITLE
Update examples and justfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Changelog for `odra`.
 
-## [2.3.0] - 2025-08-11
+## [2.3.1] - 2025-08-11
 ### Added
 - `ODRA_CASPER_LIVENET_TTL` environment variable to set the TTL for the Casper livenet.
 

--- a/examples/bin/erc20_on_livenet.rs
+++ b/examples/bin/erc20_on_livenet.rs
@@ -1,6 +1,6 @@
 //! Deploys an ERC20 contract and transfers some tokens to another address.
 use odra::casper_types::U256;
-use odra::host::{Deployer, HostEnv, HostRefLoader};
+use odra::host::{Deployer, HostEnv, HostRefLoader, InstallConfig};
 use odra::prelude::*;
 use odra_modules::erc20::{Erc20, Erc20HostRef, Erc20InitArgs};
 use std::str::FromStr;
@@ -49,6 +49,6 @@ pub fn deploy_erc20(env: &HostEnv) -> Erc20HostRef {
         initial_supply
     };
 
-    env.set_gas(100_000_000_000u64);
+    env.set_gas(450_000_000_000u64);
     Erc20::deploy(env, init_args)
 }

--- a/examples/bin/erc20_on_livenet.rs
+++ b/examples/bin/erc20_on_livenet.rs
@@ -1,6 +1,6 @@
 //! Deploys an ERC20 contract and transfers some tokens to another address.
 use odra::casper_types::U256;
-use odra::host::{Deployer, HostEnv, HostRefLoader, InstallConfig};
+use odra::host::{Deployer, HostEnv, HostRefLoader};
 use odra::prelude::*;
 use odra_modules::erc20::{Erc20, Erc20HostRef, Erc20InitArgs};
 use std::str::FromStr;

--- a/examples/justfile
+++ b/examples/justfile
@@ -1,5 +1,5 @@
 run-nctl:
-    docker run --rm -it --name mynctl -d -p 11101:11101 -p 14101:14101 -p 18101:18101 -p 25101:25101 makesoftware/casper-nctl:v200-0119c2b7
+    docker run --rm -it --name mynctl -d -p 11101:11101 -p 14101:14101 -p 18101:18101 -p 25101:25101 makesoftware/casper-nctl:v210
 
 cli *ARGS:
     cargo run --bin odra_cli -- {{ARGS}}

--- a/examples/ourcoin/bin/our_token_livenet.rs
+++ b/examples/ourcoin/bin/our_token_livenet.rs
@@ -3,9 +3,9 @@
 use std::str::FromStr;
 
 use odra::casper_types::U256;
-use odra::host::{Deployer, HostEnv, HostRef, HostRefLoader};
-use ourcoin::token::{OurTokenHostRef, OurTokenInitArgs};
-use Address;
+use odra::host::{Deployer, HostEnv, HostRefLoader};
+use odra::prelude::{Address, Addressable};
+use ourcoin::token::{OurToken, OurTokenHostRef, OurTokenInitArgs};
 
 fn main() {
     // Load the Casper livenet environment.
@@ -21,12 +21,11 @@ fn main() {
     let mut token = deploy_our_token(&env);
     println!("Token address: {}", token.address().to_string());
 
+    env.set_gas(2_500_000_000u64);
     // Propose minting new tokens.
-    env.set_gas(1_000_000_000u64);
     token.propose_new_mint(recipient, U256::from(1_000));
 
     // Vote, we are the only voter.
-    env.set_gas(1_000_000_000u64);
     token.vote(true, U256::from(1_000));
 
     // Let's advance the block time by 11 minutes, as
@@ -36,7 +35,6 @@ fn main() {
     env.advance_block_time(11 * 60 * 1000);
 
     // Tally the votes.
-    env.set_gas(1_500_000_000u64);
     token.tally();
 
     // Check the balances.
@@ -51,7 +49,7 @@ fn main() {
 fn _load_cep18(env: &HostEnv) -> OurTokenHostRef {
     let address = "hash-XXXXX";
     let address = Address::from_str(address).unwrap();
-    OurTokenHostRef::load(env, address)
+    OurToken::load(env, address)
 }
 
 /// Deploys a contract.
@@ -68,6 +66,6 @@ pub fn deploy_our_token(env: &HostEnv) -> OurTokenHostRef {
         initial_supply
     };
 
-    env.set_gas(300_000_000_000u64);
+    env.set_gas(400_000_000_000u64);
     OurToken::deploy(env, init_args)
 }

--- a/justfile
+++ b/justfile
@@ -116,7 +116,12 @@ test-livenet:
     rm -rf examples/.node-keys
 
 run-example-erc20-on-livenet:
-    cd examples && cargo run --bin erc20-on-livenet --features casper-livenet --no-default-features
+    set shell := bash
+    mkdir -p examples/.node-keys
+    cp modules/wasm/Erc20.wasm examples/wasm/
+    docker exec mynctl /bin/bash -c "cat /home/casper/casper-nctl/assets/net-1/users/user-1/secret_key.pem" > examples/.node-keys/secret_key.pem
+    cd examples && ODRA_CASPER_LIVENET_SECRET_KEY_PATH=.node-keys/secret_key.pem ODRA_CASPER_LIVENET_NODE_ADDRESS=http://localhost:11101 ODRA_CASPER_LIVENET_EVENTS_URL=http://localhost:18101/events ODRA_CASPER_LIVENET_CHAIN_NAME=casper-net-1 ODRA_CASPER_LIVENET_KEY_1=.node-keys/secret_key.pem cargo run --bin erc20_on_livenet --features livenet
+    rm -rf examples/.node-keys
 
 clean:
     cargo clean


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Documentation
  * Changelog bumped to 2.3.1; Transaction TTL increased from 1m to 5m (ODRA_CASPER_LIVENET_TTL entry present).

* Examples
  * Increased deployment gas and simplified gas scheduling for livenet flows.
  * Updated token loading approach for livenet examples.

* Chores
  * Added pre-flight setup and environment-driven run workflow; expanded clean task; updated local network Docker image.

* Tests
  * Livenet tests support a second key and standardized environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->