### PR TITLE
Fix external_contract macro

### DIFF
--- a/odra-macros/src/ast/contract_ref_item.rs
+++ b/odra-macros/src/ast/contract_ref_item.rs
@@ -133,8 +133,9 @@ struct AddressFnItem;
 
 impl ToTokens for AddressFnItem {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let ty_address = utils::ty::address();
         tokens.append_all(quote::quote! {
-            fn address(&self) -> &Address {
+            fn address(&self) -> &#ty_address {
                 &self.address
             }
         })
@@ -197,13 +198,13 @@ mod test {
         let expected = quote! {
             /// [Erc20] Contract Ref.
             pub struct Erc20ContractRef {
-                env: Rc<odra::ContractEnv>,
-                address: Address,
+                env: odra::prelude::Rc<odra::ContractEnv>,
+                address: odra::prelude::Address,
                 attached_value: odra::casper_types::U512,
             }
 
             impl odra::ContractRef for Erc20ContractRef {
-                fn new(env: Rc<odra::ContractEnv>, address: Address) -> Self {
+                fn new(env: odra::prelude::Rc<odra::ContractEnv>, address: odra::prelude::Address) -> Self {
                     Self {
                         env,
                         address,
@@ -211,7 +212,7 @@ mod test {
                     }
                 }
 
-                fn address(&self) -> &Address {
+                fn address(&self) -> &odra::prelude::Address {
                     &self.address
                 }
 
@@ -368,13 +369,13 @@ mod test {
         let expected = quote! {
             /// [Erc20] Contract Ref.
             pub struct Erc20ContractRef {
-                env: Rc<odra::ContractEnv>,
-                address: Address,
+                env: odra::prelude::Rc<odra::ContractEnv>,
+                address: odra::prelude::Address,
                 attached_value: odra::casper_types::U512,
             }
 
             impl odra::ContractRef for Erc20ContractRef {
-                fn new(env: Rc<odra::ContractEnv>, address: Address) -> Self {
+                fn new(env: odra::prelude::Rc<odra::ContractEnv>, address: odra::prelude::Address) -> Self {
                     Self {
                         env,
                         address,
@@ -382,7 +383,7 @@ mod test {
                     }
                 }
 
-                fn address(&self) -> &Address {
+                fn address(&self) -> &odra::prelude::Address {
                     &self.address
                 }
 
@@ -452,13 +453,13 @@ mod test {
         let expected = quote! {
             /// [Erc20] Contract Ref.
             pub struct Erc20ContractRef {
-                env: Rc<odra::ContractEnv>,
-                address: Address,
+                env: odra::prelude::Rc<odra::ContractEnv>,
+                address: odra::prelude::Address,
                 attached_value: odra::casper_types::U512,
             }
 
             impl odra::ContractRef for Erc20ContractRef {
-                fn new(env: Rc<odra::ContractEnv>, address: Address) -> Self {
+                fn new(env: odra::prelude::Rc<odra::ContractEnv>, address: odra::prelude::Address) -> Self {
                     Self {
                         env,
                         address,
@@ -466,7 +467,7 @@ mod test {
                     }
                 }
 
-                fn address(&self) -> &Address {
+                fn address(&self) -> &odra::prelude::Address {
                     &self.address
                 }
 

--- a/odra-macros/src/ast/external_contract_item.rs
+++ b/odra-macros/src/ast/external_contract_item.rs
@@ -45,13 +45,13 @@ mod test {
         let expected = quote::quote! {
             /// [Token] Contract Ref.
             pub struct TokenContractRef {
-                env: Rc<odra::ContractEnv>,
-                address: Address,
+                env: odra::prelude::Rc<odra::ContractEnv>,
+                address: odra::prelude::Address,
                 attached_value: odra::casper_types::U512,
             }
 
             impl odra::ContractRef for TokenContractRef {
-                fn new(env: Rc<odra::ContractEnv>, address: Address) -> Self {
+                fn new(env: odra::prelude::Rc<odra::ContractEnv>, address: odra::prelude::Address) -> Self {
                     Self {
                         env,
                         address,
@@ -59,7 +59,7 @@ mod test {
                     }
                 }
 
-                fn address(&self) -> &Address {
+                fn address(&self) -> &odra::prelude::Address {
                     &self.address
                 }
 
@@ -108,13 +108,13 @@ mod test {
 
                 /// [Token] Host Ref.
                 pub struct TokenHostRef {
-                    address: Address,
+                    address: odra::prelude::Address,
                     env: odra::host::HostEnv,
                     attached_value: odra::casper_types::U512
                 }
 
                 impl odra::host::HostRef for TokenHostRef {
-                    fn new(address: Address, env: odra::host::HostEnv) -> Self {
+                    fn new(address: odra::prelude::Address, env: odra::host::HostEnv) -> Self {
                         Self {
                             address,
                             env,
@@ -130,7 +130,7 @@ mod test {
                         }
                     }
 
-                    fn contract_address(&self) -> Address {
+                    fn contract_address(&self) -> odra::prelude::Address {
                         self.address
                     }
 

--- a/odra-macros/src/ast/factory/impl_item.rs
+++ b/odra-macros/src/ast/factory/impl_item.rs
@@ -87,7 +87,7 @@ mod test {
                                 odra::args::odra_argument::<u32>("value")
                             ],
                             is_mutable: true,
-                            return_ty: <(Address, odra::casper_types::URef) as odra::casper_types::CLTyped>::cl_type(),
+                            return_ty: <(odra::prelude::Address, odra::casper_types::URef) as odra::casper_types::CLTyped>::cl_type(),
                             ty: odra::contract_def::EntrypointType::Public,
                             attributes: odra::prelude::vec![]
                         }
@@ -97,13 +97,13 @@ mod test {
 
             /// [Erc20Factory] Contract Ref.
             pub struct Erc20FactoryContractRef {
-                env: Rc<odra::ContractEnv>,
-                address: Address,
+                env: odra::prelude::Rc<odra::ContractEnv>,
+                address: odra::prelude::Address,
                 attached_value: odra::casper_types::U512,
             }
 
             impl odra::ContractRef for Erc20FactoryContractRef {
-                fn new(env: Rc<odra::ContractEnv>, address: Address) -> Self {
+                fn new(env: odra::prelude::Rc<odra::ContractEnv>, address: odra::prelude::Address) -> Self {
                     Self {
                         env,
                         address,
@@ -111,7 +111,7 @@ mod test {
                     }
                 }
 
-                fn address(&self) -> &Address {
+                fn address(&self) -> &odra::prelude::Address {
                     &self.address
                 }
 
@@ -125,7 +125,7 @@ mod test {
             }
 
             impl Erc20FactoryContractRef {
-                pub fn factory(&mut self, contract_name: String, value: u32) -> (Address, odra::casper_types::URef) {
+                pub fn factory(&mut self, contract_name: String, value: u32) -> (odra::prelude::Address, odra::casper_types::URef) {
                     self.env.call_contract(
                         self.address,
                         odra::CallDef::new(
@@ -181,13 +181,13 @@ mod test {
 
                 /// [Erc20Factory] Host Ref.
                 pub struct Erc20FactoryHostRef {
-                    address: Address,
+                    address: odra::prelude::Address,
                     env: odra::host::HostEnv,
                     attached_value: odra::casper_types::U512
                 }
 
                 impl odra::host::HostRef for Erc20FactoryHostRef {
-                    fn new(address: Address, env: odra::host::HostEnv) -> Self {
+                    fn new(address: odra::prelude::Address, env: odra::host::HostEnv) -> Self {
                         Self {
                             address,
                             env,
@@ -203,7 +203,7 @@ mod test {
                         }
                     }
 
-                    fn contract_address(&self) -> Address {
+                    fn contract_address(&self) -> odra::prelude::Address {
                         self.address
                     }
 
@@ -224,14 +224,14 @@ mod test {
                 }
 
                 impl Erc20FactoryHostRef {
-                    pub fn factory(&mut self, contract_name: String, value: u32) -> (Address, odra::casper_types::URef) {
+                    pub fn factory(&mut self, contract_name: String, value: u32) -> (odra::prelude::Address, odra::casper_types::URef) {
                         self.try_factory(contract_name, value).unwrap()
                     }
                 }
 
                 impl Erc20FactoryHostRef {
                     /// Does not fail in case of error, returns `odra::OdraResult` instead.
-                    pub fn try_factory(&mut self, contract_name: String, value: u32) -> OdraResult<(Address, odra::casper_types::URef)> {
+                    pub fn try_factory(&mut self, contract_name: String, value: u32) -> OdraResult<(odra::prelude::Address, odra::casper_types::URef)> {
                         self.env
                             .call_contract(
                                 self.address,
@@ -514,7 +514,7 @@ mod test {
                         schemas,
                         Some(named_args)
                     );
-                    let address: Address = contract_package_hash.into();
+                    let address: odra::prelude::Address = contract_package_hash.into();
 
                     exec_env.emit_event(Erc20FactoryContractDeployed {
                         contract_name: exec_env.get_named_arg::<odra::prelude::string::String>("contract_name"),
@@ -586,7 +586,7 @@ mod test {
                         true,
                         odra::prelude::vec![]
                     ),
-                    odra::schema::entry_point::<(Address, odra::casper_types::URef)>(
+                    odra::schema::entry_point::<(odra::prelude::Address, odra::casper_types::URef)>(
                         "factory", 
                         "", 
                         true, 

--- a/odra-macros/src/ast/factory/parts/has_entrypoints_item.rs
+++ b/odra-macros/src/ast/factory/parts/has_entrypoints_item.rs
@@ -163,7 +163,7 @@ mod test {
                                 odra::args::odra_argument::<u32>("value")
                             ],
                             is_mutable: true,
-                            return_ty: <(Address, odra::casper_types::URef) as odra::casper_types::CLTyped>::cl_type(),
+                            return_ty: <(odra::prelude::Address, odra::casper_types::URef) as odra::casper_types::CLTyped>::cl_type(),
                             ty: odra::contract_def::EntrypointType::Public,
                             attributes: odra::prelude::vec![]
                         }

--- a/odra-macros/src/ast/factory/parts/ref_item.rs
+++ b/odra-macros/src/ast/factory/parts/ref_item.rs
@@ -60,13 +60,13 @@ mod test {
         let expected = quote! {
             /// [Erc20Factory] Contract Ref.
             pub struct Erc20FactoryContractRef {
-                env: Rc<odra::ContractEnv>,
-                address: Address,
+                env: odra::prelude::Rc<odra::ContractEnv>,
+                address: odra::prelude::Address,
                 attached_value: odra::casper_types::U512,
             }
 
             impl odra::ContractRef for Erc20FactoryContractRef {
-                fn new(env: Rc<odra::ContractEnv>, address: Address) -> Self {
+                fn new(env: odra::prelude::Rc<odra::ContractEnv>, address: odra::prelude::Address) -> Self {
                     Self {
                         env,
                         address,
@@ -74,7 +74,7 @@ mod test {
                     }
                 }
 
-                fn address(&self) -> &Address {
+                fn address(&self) -> &odra::prelude::Address {
                     &self.address
                 }
 
@@ -88,7 +88,7 @@ mod test {
             }
 
             impl Erc20FactoryContractRef {
-                pub fn factory(&mut self, contract_name: String, value: u32) -> (Address, odra::casper_types::URef) {
+                pub fn factory(&mut self, contract_name: String, value: u32) -> (odra::prelude::Address, odra::casper_types::URef) {
                     self.env.call_contract(
                         self.address,
                         odra::CallDef::new(

--- a/odra-macros/src/ast/factory/parts/test_parts.rs
+++ b/odra-macros/src/ast/factory/parts/test_parts.rs
@@ -73,13 +73,13 @@ mod test {
 
                 /// [Erc20Factory] Host Ref.
                 pub struct Erc20FactoryHostRef {
-                    address: Address,
+                    address: odra::prelude::Address,
                     env: odra::host::HostEnv,
                     attached_value: odra::casper_types::U512
                 }
 
                 impl odra::host::HostRef for Erc20FactoryHostRef {
-                    fn new(address: Address, env: odra::host::HostEnv) -> Self {
+                    fn new(address: odra::prelude::Address, env: odra::host::HostEnv) -> Self {
                         Self {
                             address,
                             env,
@@ -95,7 +95,7 @@ mod test {
                         }
                     }
 
-                    fn contract_address(&self) -> Address {
+                    fn contract_address(&self) -> odra::prelude::Address {
                         self.address
                     }
 
@@ -116,14 +116,14 @@ mod test {
                 }
 
                 impl Erc20FactoryHostRef {
-                    pub fn factory(&mut self, contract_name: String, value: u32) -> (Address, odra::casper_types::URef) {
+                    pub fn factory(&mut self, contract_name: String, value: u32) -> (odra::prelude::Address, odra::casper_types::URef) {
                         self.try_factory(contract_name, value).unwrap()
                     }
                 }
 
                 impl Erc20FactoryHostRef {
                     /// Does not fail in case of error, returns `odra::OdraResult` instead.
-                    pub fn try_factory(&mut self, contract_name: String, value: u32) -> OdraResult<(Address, odra::casper_types::URef)> {
+                    pub fn try_factory(&mut self, contract_name: String, value: u32) -> OdraResult<(odra::prelude::Address, odra::casper_types::URef)> {
                         self.env
                             .call_contract(
                                 self.address,

--- a/odra-macros/src/ast/factory/parts/wasm_parts.rs
+++ b/odra-macros/src/ast/factory/parts/wasm_parts.rs
@@ -513,7 +513,7 @@ mod test {
                         schemas,
                         Some(named_args)
                     );
-                    let address: Address = contract_package_hash.into();
+                    let address: odra::prelude::Address = contract_package_hash.into();
 
                     exec_env.emit_event(Erc20FactoryContractDeployed {
                         contract_name: exec_env.get_named_arg::<odra::prelude::string::String>("contract_name"),

--- a/odra-macros/src/ast/host_ref_item.rs
+++ b/odra-macros/src/ast/host_ref_item.rs
@@ -323,13 +323,13 @@ mod ref_item_tests {
         let expected = quote! {
             /// [Erc20] Host Ref.
             pub struct Erc20HostRef {
-                address: Address,
+                address: odra::prelude::Address,
                 env: odra::host::HostEnv,
                 attached_value: odra::casper_types::U512
             }
 
             impl odra::host::HostRef for Erc20HostRef {
-                fn new(address: Address, env: odra::host::HostEnv) -> Self {
+                fn new(address: odra::prelude::Address, env: odra::host::HostEnv) -> Self {
                     Self {
                         address,
                         env,
@@ -345,7 +345,7 @@ mod ref_item_tests {
                     }
                 }
 
-                fn contract_address(&self) -> Address {
+                fn contract_address(&self) -> odra::prelude::Address {
                     self.address
                 }
 
@@ -540,13 +540,13 @@ mod ref_item_tests {
         let expected = quote! {
             /// [Erc20] Host Ref.
             pub struct Erc20HostRef {
-                address: Address,
+                address: odra::prelude::Address,
                 env: odra::host::HostEnv,
                 attached_value: odra::casper_types::U512
             }
 
             impl odra::host::HostRef for Erc20HostRef {
-                fn new(address: Address, env: odra::host::HostEnv) -> Self {
+                fn new(address: odra::prelude::Address, env: odra::host::HostEnv) -> Self {
                     Self {
                         address,
                         env,
@@ -562,7 +562,7 @@ mod ref_item_tests {
                     }
                 }
 
-                fn contract_address(&self) -> Address {
+                fn contract_address(&self) -> odra::prelude::Address {
                     self.address
                 }
 
@@ -643,13 +643,13 @@ mod ref_item_tests {
         let expected = quote! {
             /// [Erc20] Host Ref.
             pub struct Erc20HostRef {
-                address: Address,
+                address: odra::prelude::Address,
                 env: odra::host::HostEnv,
                 attached_value: odra::casper_types::U512
             }
 
             impl odra::host::HostRef for Erc20HostRef {
-                fn new(address: Address, env: odra::host::HostEnv) -> Self {
+                fn new(address: odra::prelude::Address, env: odra::host::HostEnv) -> Self {
                     Self {
                         address,
                         env,
@@ -665,7 +665,7 @@ mod ref_item_tests {
                     }
                 }
 
-                fn contract_address(&self) -> Address {
+                fn contract_address(&self) -> odra::prelude::Address {
                     self.address
                 }
 

--- a/odra-macros/src/ast/module_def.rs
+++ b/odra-macros/src/ast/module_def.rs
@@ -59,7 +59,7 @@ mod tests {
                 counter2: SubModule<Counter>,
                 counters: Var<u32>,
                 counters_map: Mapping<u8, Counter>,
-                __env: Rc<odra::ContractEnv>
+                __env: odra::prelude::Rc<odra::ContractEnv>
             }
         };
 
@@ -72,7 +72,7 @@ mod tests {
         let def = ModuleDefItem::try_from(&ir).unwrap();
         let expected = quote::quote! {
             pub struct CounterPack {
-                __env: Rc<odra::ContractEnv>
+                __env: odra::prelude::Rc<odra::ContractEnv>
             }
         };
         assert_eq(def, expected);

--- a/odra-macros/src/ast/module_item.rs
+++ b/odra-macros/src/ast/module_item.rs
@@ -202,11 +202,11 @@ mod test {
                 use super::*;
 
                 impl Module for CounterPack {
-                    fn new(env: Rc<odra::ContractEnv>) -> Self {
+                    fn new(env: odra::prelude::Rc<odra::ContractEnv>) -> Self {
                         Self { __env: env }
                     }
 
-                    fn env(&self) -> Rc<odra::ContractEnv> {
+                    fn env(&self) -> odra::prelude::Rc<odra::ContractEnv> {
                         self.__env.clone()
                     }
                 }
@@ -224,7 +224,7 @@ mod test {
                 use super::*;
 
                 impl Module for CounterPack {
-                    fn new(env: Rc<odra::ContractEnv>) -> Self {
+                    fn new(env: odra::prelude::Rc<odra::ContractEnv>) -> Self {
                         let counter0 =
                             <SubModule<Counter> as odra::module::ModuleComponent>::instance(
                                 odra::prelude::Rc::clone(&env),
@@ -259,7 +259,7 @@ mod test {
                         }
                     }
 
-                    fn env(&self) -> Rc<odra::ContractEnv> {
+                    fn env(&self) -> odra::prelude::Rc<odra::ContractEnv> {
                         self.__env.clone()
                     }
                 }

--- a/odra-macros/src/ast/schema/entry_points.rs
+++ b/odra-macros/src/ast/schema/entry_points.rs
@@ -300,7 +300,7 @@ mod test {
                             true,
                             odra::prelude::vec![]
                         ),
-                        odra::schema::entry_point::<(Address, odra::casper_types::URef)>(
+                        odra::schema::entry_point::<(odra::prelude::Address, odra::casper_types::URef)>(
                             "factory",
                             "",
                             true,

--- a/odra-macros/src/ast/test_parts.rs
+++ b/odra-macros/src/ast/test_parts.rs
@@ -85,13 +85,13 @@ mod test {
 
                 /// [Erc20] Host Ref.
                 pub struct Erc20HostRef {
-                    address: Address,
+                    address: odra::prelude::Address,
                     env: odra::host::HostEnv,
                     attached_value: odra::casper_types::U512
                 }
 
                 impl odra::host::HostRef for Erc20HostRef {
-                    fn new(address: Address, env: odra::host::HostEnv) -> Self {
+                    fn new(address: odra::prelude::Address, env: odra::host::HostEnv) -> Self {
                         Self {
                             address,
                             env,
@@ -107,7 +107,7 @@ mod test {
                         }
                     }
 
-                    fn contract_address(&self) -> Address {
+                    fn contract_address(&self) -> odra::prelude::Address {
                         self.address
                     }
 
@@ -391,13 +391,13 @@ mod test {
 
                 /// [Erc20] Host Ref.
                 pub struct Erc20HostRef {
-                    address: Address,
+                    address: odra::prelude::Address,
                     env: odra::host::HostEnv,
                     attached_value: odra::casper_types::U512
                 }
 
                 impl odra::host::HostRef for Erc20HostRef {
-                    fn new(address: Address, env: odra::host::HostEnv) -> Self {
+                    fn new(address: odra::prelude::Address, env: odra::host::HostEnv) -> Self {
                         Self {
                             address,
                             env,
@@ -413,7 +413,7 @@ mod test {
                         }
                     }
 
-                    fn contract_address(&self) -> Address {
+                    fn contract_address(&self) -> odra::prelude::Address {
                         self.address
                     }
 

--- a/odra-macros/src/ir/mod.rs
+++ b/odra-macros/src/ir/mod.rs
@@ -195,6 +195,11 @@ impl TryFrom<(&proc_macro2::TokenStream, &proc_macro2::TokenStream)> for ModuleI
         }
 
         if let Ok(code) = syn::parse2::<syn::ItemTrait>(stream.1.clone()) {
+            for c in code.items.iter() {
+                if let syn::TraitItem::Verbatim(func) = c {
+                    syn::parse2::<syn::TraitItemFn>(func.clone())?;
+                }
+            }
             return Ok(Self::Trait(ModuleTraitIR { code, config }));
         }
 
@@ -443,7 +448,7 @@ impl ModuleIR {
 try_parse!(syn::ItemTrait => ModuleTraitIR);
 
 impl ModuleTraitIR {
-    fn self_code(&self) -> syn::Result<syn::ItemTrait> {
+    pub fn self_code(&self) -> syn::Result<syn::ItemTrait> {
         let mut code = self.code.clone();
         code.items.iter_mut().for_each(|item| {
             if let syn::TraitItem::Fn(func) = item {

--- a/odra-macros/src/lib.rs
+++ b/odra-macros/src/lib.rs
@@ -89,13 +89,17 @@ pub fn odra_error(_attr: TokenStream, item: TokenStream) -> TokenStream {
 pub fn external_contract(attr: TokenStream, item: TokenStream) -> TokenStream {
     let attr: TokenStream2 = attr.into();
     let item: TokenStream2 = item.into();
-    if let Ok(ir) = ModuleImplIR::try_from((&attr, &item)) {
-        return ExternalContractImpl::try_from(&ir).into_code();
+
+    if syn::parse2::<syn::ItemImpl>(item.clone()).is_ok() {
+        return span_error!(
+            attr,
+            "#[external_contract] can be only applied to trait only"
+        );
     }
-    span_error!(
-        item,
-        "#[external_contract] can be only applied to trait only"
-    )
+    match ModuleImplIR::try_from((&attr, &item)) {
+        Ok(ir) => ExternalContractImpl::try_from(&ir).into_code(),
+        Err(e) => e.to_compile_error().into()
+    }
 }
 
 /// This macro is used to implement the boilerplate code for the event and contract schema.

--- a/odra-macros/src/utils/ty.rs
+++ b/odra-macros/src/utils/ty.rs
@@ -2,7 +2,7 @@ use quote::ToTokens;
 use syn::parse_quote;
 
 pub fn address() -> syn::Type {
-    parse_quote!(Address)
+    parse_quote!(odra::prelude::Address)
 }
 
 pub fn contract_env() -> syn::Type {
@@ -10,7 +10,7 @@ pub fn contract_env() -> syn::Type {
 }
 
 pub fn rc_contract_env() -> syn::Type {
-    parse_quote!(Rc<odra::ContractEnv>)
+    parse_quote!(odra::prelude::Rc<odra::ContractEnv>)
 }
 
 pub fn from_bytes() -> syn::Type {


### PR DESCRIPTION
- full path to Address and Rc in generated code
- raise an error if a function is declared as pub
- fix error handling in `external_contract` macro

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated macro-generated code to use fully qualified type paths from the odra prelude for `Address`, `Rc<ContractEnv>`, and related types across contract references and factory implementations, improving consistency and clarity in generated code structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->