### PR TITLE
Allow List as a value of Mapping (#636)

### DIFF
--- a/core/src/mapping.rs
+++ b/core/src/mapping.rs
@@ -3,6 +3,7 @@ use crate::casper_types::{
     bytesrepr::{FromBytes, ToBytes},
     CLTyped
 };
+use crate::list::List;
 use crate::module::{ModuleComponent, ModulePrimitive};
 use crate::prelude::*;
 use crate::ContractEnv;
@@ -77,6 +78,24 @@ impl<K: ToBytes, V: Module> Mapping<K, V> {
     pub fn module(&self, key: &K) -> SubModule<V> {
         let env = self.env_for_key(key);
         SubModule::instance(Rc::new(env), self.index)
+    }
+}
+
+impl<K: ToBytes, T> Mapping<K, List<T>> {
+    /// Retrieves the [`List`] associated with the given key.
+    ///
+    /// Each key gets its own, independently-stored `List`: the key is folded into the
+    /// storage namespace (the same way [`Mapping::env_for_key`] namespaces any other
+    /// value), so two different keys never share the underlying storage, even though
+    /// both lists are addressed using the same `index`.
+    ///
+    /// `List` cannot itself be a mapping KEY: every accessor here requires
+    /// `K: ToBytes`, and `List` is a storage component that deliberately implements
+    /// no serialization, so `Mapping<List<T>, V>` fails to compile with
+    /// `trait bound List<u32>: ToBytes was not satisfied`.
+    pub fn list(&self, key: &K) -> List<T> {
+        let env = self.env_for_key(key);
+        List::instance(Rc::new(env), self.index)
     }
 }
 

--- a/examples/Odra.toml
+++ b/examples/Odra.toml
@@ -32,6 +32,9 @@ fqn = "features::storage::mapping::DogContract2"
 fqn = "features::storage::list::DogContract3"
 
 [[contracts]]
+fqn = "features::storage::list_in_mapping::ScheduleContract"
+
+[[contracts]]
 fqn = "features::testing::TestingContract"
 
 [[contracts]]

--- a/examples/src/features/storage/list_in_mapping.rs
+++ b/examples/src/features/storage/list_in_mapping.rs
@@ -1,0 +1,85 @@
+//! Module containing ScheduleContract. It is used in docs to explain how to store a `List`
+//! as a value of a `Mapping`.
+use odra::prelude::*;
+
+/// A simple contract that keeps a schedule of task ids per address.
+#[odra::module]
+pub struct ScheduleContract {
+    schedules: Mapping<Address, List<u32>>
+}
+
+#[odra::module]
+impl ScheduleContract {
+    /// Adds a task id to the caller's schedule.
+    pub fn add_task(&mut self, owner: &Address, id: u32) {
+        self.schedules.list(owner).push(id);
+    }
+
+    /// Returns the number of tasks scheduled for the given address.
+    pub fn task_count(&self, owner: &Address) -> u32 {
+        self.schedules.list(owner).len()
+    }
+
+    /// Returns the n-th task id scheduled for the given address.
+    pub fn task_at(&self, owner: &Address, index: u32) -> Option<u32> {
+        self.schedules.list(owner).get(index)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ScheduleContract;
+    use odra::host::{Deployer, NoArgs};
+
+    #[test]
+    fn unseen_key_has_empty_list() {
+        let test_env = odra_test::env();
+        let contract = ScheduleContract::deploy(&test_env, NoArgs);
+        let owner = test_env.get_account(0);
+
+        assert_eq!(contract.task_count(&owner), 0);
+        assert_eq!(contract.task_at(&owner, 0), None);
+    }
+
+    #[test]
+    fn push_then_read_back() {
+        let test_env = odra_test::env();
+        let mut contract = ScheduleContract::deploy(&test_env, NoArgs);
+        let owner = test_env.get_account(0);
+
+        contract.add_task(&owner, 42);
+        contract.add_task(&owner, 43);
+
+        assert_eq!(contract.task_count(&owner), 2);
+        assert_eq!(contract.task_at(&owner, 0), Some(42));
+        assert_eq!(contract.task_at(&owner, 1), Some(43));
+    }
+
+    #[test]
+    fn different_keys_get_independent_lists() {
+        let test_env = odra_test::env();
+        let mut contract = ScheduleContract::deploy(&test_env, NoArgs);
+        let alice = test_env.get_account(0);
+        let bob = test_env.get_account(1);
+
+        // Only alice gets tasks - bob's list must stay empty.
+        contract.add_task(&alice, 1);
+        contract.add_task(&alice, 2);
+        contract.add_task(&alice, 3);
+
+        assert_eq!(contract.task_count(&alice), 3);
+        assert_eq!(contract.task_count(&bob), 0);
+        assert_eq!(contract.task_at(&bob, 0), None);
+
+        // Now give bob different values and make sure alice's list is untouched
+        // and the two lists never overlap in storage.
+        contract.add_task(&bob, 100);
+
+        assert_eq!(contract.task_count(&alice), 3);
+        assert_eq!(contract.task_count(&bob), 1);
+        assert_eq!(contract.task_at(&alice, 0), Some(1));
+        assert_eq!(contract.task_at(&alice, 1), Some(2));
+        assert_eq!(contract.task_at(&alice, 2), Some(3));
+        assert_eq!(contract.task_at(&bob, 0), Some(100));
+    }
+}

--- a/examples/src/features/storage/mod.rs
+++ b/examples/src/features/storage/mod.rs
@@ -1,4 +1,5 @@
 //! This module contains examples of how to handle different storage types in Odra.
 pub mod list;
+pub mod list_in_mapping;
 pub mod mapping;
 pub mod variable;


### PR DESCRIPTION
    schedules: Mapping<Address, List<Id>>

Mirrors the existing `Mapping<K, V: Module>::module()` accessor: fold the key into the storage namespace with `env_for_key`, then instantiate the component against it. `List` is a `ModuleComponent` rather than a `Module`, so it is returned bare instead of wrapped in `SubModule`, and `List::instance` already performs its own `child(index)` split for its inner map and length counter -- no new machinery is needed.

`List` remains impossible as a KEY, and this is proved rather than assumed: every accessor requires `K: ToBytes`, and `List` deliberately implements no serialization, so `Mapping<List<u32>, u32>` fails to compile with `trait bound List<u32>: ToBytes was not satisfied`.

The test that matters is `different_keys_get_independent_lists`. Per-key storage isolation is the one thing a plausible implementation can get wrong while every single-key test still passes, so it pushes to one key, asserts the other is untouched, then writes to the second and re-checks the first.

Closes #636.