### PR TITLE
Logging error in wasm-client

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 CARGO_ODRA_GIT_REPO := "https://github.com/odradev/cargo-odra"
-CARGO_ODRA_BRANCH := "feature/wasm-opt-flags"
+CARGO_ODRA_BRANCH := "release/0.1.7"
 BINARYEN_VERSION := "version_125"
 BINARYEN_CHECKSUM := "7c3bc16599c8274a04d34a504fe4be2047884f900e0e2da2f6fb9cd667183be4"
 set dotenv-load := true

--- a/odra-wasm-client/src/client.rs
+++ b/odra-wasm-client/src/client.rs
@@ -271,6 +271,13 @@ impl OdraWasmClient {
         .result
         .execution_result;
 
+        if let Some(ref error) = result.error {
+            return Err(JsError::new(&format!(
+                "Speculative execution failed for '{}': {}",
+                entry_point, error
+            )));
+        }
+
         let cl_value = find_result(&result.effects)?;
         let (result, _) = T::from_bytes(&cl_value.inner_bytes()[4..])?;
         Ok(result.to_wasm_value())


### PR DESCRIPTION
So we can extract error number instead of getting parse error.