### PR TITLE
Use get_immediate_caller instead of stack.

### DIFF
--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -180,6 +180,8 @@ pub enum ExecutionError {
     CannotUpgradeWithoutUpgrade = 134,
     /// Factory module function should not be called directly.
     FactoryModuleCall = 135,
+    /// Cannot get an immediate caller
+    CannotGetAnImmediateCaller = 136,
     /// Maximum code for user errors
     MaxUserError = 64535,
     /// User error too high. The code should be in range 0..32767.

--- a/odra-casper/wasm-env/src/host_functions.rs
+++ b/odra-casper/wasm-env/src/host_functions.rs
@@ -9,7 +9,7 @@
 
 use crate::consts;
 use crate::consts::{CONSTRUCTOR_GROUP_NAME, NATIVE_EVENT_TOPIC, UPGRADER_GROUP_NAME};
-use casper_contract::contract_api::runtime::emit_message;
+use casper_contract::contract_api::runtime::{emit_message, get_immediate_caller};
 use casper_contract::contract_api::storage;
 use casper_contract::contract_api::system;
 use casper_contract::ext_ffi::{casper_emit_message, casper_remove_contract_user_group_urefs};
@@ -48,6 +48,7 @@ use odra_core::consts::{
     ALLOW_KEY_OVERRIDE_ARG, CREATE_UPGRADE_GROUP, IS_UPGRADABLE_ARG, IS_UPGRADE_ARG,
     PACKAGE_HASH_KEY_NAME_ARG, PACKAGE_HASH_TO_UPGRADE_ARG, RANDOM_BYTES_COUNT
 };
+use odra_core::prelude::ExecutionError::{CannotExtractCallerInfo, CannotGetAnImmediateCaller};
 use odra_core::validator::ValidatorInfo;
 use odra_core::{
     args::EntrypointArgument,
@@ -522,8 +523,7 @@ pub fn emit_native_event(event: &Bytes) {
 /// Gets the immediate session caller of the current execution.
 #[inline(always)]
 pub fn caller() -> OdraResult<Address> {
-    let second_elem = take_nth_caller_from_stack(1);
-    let caller = caller_info_to_caller(second_elem)?;
+    let caller = caller_info_to_caller(get_immediate_caller().unwrap_or_revert())?;
     Ok(Address::from(caller))
 }
 


### PR DESCRIPTION
Closes #612

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Caller identification now uses the immediate caller address instead of a call-stack lookup, improving accuracy for who initiated a transaction.
  * Added explicit handling and a clearer error outcome when immediate-caller retrieval fails, making failures more deterministic and diagnosable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->