### PR TITLE
Update schema generation

### DIFF
--- a/examples/resources/casper_contract_schemas/balance_checker_schema.json
+++ b/examples/resources/casper_contract_schemas/balance_checker_schema.json
@@ -50,6 +50,12 @@
         "optional": false
       },
       {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
+      },
+      {
         "name": "address",
         "description": null,
         "ty": "Key",

--- a/examples/resources/casper_contract_schemas/counterv1_schema.json
+++ b/examples/resources/casper_contract_schemas/counterv1_schema.json
@@ -78,6 +78,12 @@
         "description": "The arg name for the contract upgradeability setting.",
         "ty": "Bool",
         "optional": false
+      },
+      {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
       }
     ]
   }

--- a/examples/resources/casper_contract_schemas/counterv2_schema.json
+++ b/examples/resources/casper_contract_schemas/counterv2_schema.json
@@ -24,24 +24,6 @@
   "errors": [],
   "entry_points": [
     {
-      "name": "upgrade",
-      "description": "",
-      "is_mutable": true,
-      "arguments": [
-        {
-          "name": "new_start",
-          "description": null,
-          "ty": {
-            "Option": "U256"
-          },
-          "optional": false
-        }
-      ],
-      "return_ty": "Unit",
-      "is_contract_context": true,
-      "access": "public"
-    },
-    {
       "name": "increment",
       "description": "",
       "is_mutable": true,
@@ -119,6 +101,12 @@
       {
         "name": "odra_cfg_is_upgradable",
         "description": "The arg name for the contract upgradeability setting.",
+        "ty": "Bool",
+        "optional": false
+      },
+      {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
         "ty": "Bool",
         "optional": false
       },

--- a/examples/resources/casper_contract_schemas/cross_contract_schema.json
+++ b/examples/resources/casper_contract_schemas/cross_contract_schema.json
@@ -43,6 +43,12 @@
         "optional": false
       },
       {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
+      },
+      {
         "name": "math_engine_address",
         "description": null,
         "ty": "Key",

--- a/examples/resources/casper_contract_schemas/dog_contract2_schema.json
+++ b/examples/resources/casper_contract_schemas/dog_contract2_schema.json
@@ -75,6 +75,12 @@
         "optional": false
       },
       {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
+      },
+      {
         "name": "name",
         "description": null,
         "ty": "String",

--- a/examples/resources/casper_contract_schemas/dog_contract3_schema.json
+++ b/examples/resources/casper_contract_schemas/dog_contract3_schema.json
@@ -77,6 +77,12 @@
         "optional": false
       },
       {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
+      },
+      {
         "name": "name",
         "description": null,
         "ty": "String",

--- a/examples/resources/casper_contract_schemas/dog_contract_schema.json
+++ b/examples/resources/casper_contract_schemas/dog_contract_schema.json
@@ -119,6 +119,12 @@
         "optional": false
       },
       {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
+      },
+      {
         "name": "barks",
         "description": null,
         "ty": "Bool",

--- a/examples/resources/casper_contract_schemas/host_contract_schema.json
+++ b/examples/resources/casper_contract_schemas/host_contract_schema.json
@@ -77,6 +77,12 @@
         "optional": false
       },
       {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
+      },
+      {
         "name": "name",
         "description": null,
         "ty": "String",

--- a/examples/resources/casper_contract_schemas/livenet_contract_schema.json
+++ b/examples/resources/casper_contract_schemas/livenet_contract_schema.json
@@ -188,6 +188,12 @@
         "optional": false
       },
       {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
+      },
+      {
         "name": "erc20_address",
         "description": null,
         "ty": "Key",

--- a/examples/resources/casper_contract_schemas/math_engine_schema.json
+++ b/examples/resources/casper_contract_schemas/math_engine_schema.json
@@ -54,6 +54,12 @@
         "description": "The arg name for the contract upgradeability setting.",
         "ty": "Bool",
         "optional": false
+      },
+      {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
       }
     ]
   }

--- a/examples/resources/casper_contract_schemas/mock_moderated_schema.json
+++ b/examples/resources/casper_contract_schemas/mock_moderated_schema.json
@@ -247,6 +247,12 @@
         "description": "The arg name for the contract upgradeability setting.",
         "ty": "Bool",
         "optional": false
+      },
+      {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
       }
     ]
   }

--- a/examples/resources/casper_contract_schemas/modules_contract_schema.json
+++ b/examples/resources/casper_contract_schemas/modules_contract_schema.json
@@ -41,6 +41,12 @@
         "description": "The arg name for the contract upgradeability setting.",
         "ty": "Bool",
         "optional": false
+      },
+      {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
       }
     ]
   }

--- a/examples/resources/casper_contract_schemas/my_contract_schema.json
+++ b/examples/resources/casper_contract_schemas/my_contract_schema.json
@@ -223,6 +223,12 @@
         "optional": false
       },
       {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
+      },
+      {
         "name": "ip",
         "description": null,
         "ty": "IP",

--- a/examples/resources/casper_contract_schemas/nested_odra_types_contract_schema.json
+++ b/examples/resources/casper_contract_schemas/nested_odra_types_contract_schema.json
@@ -142,6 +142,12 @@
         "description": "The arg name for the contract upgradeability setting.",
         "ty": "Bool",
         "optional": false
+      },
+      {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
       }
     ]
   }

--- a/examples/resources/casper_contract_schemas/owned_cep95_schema.json
+++ b/examples/resources/casper_contract_schemas/owned_cep95_schema.json
@@ -636,6 +636,12 @@
         "optional": false
       },
       {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
+      },
+      {
         "name": "name",
         "description": null,
         "ty": "String",

--- a/examples/resources/casper_contract_schemas/owned_contract_schema.json
+++ b/examples/resources/casper_contract_schemas/owned_contract_schema.json
@@ -79,6 +79,12 @@
         "optional": false
       },
       {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
+      },
+      {
         "name": "name",
         "description": null,
         "ty": "String",

--- a/examples/resources/casper_contract_schemas/owned_token_schema.json
+++ b/examples/resources/casper_contract_schemas/owned_token_schema.json
@@ -364,6 +364,12 @@
         "optional": false
       },
       {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
+      },
+      {
         "name": "name",
         "description": null,
         "ty": "String",

--- a/examples/resources/casper_contract_schemas/party_contract_schema.json
+++ b/examples/resources/casper_contract_schemas/party_contract_schema.json
@@ -87,6 +87,12 @@
         "description": "The arg name for the contract upgradeability setting.",
         "ty": "Bool",
         "optional": false
+      },
+      {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
       }
     ]
   }

--- a/examples/resources/casper_contract_schemas/pauseable_counter_schema.json
+++ b/examples/resources/casper_contract_schemas/pauseable_counter_schema.json
@@ -124,6 +124,12 @@
         "description": "The arg name for the contract upgradeability setting.",
         "ty": "Bool",
         "optional": false
+      },
+      {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
       }
     ]
   }

--- a/examples/resources/casper_contract_schemas/public_wallet_schema.json
+++ b/examples/resources/casper_contract_schemas/public_wallet_schema.json
@@ -66,6 +66,12 @@
         "description": "The arg name for the contract upgradeability setting.",
         "ty": "Bool",
         "optional": false
+      },
+      {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
       }
     ]
   }

--- a/examples/resources/casper_contract_schemas/reentrancy_mock_schema.json
+++ b/examples/resources/casper_contract_schemas/reentrancy_mock_schema.json
@@ -82,6 +82,12 @@
         "description": "The arg name for the contract upgradeability setting.",
         "ty": "Bool",
         "optional": false
+      },
+      {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
       }
     ]
   }

--- a/examples/resources/casper_contract_schemas/signature_verifier_schema.json
+++ b/examples/resources/casper_contract_schemas/signature_verifier_schema.json
@@ -64,6 +64,12 @@
         "description": "The arg name for the contract upgradeability setting.",
         "ty": "Bool",
         "optional": false
+      },
+      {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
       }
     ]
   }

--- a/examples/resources/casper_contract_schemas/testing_contract_schema.json
+++ b/examples/resources/casper_contract_schemas/testing_contract_schema.json
@@ -61,6 +61,12 @@
         "optional": false
       },
       {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
+      },
+      {
         "name": "name",
         "description": null,
         "ty": "String",

--- a/examples/resources/casper_contract_schemas/time_lock_wallet_schema.json
+++ b/examples/resources/casper_contract_schemas/time_lock_wallet_schema.json
@@ -146,6 +146,12 @@
         "optional": false
       },
       {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
+      },
+      {
         "name": "lock_duration",
         "description": null,
         "ty": "U64",

--- a/examples/resources/casper_contract_schemas/token_manager_schema.json
+++ b/examples/resources/casper_contract_schemas/token_manager_schema.json
@@ -157,6 +157,12 @@
         "description": "The arg name for the contract upgradeability setting.",
         "ty": "Bool",
         "optional": false
+      },
+      {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
       }
     ]
   }

--- a/examples/resources/casper_contract_schemas/token_schema.json
+++ b/examples/resources/casper_contract_schemas/token_schema.json
@@ -43,6 +43,12 @@
         "optional": false
       },
       {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
+      },
+      {
         "name": "name",
         "description": null,
         "ty": "String",

--- a/examples/resources/casper_contract_schemas/validators_contract_schema.json
+++ b/examples/resources/casper_contract_schemas/validators_contract_schema.json
@@ -102,6 +102,12 @@
         "optional": false
       },
       {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
+      },
+      {
         "name": "validator",
         "description": null,
         "ty": "PublicKey",

--- a/modules/resources/casper_contract_schemas/basic_cep95_schema.json
+++ b/modules/resources/casper_contract_schemas/basic_cep95_schema.json
@@ -622,6 +622,12 @@
         "optional": false
       },
       {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
+      },
+      {
         "name": "name",
         "description": null,
         "ty": "String",

--- a/modules/resources/casper_contract_schemas/basic_contract_schema.json
+++ b/modules/resources/casper_contract_schemas/basic_contract_schema.json
@@ -35,6 +35,12 @@
         "description": "The arg name for the contract upgradeability setting.",
         "ty": "Bool",
         "optional": false
+      },
+      {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
       }
     ]
   }

--- a/modules/resources/casper_contract_schemas/cep18_client_contract_schema.json
+++ b/modules/resources/casper_contract_schemas/cep18_client_contract_schema.json
@@ -192,6 +192,12 @@
         "description": "The arg name for the contract upgradeability setting.",
         "ty": "Bool",
         "optional": false
+      },
+      {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
       }
     ]
   }

--- a/modules/resources/casper_contract_schemas/cep18_example_schema.json
+++ b/modules/resources/casper_contract_schemas/cep18_example_schema.json
@@ -535,6 +535,12 @@
         "optional": false
       },
       {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
+      },
+      {
         "name": "symbol",
         "description": null,
         "ty": "String",

--- a/modules/resources/casper_contract_schemas/cep18_schema.json
+++ b/modules/resources/casper_contract_schemas/cep18_schema.json
@@ -440,6 +440,12 @@
         "optional": false
       },
       {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
+      },
+      {
         "name": "symbol",
         "description": null,
         "ty": "String",

--- a/modules/resources/casper_contract_schemas/erc1155_receiver_schema.json
+++ b/modules/resources/casper_contract_schemas/erc1155_receiver_schema.json
@@ -224,6 +224,12 @@
         "description": "The arg name for the contract upgradeability setting.",
         "ty": "Bool",
         "optional": false
+      },
+      {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
       }
     ]
   }

--- a/modules/resources/casper_contract_schemas/erc1155_token_schema.json
+++ b/modules/resources/casper_contract_schemas/erc1155_token_schema.json
@@ -597,6 +597,12 @@
         "description": "The arg name for the contract upgradeability setting.",
         "ty": "Bool",
         "optional": false
+      },
+      {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
       }
     ]
   }

--- a/modules/resources/casper_contract_schemas/erc20_schema.json
+++ b/modules/resources/casper_contract_schemas/erc20_schema.json
@@ -314,6 +314,12 @@
         "optional": false
       },
       {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
+      },
+      {
         "name": "symbol",
         "description": null,
         "ty": "String",

--- a/modules/resources/casper_contract_schemas/erc721_receiver_schema.json
+++ b/modules/resources/casper_contract_schemas/erc721_receiver_schema.json
@@ -74,6 +74,12 @@
         "description": "The arg name for the contract upgradeability setting.",
         "ty": "Bool",
         "optional": false
+      },
+      {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
       }
     ]
   }

--- a/modules/resources/casper_contract_schemas/erc721_token_schema.json
+++ b/modules/resources/casper_contract_schemas/erc721_token_schema.json
@@ -533,6 +533,12 @@
         "optional": false
       },
       {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
+      },
+      {
         "name": "name",
         "description": null,
         "ty": "String",

--- a/modules/resources/casper_contract_schemas/nft_receiver_schema.json
+++ b/modules/resources/casper_contract_schemas/nft_receiver_schema.json
@@ -102,6 +102,12 @@
         "description": "The arg name for the contract upgradeability setting.",
         "ty": "Bool",
         "optional": false
+      },
+      {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
       }
     ]
   }

--- a/modules/resources/casper_contract_schemas/ownable2_step_schema.json
+++ b/modules/resources/casper_contract_schemas/ownable2_step_schema.json
@@ -188,6 +188,12 @@
         "optional": false
       },
       {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
+      },
+      {
         "name": "owner",
         "description": null,
         "ty": "Key",

--- a/modules/resources/casper_contract_schemas/ownable_schema.json
+++ b/modules/resources/casper_contract_schemas/ownable_schema.json
@@ -171,6 +171,12 @@
         "optional": false
       },
       {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
+      },
+      {
         "name": "owner",
         "description": null,
         "ty": "Key",

--- a/modules/resources/casper_contract_schemas/rejectingnft_receiver_schema.json
+++ b/modules/resources/casper_contract_schemas/rejectingnft_receiver_schema.json
@@ -74,6 +74,12 @@
         "description": "The arg name for the contract upgradeability setting.",
         "ty": "Bool",
         "optional": false
+      },
+      {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
       }
     ]
   }

--- a/modules/resources/casper_contract_schemas/wrapped_native_token_schema.json
+++ b/modules/resources/casper_contract_schemas/wrapped_native_token_schema.json
@@ -463,6 +463,12 @@
         "description": "The arg name for the contract upgradeability setting.",
         "ty": "Bool",
         "optional": false
+      },
+      {
+        "name": "odra_cfg_is_upgrade",
+        "description": "The arg name for telling the installer that the contract is being upgraded.",
+        "ty": "Bool",
+        "optional": false
       }
     ]
   }

--- a/odra-schema/src/lib.rs
+++ b/odra-schema/src/lib.rs
@@ -287,6 +287,14 @@ fn call_method(
                 ty: NamedCLType::Bool.into(),
                 optional: false
             },
+            Argument {
+                name: odra_core::consts::IS_UPGRADE_ARG.to_string(),
+                description: Some(
+                    "The arg name for telling the installer that the contract is being upgraded.".to_string()
+                ),
+                ty: NamedCLType::Bool.into(),
+                optional: false
+            },
         ]
         .iter()
         .chain(constructor_args.iter())

--- a/odra-schema/src/lib.rs
+++ b/odra-schema/src/lib.rs
@@ -190,7 +190,7 @@ pub fn schema<T: SchemaEntrypoints + SchemaEvents + SchemaCustomTypes + SchemaEr
 
     let entry_points = entry_points
         .into_iter()
-        .filter(|e| e.name != "init")
+        .filter(|e| e.name != "init" && e.name != "upgrade")
         .collect();
 
     let wasm_file_name = format!("{}.wasm", module_name);


### PR DESCRIPTION
add the `odra_cfg_is_upgrade` arg in the call entry point
Do not generate non public entry points (migrate_events, upgrade)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a required upgrade indicator argument to initialization/call schemas across example and module contracts (e.g., ERC20/721/1155, CEP18, tokens, wallets, owned/ownable, counters, validators, math engine, cross-contract, etc.). This flag clarifies when a deploy is performing an upgrade.
- Refactor
  - Consolidated upgrade handling in schemas by removing the separate upgrade entry point (e.g., CounterV2). Upgrades are now signaled via the new argument.
- Chores
  - Schema generation updated to exclude upgrade entry points for consistency across all published contract schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->