### PR TITLE
Use network name in contracts.toml

### DIFF
--- a/examples/justfile
+++ b/examples/justfile
@@ -1,5 +1,13 @@
-run-nctl:
-    docker run --rm -it --name mynctl -d -p 11101:11101 -p 14101:14101 -p 18101:18101 -p 25101:25101 makesoftware/casper-nctl:v210
-
 cli *ARGS:
     cargo run --bin odra_cli -- {{ARGS}}
+
+cli-on-nctl *args="":
+    set shell := bash
+    mkdir -p .node-keys
+    # Extract the secret keys from the local Casper node
+    docker exec mynctl /bin/bash -c "cat /home/casper/casper-nctl/assets/net-1/users/user-1/secret_key.pem" > .node-keys/secret_key.pem
+    docker exec mynctl /bin/bash -c "cat  /home/casper/casper-nctl/assets/net-1/users/user-2/secret_key.pem" > .node-keys/secret_key_1.pem
+    # Run the command
+    ODRA_CASPER_LIVENET_SECRET_KEY_PATH=.node-keys/secret_key.pem ODRA_CASPER_LIVENET_NODE_ADDRESS=http://localhost:11101 ODRA_CASPER_LIVENET_EVENTS_URL=http://localhost:18101/events ODRA_CASPER_LIVENET_CHAIN_NAME=casper-net-1 ODRA_CASPER_LIVENET_KEY_1=.node-keys/secret_key_1.pem  cargo run --bin odra_cli -- {{args}}
+
+    rm -rf .node-keys

--- a/odra-cli/src/cli.rs
+++ b/odra-cli/src/cli.rs
@@ -19,8 +19,9 @@ use crate::{
         PrintEventsCmd, Scenario, ScenarioMetadata, ScenariosCmd, WhoamiCmd, CONTRACTS_SUBCOMMAND,
         DEPLOY_SUBCOMMAND, PRINT_EVENTS_SUBCOMMAND, SCENARIOS_SUBCOMMAND, WHOAMI_SUBCOMMAND
     },
-    container::{FileContractStorage, DEPLOYED_CONTRACTS_FILE},
+    container::FileContractStorage,
     custom_types::CustomTypes,
+    utils::get_default_contracts_file,
     ContractProvider, DeployedContractsContainer
 };
 
@@ -161,7 +162,7 @@ impl OdraCli {
             let caller = self.callers.get(&(deployed_contract.name(), deployed_contract.key_name())).unwrap_or_else(|| {
                 let path = match &contracts_path {
                     Some(path) => path.to_str().map(|s| s.to_string()).unwrap_or_default(),
-                    None => DEPLOYED_CONTRACTS_FILE.to_string()
+                    None => get_default_contracts_file()
                 };
                 prettycli::error(&format!(
                     "Caller for `{}` not found. The contract is registered in {:?} file, but not in the CLI builder. Make sure you have added it to the builder using `.contract::<{}>()`.",

--- a/odra-cli/src/container.rs
+++ b/odra-cli/src/container.rs
@@ -12,10 +12,9 @@ use thiserror::Error;
 
 use crate::{
     cmd::args::{DEPLOY_MODE_ARCHIVE, DEPLOY_MODE_OVERRIDE},
-    log
+    log,
+    utils::get_default_contracts_file
 };
-
-pub const DEPLOYED_CONTRACTS_FILE: &str = "resources/contracts.toml";
 
 #[derive(Error, Debug)]
 pub enum ContractError {
@@ -54,7 +53,10 @@ impl FileContractStorage {
             Some(path_str) if !path_str.to_str().unwrap_or_default().is_empty() => {
                 path.push(path_str);
             }
-            _ => path.push(DEPLOYED_CONTRACTS_FILE)
+            _ => {
+                let default_file = get_default_contracts_file();
+                path.push(&default_file);
+            }
         }
         if !path.exists() {
             let parent_path = path.parent().ok_or_else(|| {

--- a/odra-cli/src/utils.rs
+++ b/odra-cli/src/utils.rs
@@ -7,9 +7,22 @@ use odra::{
 
 use crate::{ContractProvider, DeployedContractsContainer};
 
+const DEFAULT_CONTRACTS_FILE: &str = "resources/contracts.toml";
+
 /// Logs a message to the console.
 pub fn log<T: ToString>(msg: T) {
     prettycli::info(&msg.to_string());
+}
+
+/// Returns the default contracts file path, checking for ODRA_CASPER_LIVENET_CHAIN_NAME
+/// environment variable. If the variable exists, returns `resources/{network_name}-contracts.toml`,
+/// otherwise returns the default contracts file path.
+pub(crate) fn get_default_contracts_file() -> String {
+    if let Ok(network_name) = std::env::var("ODRA_CASPER_LIVENET_CHAIN_NAME") {
+        format!("resources/{}-contracts.toml", network_name)
+    } else {
+        DEFAULT_CONTRACTS_FILE.to_string()
+    }
 }
 
 /// Trait that extends the functionality of OdraContract to include deployment capabilities.


### PR DESCRIPTION
Now instead of contracts.toml file, it will be network-name-contracts.toml. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NCTL integration with new Justfile target for running CLI against NCTL nodes with automatic environment configuration and key management
  * Enhanced path resolution: default contracts file path now dynamically determined from environment variables, enabling network-specific contract selection and multi-network flexibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->