### PR TITLE
Add deploy mode argument and functionality to the CLI

### DIFF
--- a/odra-cli/src/cmd/args.rs
+++ b/odra-cli/src/cmd/args.rs
@@ -176,7 +176,7 @@ fn arg_deploy_mode() -> clap::Arg {
         .long_help(
             "Deployment mode strategy:\n\
              - default: Use existing contract if available, otherwise deploy a new one\n\
-             - override: Force redeploy, make edits in the existing contract configuration\n\
+             - override: Force redeploy, overwrite the existing contract configuration\n\
              - archive: Redeploy contracts, archive the existing contract configuration and create a new one."
         )
         .value_name("MODE")

--- a/odra-cli/src/cmd/args.rs
+++ b/odra-cli/src/cmd/args.rs
@@ -9,6 +9,10 @@ pub const ARG_GAS: &str = "gas";
 pub const ARG_CONTRACTS: &str = "contracts-toml";
 pub const ARG_PRINT_EVENTS: &str = "print-events";
 pub const ARG_NUMBER: &str = "number";
+pub const ARG_DEPLOY_MODE: &str = "deploy-mode";
+
+pub const DEPLOY_MODE_OVERRIDE: &str = "override";
+pub const DEPLOY_MODE_ARCHIVE: &str = "archive";
 
 #[derive(Debug, thiserror::Error)]
 pub enum ArgsError {
@@ -86,7 +90,8 @@ pub enum Arg {
     Gas,
     Contracts,
     EventsNumber,
-    PrintEvents
+    PrintEvents,
+    DeployMode
 }
 
 impl Arg {
@@ -96,7 +101,8 @@ impl Arg {
             Arg::Gas => ARG_GAS,
             Arg::Contracts => ARG_CONTRACTS,
             Arg::EventsNumber => ARG_NUMBER,
-            Arg::PrintEvents => ARG_PRINT_EVENTS
+            Arg::PrintEvents => ARG_PRINT_EVENTS,
+            Arg::DeployMode => ARG_DEPLOY_MODE
         }
     }
 }
@@ -108,7 +114,8 @@ impl From<Arg> for clap::Arg {
             Arg::Gas => arg_gas(),
             Arg::Contracts => arg_contracts(),
             Arg::EventsNumber => arg_number("Number of events to print"),
-            Arg::PrintEvents => arg_print_events()
+            Arg::PrintEvents => arg_print_events(),
+            Arg::DeployMode => arg_deploy_mode()
         }
     }
 }
@@ -160,6 +167,23 @@ fn arg_print_events() -> clap::Arg {
         .short('p')
         .help("Print events emitted by the contract")
         .action(ArgAction::SetTrue)
+}
+
+fn arg_deploy_mode() -> clap::Arg {
+    clap::Arg::new(ARG_DEPLOY_MODE)
+        .long(ARG_DEPLOY_MODE)
+        .help("Deployment mode strategy.")
+        .long_help(
+            "Deployment mode strategy:\n\
+             - default: Use existing contract if available, otherwise deploy a new one\n\
+             - override: Force redeploy, make edits in the existing contract configuration\n\
+             - archive: Redeploy contracts, archive the existing contract configuration and create a new one."
+        )
+        .value_name("MODE")
+        .required(false)
+        .default_value("default")
+        .value_parser(["default", DEPLOY_MODE_OVERRIDE, DEPLOY_MODE_ARCHIVE])
+        .action(ArgAction::Set)
 }
 
 pub fn read_arg<T: ToOwned<Owned = T> + Any + Clone + Send + Sync + 'static>(

--- a/odra-cli/src/cmd/args.rs
+++ b/odra-cli/src/cmd/args.rs
@@ -9,7 +9,8 @@ pub const ARG_GAS: &str = "gas";
 pub const ARG_CONTRACTS: &str = "contracts-toml";
 pub const ARG_PRINT_EVENTS: &str = "print-events";
 pub const ARG_NUMBER: &str = "number";
-pub const ARG_DEPLOY_MODE: &str = "deploy-mode";
+pub const ARG_DEPLOY_MODE: &str = "deploy_mode";
+const ARG_DEPLOY_MODE_LONG: &str = "deploy-mode";
 
 pub const DEPLOY_MODE_OVERRIDE: &str = "override";
 pub const DEPLOY_MODE_ARCHIVE: &str = "archive";
@@ -171,7 +172,7 @@ fn arg_print_events() -> clap::Arg {
 
 fn arg_deploy_mode() -> clap::Arg {
     clap::Arg::new(ARG_DEPLOY_MODE)
-        .long(ARG_DEPLOY_MODE)
+        .long(ARG_DEPLOY_MODE_LONG)
         .help("Deployment mode strategy.")
         .long_help(
             "Deployment mode strategy:\n\

--- a/odra-cli/src/cmd/deploy.rs
+++ b/odra-cli/src/cmd/deploy.rs
@@ -1,8 +1,13 @@
 use crate::{
-    cmd::DEPLOY_SUBCOMMAND, container::ContractError, custom_types::CustomTypeSet,
+    cmd::{
+        args::{read_arg, Arg},
+        DEPLOY_SUBCOMMAND
+    },
+    container::ContractError,
+    custom_types::CustomTypeSet,
     DeployedContractsContainer
 };
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use clap::{ArgMatches, Command};
 use odra::{host::HostEnv, prelude::OdraError};
 use thiserror::Error;
@@ -29,10 +34,14 @@ impl MutableCommand for DeployCmd {
     fn run(
         &self,
         env: &HostEnv,
-        _args: &ArgMatches,
+        args: &ArgMatches,
         _types: &CustomTypeSet,
         container: &mut DeployedContractsContainer
     ) -> Result<()> {
+        let deploy_mode = read_arg::<String>(args, Arg::DeployMode)
+            .ok_or_else(|| anyhow!("Failed to read deploy mode"))?;
+        container.apply_deploy_mode(deploy_mode)?;
+
         self.script.deploy(env, container)?;
         Ok(())
     }
@@ -40,7 +49,9 @@ impl MutableCommand for DeployCmd {
 
 impl From<&DeployCmd> for Command {
     fn from(_value: &DeployCmd) -> Self {
-        Command::new(DEPLOY_SUBCOMMAND).about("Runs the deploy script")
+        Command::new(DEPLOY_SUBCOMMAND)
+            .arg(Arg::DeployMode)
+            .about("Runs the deploy script")
     }
 }
 
@@ -117,15 +128,35 @@ mod tests {
     }
 
     #[test]
-    fn deploy_does_not_accept_args() {
-        // This is a placeholder test to ensure the DeployCmd can be converted to a Command.
+    fn deploy_accepts_mode_arg() {
         let cmd = DeployCmd::new(MockDeployScript);
         let command: Command = (&cmd).into();
+
+        let result =
+            command
+                .clone()
+                .try_get_matches_from(vec!["test", "--deploy-mode", "override"]);
+        assert!(result.is_ok());
+
+        let result = command
+            .clone()
+            .try_get_matches_from(vec!["test", "--deploy-mode", "default"]);
+        assert!(result.is_ok());
+
+        let result = command
+            .clone()
+            .try_get_matches_from(vec!["test", "--deploy-mode", "fresh"]);
+        assert!(result.is_ok());
+
+        let result = command
+            .clone()
+            .try_get_matches_from(vec!["test", "--deploy-mode", "abc"]);
+        assert!(result.is_err());
 
         let result = command.try_get_matches_from(vec!["test"]);
         assert!(result.is_ok());
 
         let command: Command = (&cmd).into();
-        assert_eq!(command.get_arguments().count(), 0);
+        assert_eq!(command.get_arguments().count(), 1);
     }
 }

--- a/odra-cli/src/cmd/deploy.rs
+++ b/odra-cli/src/cmd/deploy.rs
@@ -38,8 +38,9 @@ impl MutableCommand for DeployCmd {
         _types: &CustomTypeSet,
         container: &mut DeployedContractsContainer
     ) -> Result<()> {
-        let deploy_mode = read_arg::<String>(args, Arg::DeployMode)
-            .unwrap_or("default".to_string());
+        let deploy_mode =
+            read_arg::<String>(args, Arg::DeployMode).ok_or(DeployError::MissingDeployMode)?;
+        crate::log(format!("Deploy mode: {}", deploy_mode));
         container.apply_deploy_mode(deploy_mode)?;
 
         self.script.deploy(env, container)?;
@@ -73,7 +74,9 @@ pub enum DeployError {
     #[error("Deploy error: {message}")]
     OdraError { message: String },
     #[error("Contract read error: {0}")]
-    ContractReadError(#[from] ContractError)
+    ContractReadError(#[from] ContractError),
+    #[error("Missing deploy mode argument")]
+    MissingDeployMode
 }
 
 impl From<OdraError> for DeployError {
@@ -109,9 +112,11 @@ mod tests {
         let env = test_utils::mock_host_env();
         let cmd = DeployCmd::new(MockDeployScript);
         let mut container = test_utils::mock_contracts_container();
+        let command: Command = (&cmd).into();
+        let arg_matches = command.try_get_matches_from(vec!["test"]).unwrap();
         let result = cmd.run(
             &env,
-            &ArgMatches::default(),
+            &arg_matches,
             &CustomTypeSet::default(),
             &mut container
         );

--- a/odra-cli/src/cmd/deploy.rs
+++ b/odra-cli/src/cmd/deploy.rs
@@ -7,7 +7,7 @@ use crate::{
     custom_types::CustomTypeSet,
     DeployedContractsContainer
 };
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use clap::{ArgMatches, Command};
 use odra::{host::HostEnv, prelude::OdraError};
 use thiserror::Error;
@@ -39,7 +39,7 @@ impl MutableCommand for DeployCmd {
         container: &mut DeployedContractsContainer
     ) -> Result<()> {
         let deploy_mode = read_arg::<String>(args, Arg::DeployMode)
-            .ok_or_else(|| anyhow!("Failed to read deploy mode"))?;
+            .unwrap_or("default".to_string());
         container.apply_deploy_mode(deploy_mode)?;
 
         self.script.deploy(env, container)?;
@@ -145,7 +145,7 @@ mod tests {
 
         let result = command
             .clone()
-            .try_get_matches_from(vec!["test", "--deploy-mode", "fresh"]);
+            .try_get_matches_from(vec!["test", "--deploy-mode", "archive"]);
         assert!(result.is_ok());
 
         let result = command

--- a/odra-cli/src/container.rs
+++ b/odra-cli/src/container.rs
@@ -10,6 +10,11 @@ use odra::{
 use serde_derive::{Deserialize, Serialize};
 use thiserror::Error;
 
+use crate::{
+    cmd::args::{DEPLOY_MODE_ARCHIVE, DEPLOY_MODE_OVERRIDE},
+    log
+};
+
 pub const DEPLOYED_CONTRACTS_FILE: &str = "resources/contracts.toml";
 
 #[derive(Error, Debug)]
@@ -33,6 +38,8 @@ pub(crate) trait ContractStorage {
     fn read(&self) -> Result<ContractsData, ContractError>;
     /// Writes the contract data to the storage.
     fn write(&mut self, data: &ContractsData) -> Result<(), ContractError>;
+    /// Creates a backup copy of the contract data.
+    fn backup(&self) -> Result<(), ContractError>;
 }
 
 /// Represents the data structure for storing deployed contracts in a TOML file.
@@ -74,6 +81,15 @@ impl ContractStorage for FileContractStorage {
         let mut file = File::create(&self.file_path).map_err(ContractError::Io)?;
         file.write_all(content.as_bytes())
             .map_err(ContractError::Io)?;
+        Ok(())
+    }
+
+    fn backup(&self) -> Result<(), ContractError> {
+        let mut new_path = self.file_path.with_extension("old");
+        while new_path.exists() {
+            new_path = new_path.with_added_extension("old");
+        }
+        std::fs::copy(&self.file_path, new_path).map_err(ContractError::Io)?;
         Ok(())
     }
 }
@@ -120,6 +136,24 @@ impl DeployedContractsContainer {
                 storage: Box::new(storage)
             }
         }
+    }
+
+    pub fn apply_deploy_mode(&mut self, mode: String) -> Result<(), ContractError> {
+        match mode.as_str() {
+            DEPLOY_MODE_OVERRIDE => {
+                self.data.contracts.clear();
+                self.storage.write(&self.data)?;
+                log("Contracts configuration has been overridden");
+            }
+            DEPLOY_MODE_ARCHIVE => {
+                self.storage.backup()?;
+                self.data.contracts.clear();
+                self.storage.write(&self.data)?;
+                log("Starting fresh deployment. Previous contracts configuration has been backed up.");
+            }
+            _ => {} // default mode does nothing
+        }
+        Ok(())
     }
 
     /// Adds a contract to the container.

--- a/odra-cli/src/lib.rs
+++ b/odra-cli/src/lib.rs
@@ -3,7 +3,7 @@
 //! The Odra CLI is a command line interface built on top of the [clap] crate
 //! that allows users to interact with smart contracts.
 
-#![feature(box_patterns, error_generic_member_access)]
+#![feature(box_patterns, error_generic_member_access, path_add_extension)]
 mod cli;
 mod cmd;
 mod container;

--- a/odra-cli/src/test_utils.rs
+++ b/odra-cli/src/test_utils.rs
@@ -343,6 +343,10 @@ impl ContractStorage for MockContractStorage {
     fn write(&mut self, data: &ContractsData) -> Result<(), ContractError> {
         Ok(())
     }
+
+    fn backup(&self) -> Result<(), ContractError> {
+        Ok(())
+    }
 }
 
 pub fn mock_contracts_container() -> DeployedContractsContainer {


### PR DESCRIPTION
- Introduced `deploy-mode` argument with options: `default`, `override`, and `archive`.
- Implemented logic to handle deployment modes in `DeployedContractsContainer`.
- Updated `DeployCmd` to accept and process the new argument.
- Added backup functionality for contract data during deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a deploy mode option (--deploy-mode) with values: default, override, archive.
  - Deploys can now override existing contracts (reset) or archive current state (create backup then reset); actions are logged.

- **Tests**
  - Added validation that --deploy-mode accepts supported values and rejects invalid ones.

- **Chores**
  - Added backup support for storage and a small crate feature adjustment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->