### PR TITLE
Refactor ContractProvider to use key_name for contract lookup and add…

### DIFF
--- a/odra-cli/src/container.rs
+++ b/odra-cli/src/container.rs
@@ -202,7 +202,7 @@ impl ContractProvider for DeployedContractsContainer {
         self.data
             .contracts()
             .iter()
-            .find(|c| c.package_name == name)
+            .find(|c| c.key_name() == name)
             .map(|c| Address::from_str(&c.package_hash).ok())
             .and_then(|opt| opt.map(|addr| <T as HostRefLoader<T::HostRef>>::load(env, addr)))
             .ok_or(ContractError::NotFound(T::HostRef::ident()))
@@ -216,7 +216,7 @@ impl ContractProvider for DeployedContractsContainer {
         self.data
             .contracts()
             .iter()
-            .find(|c| c.package_name == package_name)
+            .find(|c| c.key_name() == package_name)
             .and_then(|c| Address::from_str(&c.package_hash).ok())
     }
 }
@@ -225,6 +225,7 @@ impl ContractProvider for DeployedContractsContainer {
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct DeployedContract {
     name: String,
+    #[serde(default)]
     package_name: String,
     package_hash: String
 }
@@ -240,7 +241,11 @@ impl DeployedContract {
     }
 
     pub fn key_name(&self) -> String {
-        self.package_name.clone()
+        if self.package_name.is_empty() {
+            self.name.clone()
+        } else {
+            self.package_name.clone()
+        }
     }
 
     pub fn name(&self) -> String {


### PR DESCRIPTION
… default for package_name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved contract name resolution when looking up deployed contracts
  * Enhanced handling of missing contract metadata during data import

<!-- end of auto-generated comment: release notes by coderabbit.ai -->