### PR TITLE
refactor: Replace Rc<RefCell<dyn HostContext>> with Rc<dyn HostContext>

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ AGENTS.md
 odra-wasm-client/example/index.js
 odra-wasm-client/example/web/dist/**
 odra-wasm-client/package-lock.json
+CLAUDE.md

--- a/core/src/contract_container.rs
+++ b/core/src/contract_container.rs
@@ -99,7 +99,7 @@ mod tests {
 
     impl ContractContainer {
         fn empty() -> Self {
-            let ctx = Rc::new(RefCell::new(MockHostContext::new()));
+            let ctx = Rc::new(MockHostContext::new());
             let env = HostEnv::new(ctx);
             let entry_points_caller = EntryPointsCaller::new(env, vec![], |_, call_def| {
                 Err(OdraError::VmError(VmError::NoSuchMethod(
@@ -124,7 +124,7 @@ mod tests {
             ctx.expect_contract_env().returning(|| {
                 ContractEnv::new(0, Rc::new(RefCell::new(MockContractContext::new())))
             });
-            let env = HostEnv::new(Rc::new(RefCell::new(ctx)));
+            let env = HostEnv::new(Rc::new(ctx));
 
             let entry_points_caller = EntryPointsCaller::new(env, entry_points, |_, call_def| {
                 if call_def.entry_point() == TEST_ENTRYPOINT {

--- a/core/src/host.rs
+++ b/core/src/host.rs
@@ -432,7 +432,7 @@ pub trait HostContext {
 /// the execution of contracts.
 #[derive(Clone)]
 pub struct HostEnv {
-    backend: Rc<RefCell<dyn HostContext>>,
+    backend: Rc<dyn HostContext>,
     last_call_result: Rc<RefCell<Option<CallResult>>>,
     deployed_contracts: Rc<RefCell<BTreeMap<Address, DeployedContract>>>,
     captures_events: Rc<RefCell<bool>>
@@ -440,7 +440,7 @@ pub struct HostEnv {
 
 impl HostEnv {
     /// Creates a new `HostEnv` instance with the specified backend.
-    pub fn new(backend: Rc<RefCell<dyn HostContext>>) -> HostEnv {
+    pub fn new(backend: Rc<dyn HostContext>) -> HostEnv {
         HostEnv {
             backend,
             last_call_result: RefCell::new(None).into(),
@@ -465,13 +465,13 @@ impl HostEnv {
 
     /// Returns the account address at the specified index.
     pub fn get_account(&self, index: usize) -> Address {
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         backend.get_account(index)
     }
 
     /// Returns the validator public key.
     pub fn get_validator(&self, index: usize) -> PublicKey {
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         backend.get_validator(index)
     }
 
@@ -480,62 +480,62 @@ impl HostEnv {
         if address.is_contract() {
             panic!("Caller cannot be a contract: {:?}", address)
         }
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         backend.set_caller(address)
     }
 
     /// Advances the block time by the specified time difference in milliseconds.
     pub fn advance_block_time(&self, time_diff: u64) {
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         backend.advance_block_time(time_diff)
     }
 
     /// Advances the block time by the specified time difference in milliseconds
     /// and processes auctions.
     pub fn advance_with_auctions(&self, time_diff: u64) {
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         backend.advance_with_auctions(time_diff);
     }
 
     /// Returns the era length in milliseconds.
     pub fn auction_delay(&self) -> u64 {
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         backend.auction_delay()
     }
 
     /// Returns the delay between unstaking and the transfer of funds back to the delegator in milliseconds.
     pub fn unbonding_delay(&self) -> u64 {
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         backend.unbonding_delay()
     }
 
     /// Returns the amount of CSPR delegated to the specified validator by the specified delegator.
     pub fn delegated_amount(&self, delegator: Address, validator: PublicKey) -> U512 {
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         backend.delegated_amount(delegator, validator)
     }
 
     /// Evicts the validator at the specified index from the validator set.
     pub fn remove_validator(&self, index: usize) {
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         backend.remove_validator(index);
     }
 
     /// Returns the current block time in milliseconds.
     pub fn block_time(&self) -> u64 {
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         backend.block_time()
     }
 
     /// Returns the current block time in milliseconds.
     pub fn block_time_millis(&self) -> u64 {
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         backend.block_time()
     }
 
     /// Returns the current block time in seconds.
     pub fn block_time_secs(&self) -> u64 {
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         backend.block_time().checked_div(1000).unwrap()
     }
 
@@ -550,7 +550,7 @@ impl HostEnv {
         let mut entry_points_caller = entry_points_caller.clone();
         entry_points_caller.remove_entry_point("upgrade");
 
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         let contract_address = backend.new_contract(name, init_args, entry_points_caller)?;
 
         self.deployed_contracts
@@ -572,7 +572,7 @@ impl HostEnv {
         let mut entry_points_caller = entry_points_caller.clone();
         entry_points_caller.remove_entry_point("init");
 
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         let upgraded_contract = backend.upgrade_contract(
             name,
             contract_to_upgrade,
@@ -595,7 +595,7 @@ impl HostEnv {
         contract_name: String,
         entry_points_caller: EntryPointsCaller
     ) {
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         backend.register_contract(address, contract_name, entry_points_caller);
         self.deployed_contracts
             .borrow_mut()
@@ -626,7 +626,7 @@ impl HostEnv {
         use_proxy: bool
     ) -> OdraResult<Bytes> {
         let call_result = {
-            let backend = self.backend.borrow();
+            let backend = self.backend.as_ref();
             backend.call_contract(&address, call_def, use_proxy)
         };
 
@@ -646,7 +646,7 @@ impl HostEnv {
             );
         }
 
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         let last_call_gas_cost = backend.last_call_gas_cost();
 
         self.last_call_result.replace(Some(CallResult::new(
@@ -663,17 +663,17 @@ impl HostEnv {
 
     /// Returns the gas cost of the last contract call.
     pub fn contract_env(&self) -> ContractEnv {
-        self.backend.borrow().contract_env()
+        self.backend.contract_env()
     }
 
     /// Prints the gas report for the current contract execution.
     pub fn gas_report(&self) -> GasReport {
-        self.backend.borrow().gas_report().clone()
+        self.backend.gas_report().clone()
     }
 
     /// Returns the CSPR balance of the specified address.
     pub fn balance_of<T: Addressable>(&self, addr: &T) -> U512 {
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         backend.balance_of(&addr.address())
     }
 
@@ -689,7 +689,7 @@ impl HostEnv {
         index: i32
     ) -> Result<T, EventError> {
         let contract_address = addr.address();
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         let events_count = self.events_count(&contract_address);
         let event_absolute_position = crate::utils::event_absolute_position(events_count, index)
             .ok_or(EventError::IndexOutOfBounds)?;
@@ -716,7 +716,7 @@ impl HostEnv {
         index: i32
     ) -> Result<T, EventError> {
         let contract_address = addr.address();
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         let events_count = self.native_events_count(&contract_address);
         let event_absolute_position = crate::utils::event_absolute_position(events_count, index)
             .ok_or(EventError::IndexOutOfBounds)?;
@@ -733,7 +733,7 @@ impl HostEnv {
         addr: &T,
         index: u32
     ) -> Result<Bytes, EventError> {
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         backend.get_event(&addr.address(), index)
     }
 
@@ -743,7 +743,7 @@ impl HostEnv {
         addr: &T,
         index: u32
     ) -> Result<Bytes, EventError> {
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         backend.get_native_event(&addr.address(), index)
     }
 
@@ -751,7 +751,7 @@ impl HostEnv {
     pub fn event_names<T: Addressable>(&self, addr: &T) -> Vec<String> {
         let events_count = self.events_count(addr);
 
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         (0..events_count)
             .map(|event_id| {
                 backend
@@ -764,7 +764,7 @@ impl HostEnv {
 
     /// Returns all events emitted by the specified contract.
     pub fn events<T: Addressable>(&self, addr: &T) -> Vec<Bytes> {
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         let contract_address = addr.address();
         let events_count = backend
             .get_events_count(&contract_address)
@@ -785,7 +785,7 @@ impl HostEnv {
 
     /// Returns the number of events emitted by the specified contract.
     pub fn events_count<T: Addressable>(&self, addr: &T) -> u32 {
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         backend
             .get_events_count(&addr.address())
             .unwrap_or_default()
@@ -793,7 +793,7 @@ impl HostEnv {
 
     /// Returns the number of native events emitted by the specified contract.
     pub fn native_events_count<T: Addressable>(&self, addr: &T) -> u32 {
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         backend
             .get_native_events_count(&addr.address())
             .unwrap_or_default()
@@ -914,25 +914,25 @@ impl HostEnv {
 
     /// Signs the specified message with the private key of the specified address.
     pub fn sign_message(&self, message: &Bytes, address: &Address) -> Bytes {
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         backend.sign_message(message, address)
     }
 
     /// Returns the public key associated with the specified address.
     pub fn public_key(&self, address: &Address) -> PublicKey {
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         backend.public_key(address)
     }
 
     /// Returns the caller address for the current contract execution.
     pub fn caller(&self) -> Address {
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         backend.caller()
     }
 
     /// Sets the gas limit for the current contract execution.
     pub fn set_gas(&self, gas: u64) {
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         backend.set_gas(gas)
     }
 
@@ -943,7 +943,7 @@ impl HostEnv {
                 ExecutionError::TransferToContract
             ));
         }
-        let backend = self.backend.borrow();
+        let backend = self.backend.as_ref();
         backend.transfer(to, amount)
     }
 
@@ -1093,7 +1093,7 @@ mod test {
         let mut ctx = MockHostContext::new();
         ctx.expect_new_contract()
             .returning(|_, _, _| Ok(Address::Account(AccountHash::new([0; 32]))));
-        let env = HostEnv::new(Rc::new(RefCell::new(ctx)));
+        let env = HostEnv::new(Rc::new(ctx));
         MockTestRef::deploy(&env, NoArgs);
     }
 
@@ -1126,7 +1126,7 @@ mod test {
             .times(1)
             .returning(|_, _| MockTestRef::default());
 
-        let env = HostEnv::new(Rc::new(RefCell::new(ctx)));
+        let env = HostEnv::new(Rc::new(ctx));
         let address = Address::Account(AccountHash::new([0; 32]));
         MockTestRef::load(&env, address);
     }
@@ -1142,7 +1142,7 @@ mod test {
         ctx.expect_gas_report().returning(GasReport::new).times(1);
         ctx.expect_set_gas().returning(|_| ()).times(1);
 
-        let env = HostEnv::new(Rc::new(RefCell::new(ctx)));
+        let env = HostEnv::new(Rc::new(ctx));
 
         assert_eq!(env.caller(), Address::Account(AccountHash::new([2; 32])));
         // should call the `HostContext`
@@ -1155,7 +1155,7 @@ mod test {
         // Given a host context that successfully transfers tokens.
         let mut ctx = MockHostContext::new();
         ctx.expect_transfer().returning(|_, _| Ok(()));
-        let env = HostEnv::new(Rc::new(RefCell::new(ctx)));
+        let env = HostEnv::new(Rc::new(ctx));
 
         let addr = Address::Account(AccountHash::new([0; 32]));
         // When transfer 100 tokens to an account.
@@ -1170,7 +1170,7 @@ mod test {
         let mut ctx = MockHostContext::new();
         ctx.expect_transfer()
             .returning(|_, _| Err(OdraError::ExecutionError(ExecutionError::UnwrapError)));
-        let env = HostEnv::new(Rc::new(RefCell::new(ctx)));
+        let env = HostEnv::new(Rc::new(ctx));
 
         let addr = Address::Account(AccountHash::new([0; 32]));
         // When transfer 100 tokens to an account.
@@ -1187,7 +1187,7 @@ mod test {
         // Given a host context that successfully transfers tokens.
         let mut ctx = MockHostContext::new();
         ctx.expect_transfer().returning(|_, _| Ok(()));
-        let env = HostEnv::new(Rc::new(RefCell::new(ctx)));
+        let env = HostEnv::new(Rc::new(ctx));
 
         let addr = Address::Contract(ContractPackageHash::new([0; 32]));
         // When transfer 100 tokens to a contract.
@@ -1217,7 +1217,7 @@ mod test {
             .with(predicate::always(), predicate::eq(1))
             .returning(|_, _| Ok(TestEv {}.to_bytes().unwrap().into()));
 
-        let env = HostEnv::new(Rc::new(RefCell::new(ctx)));
+        let env = HostEnv::new(Rc::new(ctx));
 
         assert_eq!(env.get_event(&addr, 1), Ok(TestEv {}));
         assert_eq!(env.get_event(&addr, -1), Ok(TestEv {}));
@@ -1255,7 +1255,7 @@ mod test {
             .with(predicate::always(), predicate::eq(1))
             .returning(|_, _| Ok(vec![1, 0, 1].into()));
 
-        let env = HostEnv::new(Rc::new(RefCell::new(ctx)));
+        let env = HostEnv::new(Rc::new(ctx));
 
         assert_eq!(
             env.events(&addr),
@@ -1278,7 +1278,7 @@ mod test {
             .with(predicate::always(), predicate::eq(0))
             .returning(|_, _| Err(EventError::CouldntExtractEventData));
 
-        let env = HostEnv::new(Rc::new(RefCell::new(ctx)));
+        let env = HostEnv::new(Rc::new(ctx));
 
         env.events(&addr);
     }
@@ -1292,7 +1292,7 @@ mod test {
         ctx.expect_get_event()
             .returning(|_, _| Ok(TestEv {}.to_bytes().unwrap().into()));
 
-        let env = HostEnv::new(Rc::new(RefCell::new(ctx)));
+        let env = HostEnv::new(Rc::new(ctx));
         assert!(env.emitted(&addr, "TestEv"));
         assert!(!env.emitted(&addr, "AnotherEvent"));
     }

--- a/odra-casper/livenet-env/src/livenet_host.rs
+++ b/odra-casper/livenet-env/src/livenet_host.rs
@@ -30,8 +30,8 @@ pub struct LivenetHost {
 
 impl LivenetHost {
     /// Creates a new instance of LivenetHost.
-    pub fn new() -> Rc<RefCell<Self>> {
-        Rc::new(RefCell::new(Self::new_instance()))
+    pub fn new() -> Rc<Self> {
+        Rc::new(Self::new_instance())
     }
 
     fn new_instance() -> Self {

--- a/odra-casper/test-vm/src/casper_host.rs
+++ b/odra-casper/test-vm/src/casper_host.rs
@@ -224,7 +224,7 @@ impl HostContext for CasperHost {
 
 impl CasperHost {
     /// Creates a new instance of the host.
-    pub fn new(vm: Rc<RefCell<CasperVm>>) -> Rc<RefCell<Self>> {
-        Rc::new(RefCell::new(Self { vm }))
+    pub fn new(vm: Rc<RefCell<CasperVm>>) -> Rc<Self> {
+        Rc::new(Self { vm })
     }
 }

--- a/odra-cli/src/test_utils.rs
+++ b/odra-cli/src/test_utils.rs
@@ -333,7 +333,7 @@ impl HostContext for DummyHostCtx {
 }
 
 pub fn mock_host_env() -> HostEnv {
-    HostEnv::new(Rc::new(RefCell::new(DummyHostCtx)))
+    HostEnv::new(Rc::new(DummyHostCtx))
 }
 
 struct MockContractStorage;

--- a/odra-vm/src/odra_vm_contract_env.rs
+++ b/odra-vm/src/odra_vm_contract_env.rs
@@ -16,36 +16,36 @@ use std::hash::Hasher;
 use std::io::Write;
 
 pub struct OdraVmContractEnv {
-    vm: Rc<RefCell<OdraVm>>
+    vm: Rc<OdraVm>
 }
 
 impl ContractContext for OdraVmContractEnv {
     fn get_value(&self, key: &[u8]) -> Option<Bytes> {
-        self.vm.borrow().get_var(key)
+        self.vm.get_var(key)
     }
 
     fn set_value(&self, key: &[u8], value: Bytes) {
-        self.vm.borrow().set_var(key, value)
+        self.vm.set_var(key, value)
     }
 
     fn get_named_value(&self, name: &str) -> Option<Bytes> {
-        self.vm.borrow().get_named_key(name)
+        self.vm.get_named_key(name)
     }
 
     fn set_named_value(&self, name: &str, value: CLValue) {
-        self.vm.borrow().set_named_key(name, value)
+        self.vm.set_named_key(name, value)
     }
 
     fn get_dictionary_value(&self, dictionary_name: &str, key: &[u8]) -> Option<Bytes> {
-        self.vm.borrow().get_dict_value(dictionary_name, key)
+        self.vm.get_dict_value(dictionary_name, key)
     }
 
     fn set_dictionary_value(&self, dictionary_name: &str, key: &[u8], value: CLValue) {
-        self.vm.borrow().set_dict_value(dictionary_name, key, value)
+        self.vm.set_dict_value(dictionary_name, key, value)
     }
 
     fn remove_dictionary(&self, dictionary_name: &str) {
-        self.vm.borrow().remove_dictionary(dictionary_name);
+        self.vm.remove_dictionary(dictionary_name);
     }
 
     fn init_dictionary(&self, dictionary_name: &str) {
@@ -53,51 +53,51 @@ impl ContractContext for OdraVmContractEnv {
     }
 
     fn caller(&self) -> Address {
-        self.vm.borrow().caller()
+        self.vm.caller()
     }
 
     fn self_address(&self) -> Address {
-        self.vm.borrow().self_address()
+        self.vm.self_address()
     }
 
     fn call_contract(&self, address: Address, call_def: CallDef) -> Bytes {
-        self.vm.borrow().call_contract(address, call_def)
+        self.vm.call_contract(address, call_def)
     }
 
     fn get_block_time(&self) -> u64 {
-        self.vm.borrow().get_block_time()
+        self.vm.get_block_time()
     }
 
     fn attached_value(&self) -> U512 {
-        self.vm.borrow().attached_value()
+        self.vm.attached_value()
     }
 
     fn self_balance(&self) -> U512 {
-        self.vm.borrow().self_balance()
+        self.vm.self_balance()
     }
 
     fn emit_event(&self, event: &Bytes) {
-        self.vm.borrow().emit_event(event);
+        self.vm.emit_event(event);
     }
 
     fn emit_native_event(&self, event: &Bytes) {
-        self.vm.borrow().emit_native_event(event);
+        self.vm.emit_native_event(event);
     }
 
     fn transfer_tokens(&self, to: &Address, amount: &U512) {
-        self.vm.borrow().transfer_tokens(to, amount)
+        self.vm.transfer_tokens(to, amount)
     }
 
     fn revert(&self, error: OdraError) -> ! {
-        self.vm.borrow().revert(error)
+        self.vm.revert(error)
     }
 
     fn get_named_arg_bytes(&self, name: &str) -> OdraResult<Bytes> {
-        self.vm.borrow().get_named_arg(name).map(Into::into)
+        self.vm.get_named_arg(name).map(Into::into)
     }
 
     fn get_opt_named_arg_bytes(&self, name: &str) -> Option<Bytes> {
-        self.vm.borrow().get_named_arg(name).ok().map(Into::into)
+        self.vm.get_named_arg(name).ok().map(Into::into)
     }
 
     fn handle_attached_value(&self) {
@@ -119,22 +119,22 @@ impl ContractContext for OdraVmContractEnv {
     }
 
     fn delegate(&self, validator: PublicKey, amount: U512) {
-        let delegator = self.vm.borrow().callee();
-        self.vm.borrow().delegate(validator, delegator, amount);
+        let delegator = self.vm.callee();
+        self.vm.delegate(validator, delegator, amount);
     }
 
     fn undelegate(&self, validator: PublicKey, amount: U512) {
-        let delegator = self.vm.borrow().callee();
-        self.vm.borrow().undelegate(validator, delegator, amount);
+        let delegator = self.vm.callee();
+        self.vm.undelegate(validator, delegator, amount);
     }
 
     fn delegated_amount(&self, validator: PublicKey) -> U512 {
-        let delegator = self.vm.borrow().callee();
-        self.vm.borrow().delegated_amount(delegator, validator)
+        let delegator = self.vm.callee();
+        self.vm.delegated_amount(delegator, validator)
     }
 
     fn get_validator_info(&self, validator: PublicKey) -> Option<ValidatorInfo> {
-        self.vm.borrow().get_validator_info(validator)
+        self.vm.get_validator_info(validator)
     }
 
     fn pseudorandom_bytes(&self) -> [u8; RANDOM_BYTES_COUNT] {
@@ -146,7 +146,7 @@ impl ContractContext for OdraVmContractEnv {
 }
 
 impl OdraVmContractEnv {
-    pub fn new(vm: Rc<RefCell<OdraVm>>) -> Rc<RefCell<Self>> {
+    pub fn new(vm: Rc<OdraVm>) -> Rc<RefCell<Self>> {
         Rc::new(RefCell::new(Self { vm }))
     }
 }

--- a/odra-vm/src/odra_vm_host.rs
+++ b/odra-vm/src/odra_vm_host.rs
@@ -11,13 +11,13 @@ use odra_core::{EventError, GasReport, VmError};
 
 /// HostContext utilizing the Odra in-memory virtual machine.
 pub struct OdraVmHost {
-    vm: Rc<RefCell<OdraVm>>,
+    vm: Rc<OdraVm>,
     contract_env: Rc<ContractEnv>
 }
 
 impl HostContext for OdraVmHost {
     fn set_caller(&self, caller: Address) {
-        self.vm.borrow().set_caller(caller)
+        self.vm.set_caller(caller)
     }
 
     fn set_gas(&self, gas: u64) {
@@ -25,51 +25,51 @@ impl HostContext for OdraVmHost {
     }
 
     fn caller(&self) -> Address {
-        *self.vm.borrow().callstack_tip().address()
+        *self.vm.callstack_tip().address()
     }
 
     fn get_account(&self, index: usize) -> Address {
-        self.vm.borrow().get_account(index)
+        self.vm.get_account(index)
     }
 
     fn get_validator(&self, index: usize) -> PublicKey {
-        self.vm.borrow().get_validator(index)
+        self.vm.get_validator(index)
     }
 
     fn remove_validator(&self, index: usize) {
-        self.vm.borrow().remove_validator(index);
+        self.vm.remove_validator(index);
     }
 
     fn balance_of(&self, address: &Address) -> U512 {
-        self.vm.borrow().balance_of(address)
+        self.vm.balance_of(address)
     }
 
     fn advance_block_time(&self, time_diff: u64) {
-        self.vm.borrow().advance_block_time_by(time_diff)
+        self.vm.advance_block_time_by(time_diff)
     }
 
     fn advance_with_auctions(&self, time_diff: u64) {
-        self.vm.borrow().advance_with_auctions(time_diff)
+        self.vm.advance_with_auctions(time_diff)
     }
 
     fn auction_delay(&self) -> u64 {
-        self.vm.borrow().auction_delay()
+        self.vm.auction_delay()
     }
 
     fn unbonding_delay(&self) -> u64 {
-        self.vm.borrow().unbonding_delay()
+        self.vm.unbonding_delay()
     }
 
     fn delegated_amount(&self, delegator: Address, validator: PublicKey) -> U512 {
-        self.vm.borrow().delegated_amount(delegator, validator)
+        self.vm.delegated_amount(delegator, validator)
     }
 
     fn block_time(&self) -> u64 {
-        self.vm.borrow().get_block_time()
+        self.vm.get_block_time()
     }
 
     fn get_event(&self, contract_address: &Address, index: u32) -> Result<Bytes, EventError> {
-        self.vm.borrow().get_event(contract_address, index)
+        self.vm.get_event(contract_address, index)
     }
 
     fn get_native_event(
@@ -77,15 +77,15 @@ impl HostContext for OdraVmHost {
         contract_address: &Address,
         index: u32
     ) -> Result<Bytes, EventError> {
-        self.vm.borrow().get_native_event(contract_address, index)
+        self.vm.get_native_event(contract_address, index)
     }
 
     fn get_events_count(&self, contract_address: &Address) -> Result<u32, EventError> {
-        self.vm.borrow().get_events_count(contract_address)
+        self.vm.get_events_count(contract_address)
     }
 
     fn get_native_events_count(&self, contract_address: &Address) -> Result<u32, EventError> {
-        self.vm.borrow().get_native_events_count(contract_address)
+        self.vm.get_native_events_count(contract_address)
     }
 
     fn call_contract(
@@ -98,14 +98,14 @@ impl HostContext for OdraVmHost {
 
         let mut opt_result: Option<Bytes> = None;
         let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            opt_result = Some(self.vm.borrow().call_contract(*address, call_def));
+            opt_result = Some(self.vm.call_contract(*address, call_def));
         }));
 
         match opt_result {
             Some(result) => Ok(result),
             None => {
-                eprintln!("↳ Stack trace:\n{}", self.vm.borrow().read_stack_record());
-                let error = self.vm.borrow().error();
+                eprintln!("↳ Stack trace:\n{}", self.vm.read_stack_record());
+                let error = self.vm.error();
                 Err(error.unwrap_or(OdraError::VmError(VmError::Panic)))
             }
         }
@@ -119,7 +119,6 @@ impl HostContext for OdraVmHost {
     ) -> OdraResult<Address> {
         let address =
             self.vm
-                .borrow()
                 .new_contract(name, init_args.clone(), entry_points_caller.clone());
 
         if entry_points_caller
@@ -132,7 +131,7 @@ impl HostContext for OdraVmHost {
                 CallDef::new(String::from("init"), true, init_args),
                 false
             )?;
-            self.vm.borrow().post_install(address);
+            self.vm.post_install(address);
         }
 
         Ok(address)
@@ -145,7 +144,7 @@ impl HostContext for OdraVmHost {
         upgrade_args: RuntimeArgs,
         entry_points_caller: EntryPointsCaller
     ) -> OdraResult<Address> {
-        let address = self.vm.borrow().upgrade_contract(
+        let address = self.vm.upgrade_contract(
             name,
             contract_to_upgrade,
             upgrade_args.clone(),
@@ -162,7 +161,7 @@ impl HostContext for OdraVmHost {
                 CallDef::new(String::from("upgrade"), true, upgrade_args),
                 false
             )?;
-            self.vm.borrow().post_install(address);
+            self.vm.post_install(address);
         }
 
         Ok(address)
@@ -192,25 +191,24 @@ impl HostContext for OdraVmHost {
     }
 
     fn sign_message(&self, message: &Bytes, address: &Address) -> Bytes {
-        self.vm.borrow().sign_message(message, address)
+        self.vm.sign_message(message, address)
     }
 
     fn public_key(&self, address: &Address) -> PublicKey {
-        self.vm.borrow().public_key(address)
+        self.vm.public_key(address)
     }
 
     fn transfer(&self, to: Address, amount: U512) -> OdraResult<()> {
         let caller = self.caller();
         self.vm
-            .borrow()
             .checked_transfer_tokens(&caller, &to, &amount)
     }
 }
 
 impl OdraVmHost {
     /// Creates a new `OdraVmHost` instance.
-    pub fn new(vm: Rc<RefCell<OdraVm>>) -> Rc<RefCell<Self>> {
+    pub fn new(vm: Rc<OdraVm>) -> Rc<Self> {
         let contract_env = Rc::new(ContractEnv::new(0, OdraVmContractEnv::new(vm.clone())));
-        Rc::new(RefCell::new(Self { vm, contract_env }))
+        Rc::new(Self { vm, contract_env })
     }
 }

--- a/odra-vm/src/odra_vm_host.rs
+++ b/odra-vm/src/odra_vm_host.rs
@@ -117,9 +117,9 @@ impl HostContext for OdraVmHost {
         init_args: RuntimeArgs,
         entry_points_caller: EntryPointsCaller
     ) -> OdraResult<Address> {
-        let address =
-            self.vm
-                .new_contract(name, init_args.clone(), entry_points_caller.clone());
+        let address = self
+            .vm
+            .new_contract(name, init_args.clone(), entry_points_caller.clone());
 
         if entry_points_caller
             .entry_points()
@@ -200,8 +200,7 @@ impl HostContext for OdraVmHost {
 
     fn transfer(&self, to: Address, amount: U512) -> OdraResult<()> {
         let caller = self.caller();
-        self.vm
-            .checked_transfer_tokens(&caller, &to, &amount)
+        self.vm.checked_transfer_tokens(&caller, &to, &amount)
     }
 }
 

--- a/odra-vm/src/vm/odra_vm.rs
+++ b/odra-vm/src/vm/odra_vm.rs
@@ -53,16 +53,14 @@ impl OdraVm {
         entry_points_caller: EntryPointsCaller
     ) -> Address {
         // Create a new address.
-         let address = self.state.borrow_mut().next_contract_address();
+        let address = self.state.borrow_mut().next_contract_address();
 
         // Register the contract under the address.
         {
             let contract = ContractContainer::new(name, entry_points_caller);
             let mut contract_register = self.contract_register.borrow_mut();
             contract_register.add(address, contract);
-            self.state
-                .borrow_mut()
-                .set_balance(address, U512::zero());
+            self.state.borrow_mut().set_balance(address, U512::zero());
         }
 
         address
@@ -85,9 +83,7 @@ impl OdraVm {
     }
 
     pub(crate) fn post_install(&self, address: Address) {
-        self.contract_register
-            .borrow_mut()
-            .post_install(&address);
+        self.contract_register.borrow_mut().post_install(&address);
     }
 
     /// Calls a contract with the specified address and call definition.
@@ -110,10 +106,7 @@ impl OdraVm {
                 self.revert(err);
             }
         }
-        let result = self
-            .contract_register
-            .borrow()
-            .call(&address, call_def);
+        let result = self.contract_register.borrow().call(&address, call_def);
 
         match result {
             Err(err) => self.revert(err),
@@ -258,11 +251,7 @@ impl OdraVm {
     /// Returns `None` if the dictionary or the key does not exist.
     /// If the dictionary or the key does not exist, the virtual machine is in error state.
     pub fn get_dict_value(&self, dict: &str, key: &[u8]) -> Option<Bytes> {
-        let result = {
-            self.state
-                .borrow()
-                .get_dict_value(dict.as_bytes(), key)
-        };
+        let result = { self.state.borrow().get_dict_value(dict.as_bytes(), key) };
         match result {
             Ok(result) => result,
             Err(error) => {
@@ -316,16 +305,12 @@ impl OdraVm {
 
     /// Advances the block time by the given number of milliseconds.
     pub fn advance_block_time_by(&self, milliseconds: u64) {
-        self.state
-            .borrow_mut()
-            .advance_block_time_by(milliseconds)
+        self.state.borrow_mut().advance_block_time_by(milliseconds)
     }
 
     /// Advances the block time by the given number of milliseconds and updates the auctions.
     pub fn advance_with_auctions(&self, milliseconds: u64) {
-        self.state
-            .borrow_mut()
-            .advance_with_auctions(milliseconds)
+        self.state.borrow_mut().advance_with_auctions(milliseconds)
     }
 
     /// Gets the value attached to the current call.
@@ -445,9 +430,7 @@ impl OdraVm {
     ///
     /// The amount of tokens delegated to the validator.
     pub fn delegated_amount(&self, delegator: Address, validator: PublicKey) -> U512 {
-        self.state
-            .borrow()
-            .delegated_amount(validator, delegator)
+        self.state.borrow().delegated_amount(validator, delegator)
     }
 
     /// Returns information about the validator
@@ -458,11 +441,7 @@ impl OdraVm {
     /// # Returns
     /// Option<ValidatorBid>
     pub fn get_validator_info(&self, validator: PublicKey) -> Option<ValidatorInfo> {
-        self.state
-            .borrow()
-            .validators
-            .get(&validator)
-            .cloned()
+        self.state.borrow().validators.get(&validator).cloned()
     }
 
     /// Disables the validator at the given index.

--- a/odra-vm/src/vm/odra_vm.rs
+++ b/odra-vm/src/vm/odra_vm.rs
@@ -1,7 +1,6 @@
 use std::cell::RefCell;
 use std::panic::{self, AssertUnwindSafe};
 use std::rc::Rc;
-use std::sync::{Arc, RwLock};
 
 use super::odra_vm_state::OdraVmState;
 use anyhow::Result;
@@ -26,16 +25,24 @@ use odra_core::{ContractContainer, ContractRegister};
 const NAMED_KEY_PREFIX: &str = "NAMED_KEY";
 
 /// Odra in-memory virtual machine.
-#[derive(Default)]
 pub struct OdraVm {
-    state: Arc<RwLock<OdraVmState>>,
-    contract_register: Arc<RwLock<ContractRegister>>
+    state: Rc<RefCell<OdraVmState>>,
+    contract_register: Rc<RefCell<ContractRegister>>
+}
+
+impl Default for OdraVm {
+    fn default() -> Self {
+        Self {
+            state: Rc::new(RefCell::new(OdraVmState::default())),
+            contract_register: Rc::new(RefCell::new(ContractRegister::default()))
+        }
+    }
 }
 
 impl OdraVm {
     /// Creates a new instance of OdraVm.
-    pub fn new() -> Rc<RefCell<Self>> {
-        Rc::new(RefCell::new(Self::default()))
+    pub fn new() -> Rc<Self> {
+        Rc::new(Self::default())
     }
 
     /// Adds a new contract to the virtual machine.
@@ -46,16 +53,15 @@ impl OdraVm {
         entry_points_caller: EntryPointsCaller
     ) -> Address {
         // Create a new address.
-        let address = self.state.write().unwrap().next_contract_address();
+         let address = self.state.borrow_mut().next_contract_address();
 
         // Register the contract under the address.
         {
             let contract = ContractContainer::new(name, entry_points_caller);
-            let mut contract_register = self.contract_register.write().unwrap();
+            let mut contract_register = self.contract_register.borrow_mut();
             contract_register.add(address, contract);
             self.state
-                .write()
-                .unwrap()
+                .borrow_mut()
                 .set_balance(address, U512::zero());
         }
 
@@ -70,7 +76,7 @@ impl OdraVm {
         upgrade_args: RuntimeArgs,
         entry_points_caller: EntryPointsCaller
     ) -> Address {
-        let mut contract_register = self.contract_register.write().unwrap();
+        let mut contract_register = self.contract_register.borrow_mut();
 
         // Register the contract under the address.
         let contract = ContractContainer::new(name, entry_points_caller);
@@ -80,8 +86,7 @@ impl OdraVm {
 
     pub(crate) fn post_install(&self, address: Address) {
         self.contract_register
-            .write()
-            .unwrap()
+            .borrow_mut()
             .post_install(&address);
     }
 
@@ -92,8 +97,7 @@ impl OdraVm {
     pub fn call_contract(&self, address: Address, call_def: CallDef) -> Bytes {
         let contract_name = self
             .contract_register
-            .read()
-            .unwrap()
+            .borrow()
             .get(&address)
             .map(|c| String::from(c.name()))
             .unwrap_or(String::from("UnknownContractName"));
@@ -108,8 +112,7 @@ impl OdraVm {
         }
         let result = self
             .contract_register
-            .read()
-            .unwrap()
+            .borrow()
             .call(&address, call_def);
 
         match result {
@@ -135,7 +138,7 @@ impl OdraVm {
             );
         }
 
-        let mut state = self.state.write().unwrap();
+        let mut state = self.state.borrow_mut();
         state.set_error(error.clone());
         state.clear_callstack();
         if state.is_in_caller_context() {
@@ -150,40 +153,40 @@ impl OdraVm {
     ///
     /// If the virtual machine is not in error state, returns `None`.
     pub fn error(&self) -> Option<OdraError> {
-        self.state.read().unwrap().error()
+        self.state.borrow().error()
     }
 
     /// Returns the callee, i.e. the currently executing contract.
     pub fn self_address(&self) -> Address {
-        self.state.read().unwrap().callee()
+        self.state.borrow().callee()
     }
 
     /// Retrieves from the state the address of the current caller.
     pub fn caller(&self) -> Address {
-        self.state.read().unwrap().caller()
+        self.state.borrow().caller()
     }
 
     /// Retrieves the callstack record.
     pub fn read_stack_record(&self) -> String {
-        self.state.read().unwrap().read_stack_record()
+        self.state.borrow().read_stack_record()
     }
 
     /// Retrieves from the state the address of the current callee. It is taken from the
     /// tip of the callstack.
     pub fn callee(&self) -> Address {
-        self.state.read().unwrap().callee()
+        self.state.borrow().callee()
     }
 
     /// Retrieves the first element from the callstack.
     pub fn callstack_tip(&self) -> CallstackElement {
-        self.state.read().unwrap().callstack_tip().clone()
+        self.state.borrow().callstack_tip().clone()
     }
 
     /// Gets the value of the named argument.
     ///
     /// The argument must be present in the call definition.
     pub fn get_named_arg(&self, name: &str) -> OdraResult<Vec<u8>> {
-        match self.state.read().unwrap().callstack_tip() {
+        match self.state.borrow().callstack_tip() {
             CallstackElement::Account(_) => todo!(),
             CallstackElement::ContractCall { call_def, .. } => call_def
                 .args()
@@ -195,14 +198,14 @@ impl OdraVm {
 
     /// Overrides the current caller address.
     pub fn set_caller(&self, caller: Address) {
-        self.state.write().unwrap().set_caller(caller);
+        self.state.borrow_mut().set_caller(caller);
     }
 
     /// Sets the value of the named argument.
     ///
     /// If the global state write fails, the virtual machine is in error state.
     pub fn set_var(&self, key: &[u8], value: Bytes) {
-        self.state.write().unwrap().set_var(key, value);
+        self.state.borrow_mut().set_var(key, value);
     }
 
     /// Gets the value of the named variable from the global state.
@@ -210,13 +213,12 @@ impl OdraVm {
     /// Returns `None` if the variable does not exist.
     /// If the global state read fails, the virtual machine is in error state.
     pub fn get_var(&self, key: &[u8]) -> Option<Bytes> {
-        let result = { self.state.read().unwrap().get_var(key) };
+        let result = { self.state.borrow().get_var(key) };
         match result {
             Ok(result) => result,
             Err(error) => {
                 self.state
-                    .write()
-                    .unwrap()
+                    .borrow_mut()
                     .set_error(Into::<ExecutionError>::into(error));
                 None
             }
@@ -237,7 +239,7 @@ impl OdraVm {
 
     /// Sets the value of the dictionary item.
     pub fn set_dict_value(&self, dict: &str, key: &[u8], value: CLValue) {
-        self.state.write().unwrap().set_dict_value(
+        self.state.borrow_mut().set_dict_value(
             dict.as_bytes(),
             key,
             Bytes::from(value.inner_bytes().as_slice())
@@ -247,8 +249,7 @@ impl OdraVm {
     /// Removes the dictionary from the global state.
     pub fn remove_dictionary(&self, dictionary_name: &str) {
         self.state
-            .write()
-            .unwrap()
+            .borrow_mut()
             .remove_dictionary(dictionary_name.as_bytes());
     }
 
@@ -259,16 +260,14 @@ impl OdraVm {
     pub fn get_dict_value(&self, dict: &str, key: &[u8]) -> Option<Bytes> {
         let result = {
             self.state
-                .read()
-                .unwrap()
+                .borrow()
                 .get_dict_value(dict.as_bytes(), key)
         };
         match result {
             Ok(result) => result,
             Err(error) => {
                 self.state
-                    .write()
-                    .unwrap()
+                    .borrow_mut()
                     .set_error(Into::<ExecutionError>::into(error));
                 None
             }
@@ -277,75 +276,72 @@ impl OdraVm {
 
     /// Writes an event data to the global state.
     pub fn emit_event(&self, event_data: &Bytes) {
-        self.state.write().unwrap().emit_event(event_data);
+        self.state.borrow_mut().emit_event(event_data);
     }
 
     /// Writes an event data to the global state and marks it as native.
     pub fn emit_native_event(&self, event_data: &Bytes) {
-        self.state.write().unwrap().emit_native_event(event_data);
+        self.state.borrow_mut().emit_native_event(event_data);
     }
 
     /// Gets the event emitted by the given address at the given index from the global state.
     pub fn get_event(&self, address: &Address, index: u32) -> Result<Bytes, EventError> {
-        self.state.read().unwrap().get_event(address, index)
+        self.state.borrow().get_event(address, index)
     }
 
     /// Gets the native event emitted by the given address at the given index from the global state.
     pub fn get_native_event(&self, address: &Address, index: u32) -> Result<Bytes, EventError> {
-        self.state.read().unwrap().get_native_event(address, index)
+        self.state.borrow().get_native_event(address, index)
     }
 
     /// Gets the number of events emitted by the given address from the global state.
     pub fn get_events_count(&self, address: &Address) -> Result<u32, EventError> {
-        self.state.read().unwrap().get_events_count(address)
+        self.state.borrow().get_events_count(address)
     }
 
     /// Gets the number of events emitted by the given address from the global state.
     pub fn get_native_events_count(&self, address: &Address) -> Result<u32, EventError> {
-        self.state.read().unwrap().get_native_events_count(address)
+        self.state.borrow().get_native_events_count(address)
     }
 
     /// Attaches the given amount of tokens to the current call from the global state.
     pub fn attach_value(&self, amount: U512) {
-        self.state.write().unwrap().attach_value(amount);
+        self.state.borrow_mut().attach_value(amount);
     }
 
     /// Gets the current block time.
     pub fn get_block_time(&self) -> u64 {
-        self.state.read().unwrap().block_time()
+        self.state.borrow().block_time()
     }
 
     /// Advances the block time by the given number of milliseconds.
     pub fn advance_block_time_by(&self, milliseconds: u64) {
         self.state
-            .write()
-            .unwrap()
+            .borrow_mut()
             .advance_block_time_by(milliseconds)
     }
 
     /// Advances the block time by the given number of milliseconds and updates the auctions.
     pub fn advance_with_auctions(&self, milliseconds: u64) {
         self.state
-            .write()
-            .unwrap()
+            .borrow_mut()
             .advance_with_auctions(milliseconds)
     }
 
     /// Gets the value attached to the current call.
     pub fn attached_value(&self) -> U512 {
-        self.state.read().unwrap().attached_value()
+        self.state.borrow().attached_value()
     }
 
     /// Gets the address of the account at the given index.
     pub fn get_account(&self, n: usize) -> Address {
-        self.state.read().unwrap().accounts.get(n).cloned().unwrap()
+        self.state.borrow().accounts.get(n).cloned().unwrap()
     }
 
     /// Gets the public key of the validator at the given index.
     pub fn get_validator(&self, n: usize) -> PublicKey {
         self.state
-            .read()
-            .unwrap()
+            .borrow()
             .validators
             .iter()
             .map(|a| a.0)
@@ -356,7 +352,7 @@ impl OdraVm {
 
     /// Reads the balance of the given address from the global state.
     pub fn balance_of(&self, address: &Address) -> U512 {
-        self.state.read().unwrap().balance_of(address)
+        self.state.borrow().balance_of(address)
     }
 
     /// Updates the balances of the given address and the current address in the global state.
@@ -372,7 +368,7 @@ impl OdraVm {
 
         let mut transfer_error = None;
         {
-            let mut state = self.state.write().unwrap();
+            let mut state = self.state.borrow_mut();
             if state.transfer(from, to, amount).is_err() {
                 transfer_error = Some(OdraError::VmError(VmError::BalanceExceeded));
             }
@@ -397,7 +393,7 @@ impl OdraVm {
             return Ok(());
         }
 
-        let mut state = self.state.write().unwrap();
+        let mut state = self.state.borrow_mut();
         if state.transfer(from, to, amount).is_err() {
             return Err(OdraError::VmError(VmError::BalanceExceeded));
         }
@@ -408,12 +404,12 @@ impl OdraVm {
     /// Reads the balance of the current contract from the global state.
     pub fn self_balance(&self) -> U512 {
         let address = self.self_address();
-        self.state.read().unwrap().balance_of(&address)
+        self.state.borrow().balance_of(&address)
     }
 
     /// Reads the public key of a given address from the global state.
     pub fn public_key(&self, address: &Address) -> PublicKey {
-        self.state.read().unwrap().public_key(address)
+        self.state.borrow().public_key(address)
     }
 
     /// Signs a message using the secret key associated with the public key of a given address.
@@ -430,7 +426,7 @@ impl OdraVm {
         let public_key = self.public_key(address);
         let signature = odra_core::casper_types::crypto::sign(
             message,
-            self.state.read().unwrap().secret_key(address),
+            self.state.borrow().secret_key(address),
             &public_key
         )
         .to_bytes()
@@ -450,8 +446,7 @@ impl OdraVm {
     /// The amount of tokens delegated to the validator.
     pub fn delegated_amount(&self, delegator: Address, validator: PublicKey) -> U512 {
         self.state
-            .read()
-            .unwrap()
+            .borrow()
             .delegated_amount(validator, delegator)
     }
 
@@ -464,8 +459,7 @@ impl OdraVm {
     /// Option<ValidatorBid>
     pub fn get_validator_info(&self, validator: PublicKey) -> Option<ValidatorInfo> {
         self.state
-            .read()
-            .unwrap()
+            .borrow()
             .validators
             .get(&validator)
             .cloned()
@@ -475,7 +469,7 @@ impl OdraVm {
     /// Undelegates all tokens from the validator.
     pub fn remove_validator(&self, index: usize) {
         let validator = self.get_validator(index);
-        self.state.write().unwrap().remove_validator(validator);
+        self.state.borrow_mut().remove_validator(validator);
     }
 
     /// Delegates the given amount of tokens to a given validator.
@@ -485,7 +479,7 @@ impl OdraVm {
     /// * `validator` - The public key of the validator.
     /// * `amount` - The amount of tokens to delegate.
     pub fn delegate(&self, validator: PublicKey, delegator: Address, amount: U512) {
-        let mut state = self.state.write().unwrap();
+        let mut state = self.state.borrow_mut();
         state.delegate(validator, delegator, amount);
     }
 
@@ -497,13 +491,13 @@ impl OdraVm {
     /// * `validator` - The public key of the validator.
     /// * `amount` - The amount of tokens to undelegate.
     pub fn undelegate(&self, validator: PublicKey, delegator: Address, amount: U512) {
-        let mut state = self.state.write().unwrap();
+        let mut state = self.state.borrow_mut();
         state.undelegate(validator, delegator, amount);
     }
 
     /// Gets the current auction delay.
     pub fn auction_delay(&self) -> u64 {
-        self.state.read().unwrap().auction_delay()
+        self.state.borrow().auction_delay()
     }
 
     /// Returns the delay between the unstaking and the moment when the tokens can be transferred.
@@ -514,7 +508,7 @@ impl OdraVm {
 
 impl OdraVm {
     fn prepare_call(&self, contract_name: String, address: Address, call_def: &CallDef) {
-        let mut state = self.state.write().unwrap();
+        let mut state = self.state.borrow_mut();
         // If only one address on the call_stack, record snapshot.
         if state.is_in_caller_context() {
             state.take_snapshot();
@@ -527,7 +521,7 @@ impl OdraVm {
     }
 
     fn handle_call_result(&self, result: Bytes) -> Bytes {
-        let mut state = self.state.write().unwrap();
+        let mut state = self.state.borrow_mut();
 
         // Drop the address from stack.
         state.pop_callstack_element();
@@ -858,7 +852,7 @@ mod tests {
 
     fn push_address(vm: &OdraVm, address: &Address) {
         let element = CallstackElement::new_account(*address);
-        vm.state.write().unwrap().push_callstack_element(element);
+        vm.state.borrow_mut().push_callstack_element(element);
     }
 
     fn test_call_result() -> Bytes {


### PR DESCRIPTION
Remove unnecessary RefCell wrapper from HostEnv backend since all HostContext methods take &self and manage their own interior mutability. Update all backends (OdraVmHost, CasperHost, LivenetHost) accordingly.